### PR TITLE
refactor: do not compile aot code in aarch64 unix

### DIFF
--- a/core/interoperation/Cargo.toml
+++ b/core/interoperation/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2021"
 
 [dependencies]
 arc-swap = "1.5"
-ckb-vm = { version = "0.21", features = ["aot"] }
 lazy_static = "1.4"
 
 protocol = { path = "../../protocol", package = "axon-protocol" }
+
+[target.'cfg(not(target_arch = "aarch64"))'.dependencies]
+ckb-vm = { version = "0.21", features = ["aot"] }
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+ckb-vm = { version = "0.21", features = ["asm"] }

--- a/core/interoperation/src/lib.rs
+++ b/core/interoperation/src/lib.rs
@@ -3,8 +3,7 @@ use std::error::Error;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use ckb_vm::machine::aot::AotCompilingMachine;
-use ckb_vm::machine::asm::{AotCode, AsmCoreMachine, AsmMachine};
+use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 use ckb_vm::machine::{DefaultMachineBuilder, SupportMachine, VERSION1};
 use ckb_vm::{Error as VMError, ISA_B, ISA_IMC, ISA_MOP};
 
@@ -63,17 +62,21 @@ impl Interoperation for InteroperationImpl {
             DefaultMachineBuilder::new(AsmCoreMachine::new(ISA, VERSION1, max_cycles)).build();
         let program = DISPATCHER.load().get_program(&code_hash)?;
 
-        unsafe {
-            let mut vm = AsmMachine::new(core, Some(&*Arc::as_ptr(&program.aot)));
-            let _ = vm
-                .load_program(&program.code, args)
-                .map_err(InteroperationError::CkbVM)?;
+        #[cfg(not(target_arch = "aarch64"))]
+        let aot_code = unsafe { Some(&*Arc::as_ptr(&program.aot)) };
 
-            Ok(VMResp {
-                exit_code: vm.run().map_err(InteroperationError::CkbVM)?,
-                cycles:    vm.machine.cycles(),
-            })
-        }
+        #[cfg(target_arch = "aarch64")]
+        let aot_code = None;
+
+        let mut vm = AsmMachine::new(core, aot_code);
+        let _ = vm
+            .load_program(&program.code, args)
+            .map_err(InteroperationError::CkbVM)?;
+
+        Ok(VMResp {
+            exit_code: vm.run().map_err(InteroperationError::CkbVM)?,
+            cycles:    vm.machine.cycles(),
+        })
     }
 }
 
@@ -86,6 +89,7 @@ pub fn init_dispatcher(program_map: HashMap<H160, Bytes>) -> ProtocolResult<()> 
 struct ProgramDispatcher(HashMap<H160, Program>);
 
 impl ProgramDispatcher {
+    #[cfg(not(target_arch = "aarch64"))]
     fn new(program_map: HashMap<H160, Bytes>) -> ProtocolResult<Self> {
         let mut inner = HashMap::with_capacity(program_map.len());
 
@@ -99,6 +103,16 @@ impl ProgramDispatcher {
         Ok(ProgramDispatcher(inner))
     }
 
+    #[cfg(target_arch = "aarch64")]
+    fn new(program_map: HashMap<H160, Bytes>) -> ProtocolResult<Self> {
+        Ok(ProgramDispatcher(
+            program_map
+                .into_iter()
+                .map(|kv| (kv.0, Program::new(kv.1)))
+                .collect(),
+        ))
+    }
+
     fn get_program(&self, code_hash: &H160) -> ProtocolResult<Program> {
         self.0
             .get(code_hash)
@@ -110,15 +124,22 @@ impl ProgramDispatcher {
 #[derive(Clone)]
 struct Program {
     code: Bytes,
-    aot:  Arc<AotCode>,
+    #[cfg(not(target_arch = "aarch64"))]
+    aot:  Arc<ckb_vm::machine::asm::AotCode>,
 }
 
 impl Program {
+    #[cfg(not(target_arch = "aarch64"))]
     fn new(code: Bytes, aot: AotCode) -> Self {
         Program {
             code,
             aot: Arc::new(aot),
         }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn new(code: Bytes) -> Self {
+        Program { code }
     }
 }
 

--- a/core/interoperation/src/lib.rs
+++ b/core/interoperation/src/lib.rs
@@ -94,9 +94,10 @@ impl ProgramDispatcher {
         let mut inner = HashMap::with_capacity(program_map.len());
 
         for (code_hash, code) in program_map.into_iter() {
-            let aot_code = AotCompilingMachine::load(&code, None, ISA, VERSION1)
-                .and_then(|mut m| m.compile())
-                .map_err(InteroperationError::CkbVM)?;
+            let aot_code =
+                ckb_vm::machine::aot::AotCompilingMachine::load(&code, None, ISA, VERSION1)
+                    .and_then(|mut m| m.compile())
+                    .map_err(InteroperationError::CkbVM)?;
             inner.insert(code_hash, Program::new(code, aot_code));
         }
 
@@ -130,7 +131,7 @@ struct Program {
 
 impl Program {
     #[cfg(not(target_arch = "aarch64"))]
-    fn new(code: Bytes, aot: AotCode) -> Self {
+    fn new(code: Bytes, aot: ckb_vm::machine::asm::AotCode) -> Self {
         Program {
             code,
             aot: Arc::new(aot),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Do not compile aot code in aarch64 Unix.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

### CI Switch

ci-runs-only: [Chaos CI, Cargo Clippy, Coverage Test, E2E Tests, Code Format, Unit Tests]

