### PR TITLE
perf(mempool): use vec instead of binary heap

### DIFF
--- a/core/api/src/jsonrpc/impl.rs
+++ b/core/api/src/jsonrpc/impl.rs
@@ -927,19 +927,18 @@ pub fn from_receipt_to_web3_log(
     }
 
     for (log_idex, log) in receipt.logs.iter().enumerate() {
-        let web3_log = Web3Log {
-            address:           receipt.sender,
-            topics:            log.topics.clone(),
-            data:              Hex::encode(&log.data),
-            block_hash:        Some(receipt.block_hash),
-            block_number:      Some(receipt.block_number.into()),
-            transaction_hash:  Some(receipt.tx_hash),
-            transaction_index: Some(index.into()),
-            log_index:         Some(log_idex.into()),
-            removed:           false,
-        };
-
         if contains_topic!(topics, log) {
+            let web3_log = Web3Log {
+                address:           receipt.sender,
+                topics:            log.topics.clone(),
+                data:              Hex::encode(&log.data),
+                block_hash:        Some(receipt.block_hash),
+                block_number:      Some(receipt.block_number.into()),
+                transaction_hash:  Some(receipt.tx_hash),
+                transaction_index: Some(index.into()),
+                log_index:         Some(log_idex.into()),
+                removed:           false,
+            };
             logs.push(web3_log);
         }
     }

--- a/core/mempool/src/tx_wrapper.rs
+++ b/core/mempool/src/tx_wrapper.rs
@@ -31,7 +31,7 @@ impl Ord for TxWrapper {
         if self.sender() != other.sender() {
             return self.gas_price().cmp(&other.gas_price());
         }
-        self.nonce().cmp(&other.nonce())
+        self.nonce().cmp(other.nonce())
     }
 }
 


### PR DESCRIPTION
**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

### CI Switch

ci-runs-only: [Chaos CI, Cargo Clippy, Coverage Test, E2E Tests, Code Format, Unit Tests]

