### PR TITLE
fix(API): fix filter logs address

### DIFF
--- a/core/api/src/jsonrpc/impl/filter.rs
+++ b/core/api/src/jsonrpc/impl/filter.rs
@@ -330,17 +330,13 @@ where
 
         let extend_logs = |logs: &mut Vec<Web3Log>, receipts: Vec<Option<Receipt>>| {
             for (index, receipt) in receipts.into_iter().flatten().enumerate() {
-                match filter.address {
-                    Some(ref s)
-                        if s.contains(
-                            &receipt.code_address.map(Into::into).unwrap_or_default(),
-                        ) =>
-                    {
-                        from_receipt_to_web3_log(index, topics, &receipt, logs)
-                    }
-                    None => from_receipt_to_web3_log(index, topics, &receipt, logs),
-                    _ => (),
-                }
+                from_receipt_to_web3_log(
+                    index,
+                    topics,
+                    filter.address.as_ref().unwrap_or(&Vec::new()),
+                    &receipt,
+                    logs,
+                )
             }
         };
 

--- a/core/api/src/jsonrpc/ws_subscription.rs
+++ b/core/api/src/jsonrpc/ws_subscription.rs
@@ -179,27 +179,14 @@ where
                 for receipt in receipts.into_iter().flatten() {
                     let log_len = receipt.logs.len();
                     for hub in self.log_hubs.iter_mut() {
-                        match hub.filter.address {
-                            Some(ref s)
-                                if s.contains(
-                                    &receipt.code_address.map(Into::into).unwrap_or_default(),
-                                ) =>
-                            {
-                                from_receipt_to_web3_log(
-                                    index,
-                                    hub.filter.topics.as_slice(),
-                                    &receipt,
-                                    &mut logs,
-                                )
-                            }
-                            None => from_receipt_to_web3_log(
-                                index,
-                                hub.filter.topics.as_slice(),
-                                &receipt,
-                                &mut logs,
-                            ),
-                            _ => (),
-                        }
+                        from_receipt_to_web3_log(
+                            index,
+                            hub.filter.topics.as_slice(),
+                            hub.filter.address.as_ref().unwrap_or(&Vec::new()),
+                            &receipt,
+                            &mut logs,
+                        );
+
                         for log in logs.drain(..) {
                             // unbound sender can ignore it's return
                             let _ignore = hub.sink.send(&log);


### PR DESCRIPTION
fix #744

**What this PR does / why we need it**:

This PR fix get_log filter address from receipt contract address to logs address

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `\run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
