### PR TITLE
fix: fix mempool limit overflow and make unknown_hashes insert pool correct

### DIFF
--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -214,8 +214,8 @@ where
             "[core_mempool]: flush mempool with {:?} tx_hashes",
             tx_hashes.len(),
         );
+        let rt = tokio::runtime::Handle::current();
         let nonce_check = |tx: &SignedTransaction| -> bool {
-            let rt = tokio::runtime::Handle::current();
             tokio::task::block_in_place(|| {
                 rt.block_on(self.adapter.check_authorization(Context::new(), tx))
                     .is_ok()

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -91,7 +91,7 @@ where
         self.adapter
             .check_storage_exist(ctx.clone(), &stx.transaction.hash)
             .await?;
-        self.pool.insert(stx)
+        self.pool.insert(stx, true)
     }
 
     async fn insert_tx(
@@ -117,7 +117,7 @@ where
             if is_system_script {
                 self.pool.insert_system_script_tx(tx.clone())?;
             } else {
-                self.pool.insert(tx.clone())?;
+                self.pool.insert(tx.clone(), true)?;
             }
 
             if !ctx.is_network_origin_txs() {
@@ -295,8 +295,14 @@ where
 
             self.verify_tx_in_parallel(ctx.clone(), txs.clone()).await?;
 
-            for signed_tx in txs.into_iter() {
-                self.pool.insert(signed_tx)?;
+            for signed_tx in txs {
+                let is_call_system_script =
+                    is_call_system_script(&signed_tx.transaction.unsigned.action);
+                if is_call_system_script {
+                    self.pool.insert_system_script_tx(signed_tx)?;
+                } else {
+                    self.pool.insert(signed_tx, false)?;
+                }
             }
 
             self.adapter.report_good(ctx);

--- a/core/mempool/src/tests/mempool.rs
+++ b/core/mempool/src/tests/mempool.rs
@@ -187,8 +187,8 @@ async fn test_flush_with_concurrent_insert() {
 }
 
 macro_rules! ensure_order_txs {
-    ($in_pool: expr, $out_pool: expr) => {
-        let mempool = &Arc::new(default_mempool().await);
+    ($in_pool: expr, $out_pool: expr, $pool_size: expr) => {
+        let mempool = &Arc::new(new_mempool($pool_size, 0, 0, 0).await);
 
         let txs = &default_mock_txs($in_pool + $out_pool);
         let (in_pool_txs, out_pool_txs) = txs.split_at($in_pool);
@@ -206,11 +206,15 @@ macro_rules! ensure_order_txs {
 #[tokio::test]
 async fn test_ensure_order_txs() {
     // all txs are in pool
-    ensure_order_txs!(100, 0);
+    ensure_order_txs!(100, 0, 100);
     // 50 txs are not in pool
-    ensure_order_txs!(50, 50);
+    ensure_order_txs!(50, 50, 100);
     // all txs are not in pool
-    ensure_order_txs!(0, 100);
+    ensure_order_txs!(0, 100, 100);
+
+    // pool size reach limit
+    ensure_order_txs!(0, 100, 50);
+    ensure_order_txs!(50, 50, 50);
 }
 
 #[rustfmt::skip]


### PR DESCRIPTION
**Which docs this PR relation**:
1. Fix the problem that mempool len may overflow when tx drop
2. `unknown_hashes` inserted into the mempool should be grouped and ignore the pool limit, otherwise the consensus node will exit the consensus state

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

### CI Switch

ci-runs-only: [Chaos CI, Cargo Clippy, Coverage Test, E2E Tests, Code Format, Unit Tests]

