### PR TITLE
refactor(executor): change create2 to create for contract creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,7 @@ dependencies = [
  "log",
  "parking_lot",
  "rand 0.8.4",
+ "rlp",
  "rocksdb",
 ]
 

--- a/core/executor/Cargo.toml
+++ b/core/executor/Cargo.toml
@@ -15,6 +15,7 @@ hasher = "0.1"
 lazy_static = "1.4"
 log = "0.4"
 rand = { version = "0.8", features = ["small_rng"] }
+rlp = "0.5.1"
 rocksdb = "0.17"
 parking_lot = "0.11"
 

--- a/core/executor/Cargo.toml
+++ b/core/executor/Cargo.toml
@@ -15,7 +15,7 @@ hasher = "0.1"
 lazy_static = "1.4"
 log = "0.4"
 rand = { version = "0.8", features = ["small_rng"] }
-rlp = "0.5.1"
+rlp = "0.5"
 rocksdb = "0.17"
 parking_lot = "0.11"
 

--- a/core/executor/src/adapter/mod.rs
+++ b/core/executor/src/adapter/mod.rs
@@ -14,8 +14,6 @@ use protocol::types::{
 };
 use protocol::{codec::ProtocolCodec, ProtocolResult};
 
-use crate::code_address;
-
 macro_rules! blocking_async {
     ($self_: ident, $adapter: ident, $method: ident$ (, $args: expr)*) => {{
         let (tx, rx) = crossbeam_channel::bounded(1);
@@ -299,14 +297,12 @@ where
         if let Some(c) = code {
             let new_code_hash = Hasher::digest(&c);
             if new_code_hash != old_account.code_hash {
-                let code_address = code_address(&address, &H256::default(), &new_code_hash);
-
                 let _ = blocking_async!(
                     self,
                     storage,
                     insert_code,
                     Context::new(),
-                    code_address,
+                    address.into(),
                     new_code_hash,
                     c.into()
                 );

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -171,5 +171,5 @@ pub fn code_address(sender: &H160, nonce: &U256) -> H256 {
     let mut stream = rlp::RlpStream::new_list(2);
     stream.append(sender);
     stream.append(nonce);
-    H256::from(Hasher::digest(&stream.out())).into()
+    Hasher::digest(&stream.out())
 }

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -8,8 +8,8 @@ use common_merkle::Merkle;
 use protocol::codec::ProtocolCodec;
 use protocol::traits::{ApplyBackend, Backend, Executor, ExecutorAdapter as Adapter};
 use protocol::types::{
-    Account, Config, ExecResp, Hash, Hasher, SignedTransaction, TransactionAction, TxResp, H160,
-    H256, NIL_DATA, RLP_NULL, U256,
+    Account, Config, ExecResp, Hasher, SignedTransaction, TransactionAction, TxResp, H160, H256,
+    NIL_DATA, RLP_NULL, U256,
 };
 
 pub use crate::adapter::{EVMExecutorAdapter, MPTTrie, RocksTrieDB};
@@ -104,6 +104,7 @@ impl EvmExecutor {
         backend: &mut B,
         tx: SignedTransaction,
     ) -> TxResp {
+        let old_nonce = backend.basic(tx.sender).nonce;
         let config = Config::london();
         let metadata = StackSubstateMetadata::new(u64::MAX, &config);
         let state = MemoryStackState::new(metadata, backend);
@@ -124,11 +125,10 @@ impl EvmExecutor {
                     .collect(),
             ),
             TransactionAction::Create => {
-                let exit_reason = executor.transact_create2(
+                let exit_reason = executor.transact_create(
                     tx.sender,
                     tx.transaction.unsigned.value,
                     tx.transaction.unsigned.data.to_vec(),
-                    H256::default(),
                     tx.transaction.unsigned.gas_limit.as_u64(),
                     tx.transaction
                         .unsigned
@@ -148,11 +148,7 @@ impl EvmExecutor {
             let (values, logs) = executor.into_state().deconstruct();
             backend.apply(values, logs, true);
             if tx.transaction.unsigned.action == TransactionAction::Create {
-                Some(code_address(
-                    &tx.sender,
-                    &H256::default(),
-                    &Hasher::digest(tx.transaction.unsigned.data.as_ref()),
-                ))
+                Some(code_address(&tx.sender, &old_nonce))
             } else {
                 None
             }
@@ -171,11 +167,9 @@ impl EvmExecutor {
     }
 }
 
-pub fn code_address(sender: &H160, _salt: &H256, code_hash: &Hash) -> H256 {
-    let mut encode = vec![0xff];
-    encode.extend_from_slice(sender.as_bytes());
-    encode.extend_from_slice(H256::default().as_bytes());
-    encode.extend_from_slice(code_hash.as_bytes());
-
-    Hasher::digest(&encode)
+pub fn code_address(sender: &H160, nonce: &U256) -> H256 {
+    let mut stream = rlp::RlpStream::new_list(2);
+    stream.append(sender);
+    stream.append(nonce);
+    H256::from(Hasher::digest(&stream.out())).into()
 }

--- a/core/executor/src/tests/mod.rs
+++ b/core/executor/src/tests/mod.rs
@@ -136,13 +136,13 @@ fn test_simplestorage() {
     assert_eq!(r.remain_gas, 18446744073709450374);
 
     // Thr created contract's address is
-    // 0x1334d12e187d9aa97ea520fdd100c5d4f867ade0, you can get the address from
-    // the ApplyBackend.
+    // 0xc15d2ba57d126e6603240e89437efd419ce329d2, you can get the address by
+    // `println!("{:?}", backend.state().keys());`
 
     // let's call SimpleStorage.set(42)
     let tx = gen_tx(
         H160::from_str("0xf000000000000000000000000000000000000000").unwrap(),
-        H160::from_str("0x1334d12e187d9aa97ea520fdd100c5d4f867ade0").unwrap(),
+        H160::from_str("0xc15d2ba57d126e6603240e89437efd419ce329d2").unwrap(),
         hex::decode("60fe47b1000000000000000000000000000000000000000000000000000000000000002a")
             .unwrap(),
     );
@@ -154,7 +154,7 @@ fn test_simplestorage() {
     // let's call SimpleStorage.get() by exec
     let tx = gen_tx(
         H160::from_str("0xf000000000000000000000000000000000000000").unwrap(),
-        H160::from_str("0x1334d12e187d9aa97ea520fdd100c5d4f867ade0").unwrap(),
+        H160::from_str("0xc15d2ba57d126e6603240e89437efd419ce329d2").unwrap(),
         hex::decode("6d4ce63c").unwrap(),
     );
     let r = executor.inner_exec(&mut backend, tx);
@@ -168,7 +168,7 @@ fn test_simplestorage() {
     // let's call SimpleStorage.get() by call
     let r = executor.call(
         &mut backend,
-        H160::from_str("0x1334d12e187d9aa97ea520fdd100c5d4f867ade0").unwrap(),
+        H160::from_str("0xc15d2ba57d126e6603240e89437efd419ce329d2").unwrap(),
         hex::decode("6d4ce63c").unwrap(),
     );
     assert_eq!(r.exit_reason, ExitReason::Succeed(ExitSucceed::Returned));


### PR DESCRIPTION
When a transaction is `Type:Create`, use `executor.transact_create` to create the contract.