### PR TITLE
refactor(trie): change cache from dashmap to hashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,7 +1120,6 @@ dependencies = [
  "core-storage",
  "criterion",
  "crossbeam-channel",
- "dashmap",
  "ethabi 17.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi-contract",
  "ethabi-derive",

--- a/core/executor/Cargo.toml
+++ b/core/executor/Cargo.toml
@@ -9,7 +9,6 @@ az = "1.2"
 bn = { package = "substrate-bn", version = "0.6" }
 cita_trie = "3.0"
 crossbeam-channel = "0.5"
-dashmap = "5.2"
 evm = "0.35"
 futures = "0.3"
 hasher = "0.1"

--- a/core/executor/src/adapter/trie_db.rs
+++ b/core/executor/src/adapter/trie_db.rs
@@ -169,6 +169,11 @@ impl cita_trie::DB for RocksTrieDB {
             .iter()
             .map(|kv| kv.key().clone())
             .collect::<Vec<_>>();
+
+        if keys.len() < len - self.cache_size {
+            return Ok(());
+        }
+
         let remove_list = rand_remove_list(keys, len - self.cache_size);
 
         for item in remove_list {

--- a/core/executor/src/adapter/trie_db.rs
+++ b/core/executor/src/adapter/trie_db.rs
@@ -82,7 +82,7 @@ impl RocksTrieDB {
 
     #[cfg(test)]
     fn cache_get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.cache.read().get(key).map(|v| v.clone())
+        self.cache.read().get(key).cloned()
     }
 
     #[cfg(test)]

--- a/core/mempool/src/pool.rs
+++ b/core/mempool/src/pool.rs
@@ -22,7 +22,7 @@ pub struct PriorityPool {
     co_queue:       Arc<ArrayQueue<TxPtr>>,
     real_queue:     Arc<Mutex<BinaryHeap<TxPtr>>>,
     tx_map:         DashMap<Hash, SignedTransaction>,
-    stock_len:      Arc<AtomicUsize>,
+    stock_len:      AtomicUsize,
 
     flush_lock: Arc<RwLock<()>>,
 }
@@ -35,7 +35,7 @@ impl PriorityPool {
             co_queue:       Arc::new(ArrayQueue::new(size)),
             real_queue:     Arc::new(Mutex::new(BinaryHeap::with_capacity(size * 2))),
             tx_map:         DashMap::new(),
-            stock_len:      Arc::new(AtomicUsize::new(0)),
+            stock_len:      AtomicUsize::new(0),
             flush_lock:     Arc::new(RwLock::new(())),
         };
 


### PR DESCRIPTION
**Which docs this PR relation**:

RocksTrieDB has concurrent insertion problem, num > len may exist when flush, causing `rng.gen_range(0..0)` panic

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

### CI Switch

ci-runs-only: [Chaos CI, Cargo Clippy, Coverage Test, E2E Tests, Code Format, Unit Tests]

