### PR TITLE
fix(triedb): fix panic on random flush cache

### DIFF
--- a/core/executor/src/adapter/trie_db.rs
+++ b/core/executor/src/adapter/trie_db.rs
@@ -144,13 +144,13 @@ impl cita_trie::DB for RocksTrieDB {
     }
 
     fn flush(&self) -> Result<(), Self::Error> {
-        let len = { self.cache.read().len() };
+        let mut cache = self.cache.write();
+
+        let len = cache.len();
 
         if len <= self.cache_size * 2 {
             return Ok(());
         }
-
-        let mut cache = self.cache.write();
 
         let remove_list = {
             let keys = cache.iter().map(|(k, _)| k).collect::<Vec<_>>();
@@ -160,6 +160,7 @@ impl cita_trie::DB for RocksTrieDB {
         for item in remove_list {
             cache.remove(&item);
         }
+
         Ok(())
     }
 }


### PR DESCRIPTION
**Which docs this PR relation**:

There may be concurrent intervals between `read` and `write`, causing `len` to be inconsistent with `keys.len`

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

### CI Switch

ci-runs-only: [Chaos CI, Cargo Clippy, Coverage Test, E2E Tests, Code Format, Unit Tests]

