### PR TITLE
fix: fix critical state

### DIFF
--- a/core/mempool/src/pool.rs
+++ b/core/mempool/src/pool.rs
@@ -287,7 +287,7 @@ impl PriorityPool {
 
         self.pending_queue.retain(|_, v| {
             v.clear_droped();
-            !v.is_empty()
+            !v.need_remove()
         })
     }
 


### PR DESCRIPTION
**Which docs this PR relation**:

There is a short distance between the nonce check and the formal insertion of the transaction pool, when the transaction is interrupted by a flush during the insertion process and the insertion is restarted later, there is a critical state where the current implementation cannot determine whether the transaction can be allowed to continue

There are two issues here：
1. `pop_tip_nonce` reset to zero when every flush
2. empty pending queue removed on current flush

Examples.
The current nonce is 5, allowing transactions with a nonce greater than or equal to 5 to enter the transaction pool. When flush, a transaction with a nonce of 5 is stuck in the insert stage, and after the flush, the DB max nonce is 6, but the stuck transaction can still be inserted into the transaction pool in the original implementation, and can even be packaged

This PR delays a block to delete the pending queue, and marks `pop_tip_nonce` to the current max nonce

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

### CI Switch

ci-runs-only: [Chaos CI, Cargo Clippy, Coverage Test, E2E Tests, Code Format, Unit Tests, Web3 Compatible Tests]

