### PR TITLE
fix(rlp): panic by tx signature length overflow

### DIFF
--- a/protocol/src/codec/transaction.rs
+++ b/protocol/src/codec/transaction.rs
@@ -11,11 +11,18 @@ use crate::types::{
     UnsignedTransaction, UnverifiedTransaction, H256, U256,
 };
 
+fn truncate_slice<T>(s: &[T], n: usize) -> &[T] {
+    match s.len() {
+        l if l <= n => s,
+        _ => &s[0..n],
+    }
+}
+
 impl Encodable for SignatureComponents {
     fn rlp_append(&self, s: &mut RlpStream) {
         if self.is_eth_sig() {
-            let r = U256::from(&self.r[0..32]);
-            let s_ = U256::from(&self.s[0..32]);
+            let r = U256::from(truncate_slice(&self.r, 32));
+            let s_ = U256::from(truncate_slice(&self.s, 32));
             s.append(&self.standard_v).append(&r).append(&s_);
         } else {
             s.append(&self.standard_v).append(&self.r).append(&self.s);
@@ -74,8 +81,8 @@ impl LegacyTransaction {
 
         if let Some(sig) = signature {
             rlp.append(&sig.add_chain_replay_protection(chain_id))
-                .append(&U256::from(&sig.r[0..32]))
-                .append(&U256::from(&sig.s[0..32]));
+                .append(&U256::from(truncate_slice(&sig.r, 32)))
+                .append(&U256::from(truncate_slice(&sig.s, 32)));
         } else if let Some(id) = chain_id {
             rlp.append(&id).append(&0u8).append(&0u8);
         }

--- a/protocol/src/types/transaction.rs
+++ b/protocol/src/types/transaction.rs
@@ -391,12 +391,10 @@ impl SignatureComponents {
         self.standard_v as u64 + id
     }
 
-    pub fn extract_standard_v(v: u64) -> u8 {
+    pub fn extract_standard_v(v: u64) -> Option<u8> {
         match v {
-            v if v == 27 => 0,
-            v if v == 28 => 1,
-            v if v >= 35 => ((v - 1) % 2) as u8,
-            _ => 4,
+            v if v >= 35 => Some(((v - 1) % 2) as u8),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #767 

Incorrect `s` and `v` in the transaction signature may cause panic. Removed the assumption of length in this pr.

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `\run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
