### PR TITLE
refactor: add storage lru cache size to config

### DIFF
--- a/common/config-parser/src/types.rs
+++ b/common/config-parser/src/types.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_BROADCAST_TXS_SIZE: usize = 200;
 pub const DEFAULT_BROADCAST_TXS_INTERVAL: u64 = 200; // milliseconds
 pub const DEFAULT_OVERLORD_GAP: usize = 5;
 pub const DEFAULT_SYNC_TXS_CHUNK_SIZE: usize = 5000;
-pub const DEFAULT_CACHE_SIZE: usize = 128 << 20;
+pub const DEFAULT_CACHE_SIZE: usize = 100;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct ConfigApi {

--- a/core/executor/benches/bench_transfer.rs
+++ b/core/executor/benches/bench_transfer.rs
@@ -36,9 +36,10 @@ impl BenchAdapter {
     fn new() -> Self {
         BenchAdapter {
             trie_db: Arc::new(RocksTrieDB::new(STATE_PATH, Default::default(), 1000).unwrap()),
-            storage: Arc::new(ImplStorage::new(Arc::new(
-                RocksAdapter::new(DATA_PATH, Default::default()).unwrap(),
-            ))),
+            storage: Arc::new(ImplStorage::new(
+                Arc::new(RocksAdapter::new(DATA_PATH, Default::default()).unwrap()),
+                100,
+            )),
         }
     }
 

--- a/core/executor/src/debugger/mod.rs
+++ b/core/executor/src/debugger/mod.rs
@@ -55,7 +55,7 @@ impl EvmDebugger {
 
         EvmDebugger {
             state_root: mpt.commit().unwrap(),
-            storage:    Arc::new(ImplStorage::new(rocks_adapter)),
+            storage:    Arc::new(ImplStorage::new(rocks_adapter, 10)),
             trie_db:    trie,
         }
     }

--- a/core/metadata/src/tests/mod.rs
+++ b/core/metadata/src/tests/mod.rs
@@ -45,7 +45,7 @@ impl TestHandle {
             RocksTrieDB::new(path + &salt.to_string() + "/trie", Default::default(), 50).unwrap();
 
         let mut handle = TestHandle {
-            storage:    Arc::new(ImplStorage::new(Arc::new(storage_adapter))),
+            storage:    Arc::new(ImplStorage::new(Arc::new(storage_adapter), 10)),
             trie_db:    Arc::new(trie_db),
             state_root: H256::default(),
         };

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -115,7 +115,7 @@ impl Axon {
         // Init Block db
         let path_block = self.config.data_path_for_block();
         let rocks_adapter = Arc::new(RocksAdapter::new(path_block, self.config.rocksdb.clone())?);
-        let storage = Arc::new(ImplStorage::new(rocks_adapter));
+        let storage = Arc::new(ImplStorage::new(rocks_adapter, Default::default()));
 
         match storage.get_latest_block(Context::new()).await {
             Ok(_) => {
@@ -235,7 +235,10 @@ impl Axon {
             rocks_adapter.inner_db(),
         ));
 
-        let storage = Arc::new(ImplStorage::new(rocks_adapter));
+        let storage = Arc::new(ImplStorage::new(
+            rocks_adapter,
+            self.config.rocksdb.cache_size,
+        ));
 
         // Init network
         let network_config = NetworkConfig::new()

--- a/core/storage/src/cache.rs
+++ b/core/storage/src/cache.rs
@@ -3,8 +3,6 @@ use parking_lot::Mutex;
 
 use protocol::types::{Block, Bytes, Hash, Header, Receipt, SignedTransaction};
 
-const LRU_CAPACITY: usize = 200;
-
 #[derive(Debug)]
 pub struct StorageCache {
     pub blocks:        Mutex<LruCache<u64, Block>>,
@@ -15,15 +13,15 @@ pub struct StorageCache {
     pub receipts:      Mutex<LruCache<Hash, Receipt>>,
 }
 
-impl Default for StorageCache {
-    fn default() -> Self {
+impl StorageCache {
+    pub fn new(size: usize) -> Self {
         StorageCache {
-            blocks:        Mutex::new(LruCache::new(LRU_CAPACITY)),
-            block_numbers: Mutex::new(LruCache::new(LRU_CAPACITY)),
-            headers:       Mutex::new(LruCache::new(LRU_CAPACITY)),
-            transactions:  Mutex::new(LruCache::new(LRU_CAPACITY)),
-            codes:         Mutex::new(LruCache::new(LRU_CAPACITY)),
-            receipts:      Mutex::new(LruCache::new(LRU_CAPACITY)),
+            blocks:        Mutex::new(LruCache::new(size)),
+            block_numbers: Mutex::new(LruCache::new(size)),
+            headers:       Mutex::new(LruCache::new(size)),
+            transactions:  Mutex::new(LruCache::new(size)),
+            codes:         Mutex::new(LruCache::new(size)),
+            receipts:      Mutex::new(LruCache::new(size)),
         }
     }
 }

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -105,10 +105,10 @@ pub struct ImplStorage<Adapter> {
 }
 
 impl<Adapter: StorageAdapter> ImplStorage<Adapter> {
-    pub fn new(adapter: Arc<Adapter>) -> Self {
+    pub fn new(adapter: Arc<Adapter>, cache_size: usize) -> Self {
         Self {
             adapter,
-            cache: Arc::new(StorageCache::default()),
+            cache: Arc::new(StorageCache::new(cache_size)),
             latest_block: ArcSwap::new(Arc::new(None)),
             latest_proof: ArcSwap::new(Arc::new(None)),
         }

--- a/core/storage/src/tests/storage.rs
+++ b/core/storage/src/tests/storage.rs
@@ -13,7 +13,7 @@ use crate::ImplStorage;
 
 #[test]
 fn test_storage_block_insert() {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
 
     let height = 100;
     let block = mock_block(height, Hasher::digest(get_random_bytes(10)));
@@ -33,7 +33,7 @@ fn test_storage_block_insert() {
 
 #[test]
 fn test_storage_receipts_insert() {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
     let height = 2077;
 
     let mut receipts = Vec::new();
@@ -59,7 +59,7 @@ fn test_storage_receipts_insert() {
 
 #[test]
 fn test_storage_transactions_insert() {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
     let height = 2020;
 
     let mut transactions = Vec::new();
@@ -84,7 +84,7 @@ fn test_storage_transactions_insert() {
 
 #[test]
 fn test_storage_latest_proof_insert() {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
 
     let block_hash = Hasher::digest(get_random_bytes(10));
     let proof = mock_proof(block_hash);
@@ -97,7 +97,7 @@ fn test_storage_latest_proof_insert() {
 
 #[test]
 fn test_storage_evm_code_insert() {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
 
     let code = get_random_bytes(1000);
     let code_hash = Hasher::digest(&code);
@@ -125,7 +125,7 @@ fn test_storage_evm_code_insert() {
 
 #[bench]
 fn bench_insert_10000_receipts(b: &mut Bencher) {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
     let height = 2045;
 
     let receipts = (0..10000)
@@ -140,7 +140,7 @@ fn bench_insert_10000_receipts(b: &mut Bencher) {
 
 #[bench]
 fn bench_insert_20000_receipts(b: &mut Bencher) {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
     let height = 2045;
 
     let receipts = (0..20000)
@@ -154,7 +154,7 @@ fn bench_insert_20000_receipts(b: &mut Bencher) {
 
 #[bench]
 fn bench_insert_40000_receipts(b: &mut Bencher) {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
     let height = 2077;
 
     let receipts = (0..40000)
@@ -168,7 +168,7 @@ fn bench_insert_40000_receipts(b: &mut Bencher) {
 
 #[bench]
 fn bench_insert_80000_receipts(b: &mut Bencher) {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
     let height = 2077;
 
     let receipts = (0..80000)
@@ -182,7 +182,7 @@ fn bench_insert_80000_receipts(b: &mut Bencher) {
 
 #[bench]
 fn bench_insert_10000_txs(b: &mut Bencher) {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
     let height = 2077;
 
     let txs = (0..10000).map(|_| mock_signed_tx()).collect::<Vec<_>>();
@@ -194,7 +194,7 @@ fn bench_insert_10000_txs(b: &mut Bencher) {
 
 #[bench]
 fn bench_insert_20000_txs(b: &mut Bencher) {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
     let height = 2077;
 
     let txs = (0..20000).map(|_| mock_signed_tx()).collect::<Vec<_>>();
@@ -206,7 +206,7 @@ fn bench_insert_20000_txs(b: &mut Bencher) {
 
 #[bench]
 fn bench_insert_40000_txs(b: &mut Bencher) {
-    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()));
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
     let height = 2077;
 
     let txs = (0..40000).map(|_| mock_signed_tx()).collect::<Vec<_>>();


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:
Add storage LRU cache size to config.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

### CI Switch

ci-runs-only: [Chaos CI, Cargo Clippy, Coverage Test, E2E Tests, Code Format, Unit Tests]

