### PR TITLE
feat(ibc): impl get paths by prefix interface

### DIFF
--- a/core/ibc/src/adapter.rs
+++ b/core/ibc/src/adapter.rs
@@ -136,8 +136,8 @@ where
         ))
     }
 
-    fn get_paths_by_prefix(&self, _key_prefix: &Path) -> ProtocolResult<Vec<Path>> {
-        todo!()
+    fn get_paths_by_prefix(&self, key_prefix: &Path) -> ProtocolResult<Vec<Path>> {
+        self.storage.get_keys_by_prefix(key_prefix)
     }
 }
 

--- a/core/ibc/src/error.rs
+++ b/core/ibc/src/error.rs
@@ -5,6 +5,9 @@ use protocol::{Display, ProtocolError, ProtocolErrorKind};
 #[derive(Debug, Display)]
 pub enum IbcError {
     Protocol(Error),
+
+    #[display(fmt = "Adapter error {}", _0)]
+    Adapter(String),
 }
 
 impl std::error::Error for IbcError {}

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -139,38 +139,6 @@ macro_rules! get_keys_by_schema {
 }
 
 macro_rules! impl_get_keys_by_schemas_for {
-    ($self_: ident, $vec: expr, $key_prefix: expr, $ibc_prefix: expr) => {{
-        get_keys_by_schema!($self_, $vec, $key_prefix, $ibc_prefix, ClientTypeSchema);
-        get_keys_by_schema!($self_, $vec, $key_prefix, $ibc_prefix, ClientStateSchema);
-        get_keys_by_schema!(
-            $self_,
-            $vec,
-            $key_prefix,
-            $ibc_prefix,
-            ClientConsensusStateSchema
-        );
-        get_keys_by_schema!($self_, $vec, $key_prefix, $ibc_prefix, ConnectionEndSchema);
-        get_keys_by_schema!($self_, $vec, $key_prefix, $ibc_prefix, ConnectionIdsSchema);
-        get_keys_by_schema!($self_, $vec, $key_prefix, $ibc_prefix, ChannelEndSchema);
-        get_keys_by_schema!($self_, $vec, $key_prefix, $ibc_prefix, SeqSendsSchema);
-        get_keys_by_schema!($self_, $vec, $key_prefix, $ibc_prefix, SeqRecvsSchema);
-        get_keys_by_schema!($self_, $vec, $key_prefix, $ibc_prefix, SeqAcksSchema);
-        get_keys_by_schema!(
-            $self_,
-            $vec,
-            $key_prefix,
-            $ibc_prefix,
-            PacketCommitmentSchema
-        );
-        get_keys_by_schema!(
-            $self_,
-            $vec,
-            $key_prefix,
-            $ibc_prefix,
-            AcknowledgementCommitmentSchema
-        );
-        get_keys_by_schema!($self_, $vec, $key_prefix, $ibc_prefix, IbcReceiptSchema);
-    }};
     ($self_: ident, $vec: expr, $key_prefix: expr, $ibc_prefix: expr$(, $schema: ty)+) => {
         $(get_keys_by_schema!($self_, $vec, $key_prefix, $ibc_prefix, $schema);)+
     };
@@ -1025,12 +993,8 @@ impl<Adapter: StorageAdapter> IbcCrossChainStorage for ImplStorage<Adapter> {
     ) -> ProtocolResult<Vec<LocalIbcPath>> {
         let key_prefix = KeyPrefix::from(local_ibc_prefix);
         let mut all_vec: Vec<LocalIbcPath> = Vec::new();
-        match local_ibc_prefix {
-            prefix
-                if prefix.starts_with(
-                    &<String as TryInto<LocalIbcPath>>::try_into(String::from("clients")).unwrap(),
-                ) =>
-            {
+        match local_ibc_prefix.to_string() {
+            prefix if prefix.starts_with("clients") => {
                 impl_get_keys_by_schemas_for!(
                     self,
                     all_vec,
@@ -1042,12 +1006,7 @@ impl<Adapter: StorageAdapter> IbcCrossChainStorage for ImplStorage<Adapter> {
                     ConnectionIdsSchema
                 );
             }
-            prefix
-                if prefix.starts_with(
-                    &<String as TryInto<LocalIbcPath>>::try_into(String::from("connections"))
-                        .unwrap(),
-                ) =>
-            {
+            prefix if prefix.starts_with("connections") => {
                 impl_get_keys_by_schemas_for!(
                     self,
                     all_vec,
@@ -1056,12 +1015,7 @@ impl<Adapter: StorageAdapter> IbcCrossChainStorage for ImplStorage<Adapter> {
                     ConnectionEndSchema
                 );
             }
-            prefix
-                if prefix.starts_with(
-                    &<String as TryInto<LocalIbcPath>>::try_into(String::from("channelEnds"))
-                        .unwrap(),
-                ) =>
-            {
+            prefix if prefix.starts_with("channelEnds") => {
                 impl_get_keys_by_schemas_for!(
                     self,
                     all_vec,
@@ -1070,12 +1024,7 @@ impl<Adapter: StorageAdapter> IbcCrossChainStorage for ImplStorage<Adapter> {
                     ChannelEndSchema
                 );
             }
-            prefix
-                if prefix.starts_with(
-                    &<String as TryInto<LocalIbcPath>>::try_into(String::from("nextSequence"))
-                        .unwrap(),
-                ) =>
-            {
+            prefix if prefix.starts_with("nextSequence") => {
                 impl_get_keys_by_schemas_for!(
                     self,
                     all_vec,
@@ -1086,12 +1035,7 @@ impl<Adapter: StorageAdapter> IbcCrossChainStorage for ImplStorage<Adapter> {
                     SeqAcksSchema
                 );
             }
-            prefix
-                if prefix.starts_with(
-                    &<String as TryInto<LocalIbcPath>>::try_into(String::from("commitments"))
-                        .unwrap(),
-                ) =>
-            {
+            prefix if prefix.starts_with("commitments") => {
                 impl_get_keys_by_schemas_for!(
                     self,
                     all_vec,
@@ -1100,11 +1044,7 @@ impl<Adapter: StorageAdapter> IbcCrossChainStorage for ImplStorage<Adapter> {
                     PacketCommitmentSchema
                 );
             }
-            prefix
-                if prefix.starts_with(
-                    &<String as TryInto<LocalIbcPath>>::try_into(String::from("acks")).unwrap(),
-                ) =>
-            {
+            prefix if prefix.starts_with("acks") => {
                 impl_get_keys_by_schemas_for!(
                     self,
                     all_vec,
@@ -1113,11 +1053,7 @@ impl<Adapter: StorageAdapter> IbcCrossChainStorage for ImplStorage<Adapter> {
                     AcknowledgementCommitmentSchema
                 );
             }
-            prefix
-                if prefix.starts_with(
-                    &<String as TryInto<LocalIbcPath>>::try_into(String::from("receipts")).unwrap(),
-                ) =>
-            {
+            prefix if prefix.starts_with("receipts") => {
                 impl_get_keys_by_schemas_for!(
                     self,
                     all_vec,

--- a/core/storage/src/tests/storage.rs
+++ b/core/storage/src/tests/storage.rs
@@ -129,6 +129,7 @@ fn test_ibc_storage() {
     test_ibc_get_set_next_sequence_send();
     test_ibc_get_set_next_sequence_recv();
     test_ibc_get_set_next_sequence_ack();
+    test_ibc_get_keys_by_path();
 }
 
 #[test]
@@ -277,8 +278,11 @@ fn test_ibc_get_set_packet_commitment() {
 
     assert_eq!(commitment, get_ret.unwrap().unwrap());
 
-    let del_ret = storage.delete_packet_commitment((port_id, channel_id, sequence));
+    let del_ret = storage.delete_packet_commitment((port_id.clone(), channel_id.clone(), sequence));
     assert!(del_ret.is_ok());
+
+    let get_ret2 = storage.get_packet_commitment(&(port_id, channel_id, sequence));
+    assert!(get_ret2.unwrap().is_none());
 }
 #[test]
 #[cfg(feature = "ibc")]
@@ -322,8 +326,12 @@ fn test_ibc_get_set_packet_acknowledgement() {
 
     assert_eq!(ack_commitment, get_ret.unwrap().unwrap());
 
-    let del_ret = storage.delete_packet_acknowledgement((port_id, channel_id, sequence));
+    let del_ret =
+        storage.delete_packet_acknowledgement((port_id.clone(), channel_id.clone(), sequence));
     assert!(del_ret.is_ok());
+
+    let get_ret2 = storage.get_packet_acknowledgement(&(port_id, channel_id, sequence));
+    assert!(get_ret2.unwrap().is_none());
 }
 #[test]
 #[cfg(feature = "ibc")]
@@ -378,4 +386,289 @@ fn test_ibc_get_set_next_sequence_ack() {
     assert!(get_ret.is_ok());
 
     assert_eq!(sequence, get_ret.unwrap().unwrap());
+}
+
+#[test]
+#[cfg(feature = "ibc")]
+fn test_ibc_get_keys_by_path() {
+    test_get_keys_by_path_case01();
+    test_get_keys_by_path_case02();
+    test_get_keys_by_path_case03();
+}
+
+#[test]
+#[cfg(feature = "ibc")]
+fn test_get_keys_by_path_case01() {
+    use cosmos_ibc::core::ics04_channel::packet::Sequence;
+    use cosmos_ibc::core::ics24_host::{
+        identifier::{ChannelId, ClientId, PortId},
+        path::SeqAcksPath,
+    };
+    use protocol::traits::IbcCrossChainStorage;
+    use protocol::types::ibc::Path;
+
+    use cosmos_ibc::core::ics02_client::client_type::ClientType;
+
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
+    let client_id = ClientId::new(ClientType::Tendermint, 1033).unwrap();
+    let client_id2 = ClientId::new(ClientType::Tendermint, 22).unwrap();
+    let client_id3 = ClientId::new(ClientType::Tendermint, 222).unwrap();
+    let _set_result = storage.set_client_type(client_id, ClientType::Tendermint);
+    let _set_result = storage.set_client_type(client_id2, ClientType::Tendermint);
+    let set_result = storage.set_client_type(client_id3, ClientType::Tendermint);
+    assert!(set_result.is_ok());
+
+    let port_id = PortId::default();
+    let channel_id = ChannelId::default();
+    let path = SeqAcksPath(port_id.clone(), channel_id.clone());
+    let local_path = Path::from(path);
+    let sequence = Sequence::default();
+    let set_ret = storage.set_next_sequence_ack(port_id, channel_id, sequence);
+    assert!(set_ret.is_ok());
+    let para1: Path = String::from("nextSequenceAck")
+        .try_into()
+        .expect("'channelEnds/ports' expected to be a valid Path"); // nextSequenceAck/ports
+    let res = storage.get_keys_by_prefix(&para1);
+    assert!(res.is_ok());
+    assert!(local_path.starts_with(&para1));
+    assert_eq!(res.unwrap().len(), 1);
+
+    let para2: Path = String::from("clients")
+        .try_into()
+        .expect("'channelEnds/ports' expected to be a valid Path");
+    let res2 = storage.get_keys_by_prefix(&para2);
+    // ClientTypeSchema  SeqAcksSchema
+    assert!(res2.is_ok());
+    assert_eq!(res2.unwrap().len(), 3);
+}
+
+#[test]
+#[cfg(feature = "ibc")]
+fn test_get_keys_by_path_case02() {
+    use cosmos_ibc::core::ics02_client::client_type::ClientType;
+    use cosmos_ibc::core::ics04_channel::packet::Sequence;
+    use cosmos_ibc::core::ics24_host::identifier::ClientId;
+    use cosmos_ibc::core::ics24_host::identifier::{ChannelId, PortId};
+    use protocol::traits::IbcCrossChainStorage;
+    use protocol::types::ibc::Path;
+
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
+    let client_id = ClientId::new(ClientType::Tendermint, 1033).unwrap();
+    let client_id2 = ClientId::new(ClientType::Tendermint, 22).unwrap();
+    let client_id3 = ClientId::new(ClientType::Tendermint, 222).unwrap();
+    let _set_result = storage.set_client_type(client_id, ClientType::Tendermint);
+    let _set_result = storage.set_client_type(client_id2, ClientType::Tendermint);
+    let set_result = storage.set_client_type(client_id3, ClientType::Tendermint);
+    assert!(set_result.is_ok());
+
+    let port_id = PortId::default();
+    let channel_id = ChannelId::default();
+    let sequence = Sequence::default();
+    let set_ret = storage.set_next_sequence_ack(port_id, channel_id, sequence);
+    assert!(set_ret.is_ok());
+
+    use cosmos_ibc::mock::client_state::MockClientState;
+    use cosmos_ibc::mock::header::MockHeader;
+    let client_id = ClientId::new(ClientType::Tendermint, 1033).unwrap();
+    use cosmos_ibc::core::ics02_client::client_state::AnyClientState;
+    let mock_client_state = AnyClientState::Mock(MockClientState::new(MockHeader::default()));
+    let set_result = storage.set_client_state(client_id.clone(), mock_client_state.clone());
+    assert!(set_result.is_ok());
+    let get_result = storage.get_client_state(&client_id);
+    assert!(get_result.is_ok());
+    assert_eq!(get_result.unwrap().unwrap(), mock_client_state);
+
+    let para1: Path = String::from("clients")
+        .try_into()
+        .expect("'channelEnds/ports' expected to be a valid Path"); // nextSequenceAck/ports
+    let res = storage.get_keys_by_prefix(&para1);
+    // ClientTypeSchema  SeqAcksSchema
+    assert!(res.is_ok());
+    assert_eq!(res.unwrap().len(), 4);
+}
+
+#[test]
+#[cfg(feature = "ibc")]
+fn test_get_keys_by_path_case03() {
+    use cosmos_ibc::core::ics04_channel::packet::Sequence;
+    use cosmos_ibc::core::ics24_host::{
+        identifier::{ChannelId, PortId},
+        path::SeqAcksPath,
+    };
+    use protocol::traits::IbcCrossChainStorage;
+    use protocol::types::ibc::Path;
+
+    let storage = ImplStorage::new(Arc::new(MemoryAdapter::new()), 10);
+
+    let port_id = PortId::default();
+    let channel_id = ChannelId::default();
+    let path = SeqAcksPath(port_id.clone(), channel_id.clone());
+    let local_path = Path::from(path);
+    let sequence = Sequence::default();
+    let set_ret = storage.set_next_sequence_ack(port_id, channel_id, sequence);
+    assert!(set_ret.is_ok());
+    let para1: Path = String::from("nextSequenceAck")
+        .try_into()
+        .expect("'channelEnds/ports' expected to be a valid Path");
+    let res = storage.get_keys_by_prefix(&para1);
+    assert!(res.is_ok());
+    assert!(local_path.starts_with(&para1));
+    assert_eq!(res.unwrap().len(), 1);
+
+    let para2: Path = String::from("clients")
+        .try_into()
+        .expect("'channelEnds/ports' expected to be a valid Path");
+    let res2 = storage.get_keys_by_prefix(&para2);
+    assert!(res2.is_ok());
+    assert_eq!(res2.unwrap().len(), 0);
+    // *****should panic: *****
+    // let para3: Path = String::from("")
+    //     .try_into()
+    //     .expect("'channelEnds/ports' expected to be a valid Path");
+    // let res3 = storage.get_keys_by_prefix(&para3);
+    // assert!(res3.is_ok());
+    // assert_eq!(res3.unwrap().len(), 0);
+}
+
+#[test]
+#[cfg(feature = "ibc")]
+#[should_panic]
+fn test_get_keys_by_path_case04() {
+    use protocol::types::ibc::Path;
+    let _: Path = String::from("")
+        .try_into()
+        .expect("'channelEnds/ports' expected to be a valid Path");
+}
+
+#[test]
+#[cfg(feature = "ibc")]
+fn test_mock_all_ibc_path() {
+    use cosmos_ibc::{
+        core::{
+            ics02_client::client_type::ClientType,
+            ics04_channel::packet::Sequence,
+            ics24_host::{
+                identifier::{ChannelId, ClientId, ConnectionId, PortId},
+                path::{
+                    AcksPath, ChannelEndsPath, ClientConnectionsPath, ClientConsensusStatePath,
+                    ClientStatePath, ClientTypePath, CommitmentsPath, ConnectionsPath,
+                    ReceiptsPath, SeqAcksPath, SeqRecvsPath, SeqSendsPath,
+                },
+            },
+        },
+        Height,
+    };
+    use protocol::types::ibc::{KeyPrefix, Path as LocalPath};
+    // ClientTypeSchema
+    let test_num = 1234567;
+    let client_id = ClientId::new(ClientType::Tendermint, test_num).unwrap();
+    let path = ClientTypePath(client_id);
+    let local_path: LocalPath = LocalPath::try_from(path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("ClientTypeSchema: {}", String::from(&prefix));
+    // ClientStateSchema
+    let client_id = ClientId::new(ClientType::Tendermint, test_num).unwrap();
+    let path = ClientStatePath(client_id);
+    let local_path: LocalPath = LocalPath::try_from(path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("ClientStateSchema: {}", String::from(&prefix));
+    // ClientConsensusStateSchema
+    let client_id = ClientId::new(ClientType::Tendermint, test_num).unwrap();
+    let height = Height::new(0, 1).unwrap();
+    let client_consensus_state_path = ClientConsensusStatePath {
+        client_id,
+        epoch: height.revision_number(),
+        height: height.revision_height(),
+    };
+    let local_path: LocalPath = LocalPath::try_from(client_consensus_state_path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("ClientConsensusStateSchema: {}", String::from(&prefix));
+    // ConnectionEndSchema
+    let connection_id = ConnectionId::new(test_num);
+    let path = ConnectionsPath(connection_id);
+    let local_path: LocalPath = LocalPath::try_from(path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("ConnectionEndSchema: {}", String::from(&prefix));
+    // ConnectionIdsSchema
+    let client_id = ClientId::new(ClientType::Tendermint, test_num).unwrap();
+    let path = ClientConnectionsPath(client_id);
+    let local_path: LocalPath = LocalPath::try_from(path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("ConnectionIdsSchema: {}", String::from(&prefix));
+    // ChannelEndSchema
+    let port_id = PortId::default();
+    let channel_id = ChannelId::default();
+    let path = ChannelEndsPath(port_id, channel_id);
+    let local_path: LocalPath = LocalPath::try_from(path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("ChannelEndSchema: {}", String::from(&prefix));
+    // SeqSendsSchema
+    let port_id = PortId::default();
+    let channel_id = ChannelId::default();
+    let path = SeqSendsPath(port_id, channel_id);
+    let local_path: LocalPath = LocalPath::try_from(path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("SeqSendsSchema: {}", String::from(&prefix));
+    // SeqRecvsSchema
+    let port_id = PortId::default();
+    let channel_id = ChannelId::default();
+    let path = SeqRecvsPath(port_id, channel_id);
+    let local_path: LocalPath = LocalPath::try_from(path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("SeqRecvsSchema: {}", String::from(&prefix));
+    // SeqAcksSchema
+    let port_id = PortId::default();
+    let channel_id = ChannelId::default();
+    let path = SeqAcksPath(port_id, channel_id);
+    let local_path: LocalPath = LocalPath::try_from(path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("SeqAcksSchema: {}", String::from(&prefix));
+    // PacketCommitmentSchema
+    let port_id = PortId::default();
+    let channel_id = ChannelId::default();
+    let sequence = Sequence::default();
+    let path = CommitmentsPath {
+        port_id,
+        channel_id,
+        sequence,
+    };
+    let local_path: LocalPath = LocalPath::try_from(path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("PacketCommitmentSchema: {}", String::from(&prefix));
+    // AcknowledgementCommitmentSchema
+    let port_id = PortId::default();
+    let channel_id = ChannelId::default();
+    let sequence = Sequence::default();
+    let path = AcksPath {
+        port_id,
+        channel_id,
+        sequence,
+    };
+    let local_path: LocalPath = LocalPath::try_from(path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("AcknowledgementCommitmentSchema: {}", String::from(&prefix));
+    // ReceiptSchema
+    let port_id = PortId::default();
+    let channel_id = ChannelId::default();
+    let sequence = Sequence::default();
+    let path = ReceiptsPath {
+        port_id,
+        channel_id,
+        sequence,
+    };
+    let local_path: LocalPath = LocalPath::try_from(path).unwrap();
+    let prefix: KeyPrefix = KeyPrefix::from(&local_path);
+    println!("ReceiptSchema: {}", String::from(&prefix));
+    // clients/07-tendermint-1234567/clientType
+    // clients/07-tendermint-1234567/clientState
+    // clients/07-tendermint-1234567/consensusStates/0-1
+    // connections/connection-1234567
+    // clients/07-tendermint-1234567/connections
+    // channelEnds/ports/defaultPort/channels/channel-0
+    // nextSequenceSend/ports/defaultPort/channels/channel-0
+    // nextSequenceRecv/ports/defaultPort/channels/channel-0
+    // nextSequenceAck/ports/defaultPort/channels/channel-0
+    // commitments/ports/defaultPort/channels/channel-0/sequences/0
+    // acks/ports/defaultPort/channels/channel-0/sequences/0
+    // receipts/ports/defaultPort/channels/channel-0/sequences/0
 }

--- a/protocol/src/traits/ibc.rs
+++ b/protocol/src/traits/ibc.rs
@@ -1,3 +1,5 @@
+use crate::types::{Header, Metadata, Path, StoreHeight};
+use crate::{async_trait, ProtocolResult};
 use cosmos_ibc::core::ics02_client::client_consensus::AnyConsensusState;
 use cosmos_ibc::core::ics02_client::client_state::AnyClientState;
 use cosmos_ibc::core::ics02_client::client_type::ClientType;
@@ -11,9 +13,6 @@ use cosmos_ibc::core::ics24_host::path::{
     CommitmentsPath, ConnectionsPath, ReceiptsPath,
 };
 use creep::Context;
-
-use crate::types::{Header, Metadata, Path, StoreHeight};
-use crate::{async_trait, ProtocolResult};
 
 #[async_trait]
 pub trait IbcGrpcAdapter {

--- a/protocol/src/traits/storage.rs
+++ b/protocol/src/traits/storage.rs
@@ -206,6 +206,7 @@ pub mod ibc {
         Height,
     };
 
+    use crate::types::ibc::Path as IbcPath;
     use crate::ProtocolResult;
 
     pub trait IbcCrossChainStorage {
@@ -369,5 +370,7 @@ pub mod ibc {
             &self,
             port_channel_id: &(PortId, ChannelId),
         ) -> ProtocolResult<Option<Sequence>>;
+
+        fn get_keys_by_prefix(&self, key_prefix: &IbcPath) -> ProtocolResult<Vec<IbcPath>>;
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `\run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [x] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
