### PR TITLE
feat(crosschain): some changed in constructor. 

### DIFF
--- a/builtin-contract/crosschain/contracts/MirrorToken.sol
+++ b/builtin-contract/crosschain/contracts/MirrorToken.sol
@@ -15,15 +15,8 @@ contract MirrorToken is ERC20, AccessControl, Ownable, IMirrorToken {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 
-    constructor(
-        string memory name,
-        string memory symbol,
-        address crosschain
-    ) ERC20(name, symbol) {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
-
-        _setupRole(MINTER_ROLE, crosschain);
-        _setupRole(BURNER_ROLE, crosschain);
     }
 
     function mint(address to, uint256 amount)

--- a/builtin-contract/crosschain/scripts/wckb.deploy.js
+++ b/builtin-contract/crosschain/scripts/wckb.deploy.js
@@ -1,0 +1,61 @@
+const { ethers } = require("hardhat")
+const { FeeMarketEIP1559Transaction } = require("@ethereumjs/tx")
+const util = require("ethereumjs-util")
+const fs = require("fs")
+const { hexlify, concat } = require("@ethersproject/bytes")
+const private_key = Buffer.from("37aa0f893d05914a4def0460c0a984d3611546cfb26924d7a7ca6e0db9950a2d", "hex")
+
+async function export_deploy() {
+    const wckb = await ethers.getContractFactory("MirrorToken")
+    const tx = {
+        "value": "0x0",
+        "maxPriorityFeePerGas": "0x7d0",
+        "maxFeePerGas": "0x7d0",
+        "gasLimit": "0x3231303030",
+        "nonce": "0x5",
+        "data": hexlify(concat([wckb.bytecode, wckb.interface.encodeDeploy(['wCKB', 'wCKB'])])),
+        "accessList": [],
+        "chainId": 5,
+        "type": 2
+    }
+    return FeeMarketEIP1559Transaction.fromTxData(tx).sign(private_key)
+}
+
+// caution: this method only generates mock transaction with mismatched signature to deploy to Axon genesis block
+export_deploy().then(signed_tx => {
+    const hex = (value, length) => {
+        let hexed = value.toString("hex")
+        while (length != null && hexed.length < length) {
+            hexed = "0" + hexed
+        }
+        return "0x" + hexed
+    }
+    const deploy = {
+        "transaction": {
+            "unsigned": {
+                "nonce": hex(signed_tx.nonce),
+                "max_priority_fee_per_gas": hex(signed_tx.maxPriorityFeePerGas),
+                "gas_price": hex(signed_tx.maxFeePerGas),
+                "gas_limit": hex(signed_tx.gasLimit),
+                "action": "Create",
+                "value": hex(signed_tx.value),
+                "data": Array.from(signed_tx.data),
+                "access_list": signed_tx.accessList
+            },
+            "signature": {
+                "r": hex(signed_tx.r, 64),
+                "s": hex(signed_tx.s, 64),
+                "standard_v": signed_tx.v.toNumber(),
+            },
+            "chain_id": signed_tx.chainId.toNumber(),
+            "hash": hex(signed_tx.hash())
+        },
+        "sender": hex(util.privateToAddress(private_key)),
+        "public": hex(util.privateToPublic(private_key))
+    }
+    const stream = util.rlp.encode([util.privateToAddress(private_key), signed_tx.nonce])
+    const code_address = hex(util.keccak256(stream))
+    fs.writeFileSync(__dirname + "/wckb.deploy.json", JSON.stringify({ deploy, code_address }, null, 2))
+    console.log(`export deployment info to '${__dirname}/wckb.deploy.json'`)
+    process.exit(0)
+})

--- a/builtin-contract/crosschain/test/mirror_token.js
+++ b/builtin-contract/crosschain/test/mirror_token.js
@@ -4,7 +4,7 @@ const { ethers } = require("hardhat")
 
 async function deployMirrorToken(owner, minter, burner) {
   const MirrorToken = await ethers.getContractFactory('MirrorToken');
-  const mirrorToken = await MirrorToken.connect(owner).deploy('testName', 'testSymbol', owner.address);
+  const mirrorToken = await MirrorToken.connect(owner).deploy('testName', 'testSymbol');
 
   await mirrorToken.connect(owner).grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MINTER_ROLE')), minter.address);
   await mirrorToken.connect(owner).grantRole(ethers.utils.keccak256(ethers.utils.toUtf8Bytes('BURNER_ROLE')), burner.address);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

1. we don't need a function which can modify wckb address anymore.
2. we need to send metadata and ckb address when to deploy crosschain.
3. we don't need to send the crosschain address when deploy mirrortoken.
4. wckb deployment tx should be generated in first block.

### CI Switch

ci-runs-only: [Chaos CI, Cargo Clippy, Coverage Test, E2E Tests, Code Format, Unit Tests]

