### PR TITLE
fix(synchronization): broadcasts wrong proof number

### DIFF
--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -120,7 +120,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
 
     pub async fn polling_broadcast(&self) -> ProtocolResult<()> {
         loop {
-            let current_number = self.status.inner().last_number;
+            let current_number = self.status.inner().proof.number;
             if current_number != 0 {
                 self.adapter
                     .broadcast_number(Context::new(), current_number)
@@ -353,8 +353,6 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
             last_checkpoint_block_hash: metadata.last_checkpoint_block_hash,
         };
 
-        status_agent.swap(new_status);
-
         self.save_chain_data(
             ctx.clone(),
             rich_block.txs.clone(),
@@ -362,6 +360,8 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
             rich_block.block.clone(),
         )
         .await?;
+
+        status_agent.swap(new_status);
 
         // If there are transactions in the trasnaction pool that have been on chain
         // after this execution, make sure they are cleaned up.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

Fixed 2 bugs:

1. Broadcasts number before saving block.
2. Broadcasts the block number instead of the proof number.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

### CI Switch

ci-runs-only: [Chaos CI, Cargo Clippy, Coverage Test, E2E Tests, Code Format, Unit Tests]

