### PR TITLE
test(rlp): legacy transaction decoding

### DIFF
--- a/core/run/Cargo.toml
+++ b/core/run/Cargo.toml
@@ -27,7 +27,7 @@ core-api = { path = "../../core/api" }
 core-consensus = { path = "../../core/consensus" }
 core-cross-client = { path = "../../core/cross-client" }
 core-executor = { path = "../../core/executor" }
-core-ibc = { path = "../../core/ibc"}
+core-ibc = { path = "../../core/ibc" }
 core-interoperation = { path = "../../core/interoperation" }
 core-mempool = { path = "../../core/mempool" }
 core-metadata = { path = "../../core/metadata" }

--- a/core/storage/Cargo.toml
+++ b/core/storage/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 arc-swap = "1.5"
-cosmos-ibc = { package = "ibc", version = "0.19", optional = true , features = ["mocks"]}
+cosmos-ibc = { package = "ibc", version = "0.19", optional = true, features = ["mocks"] }
 futures = "0.3"
 lazy_static = "1.4"
 log = "0.4"

--- a/protocol/src/codec/transaction.rs
+++ b/protocol/src/codec/transaction.rs
@@ -410,7 +410,7 @@ mod tests {
 
     #[test]
     fn test_legacy_decode() {
-        let bytes = hex_decode("f85f800182520894095e7baea6a6c7c4c2dfeb977efac326af552d870a801ba048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a0efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804").unwrap();
+        let bytes = hex_decode("f85f800182520894095e7baea6a6c7c4c2dfeb977efac326af552d870a8023a048b55bfa915ac795c431978d8a6a992b628d557da5ff759b307d495a36649353a0efffd310ac743f371de3b9f7f9cb56c0b28ad43601b4ab949f53faa07bd2c804").unwrap();
         let tx = UnverifiedTransaction::decode(&Rlp::new(&bytes)).unwrap();
 
         assert!(tx.unsigned.data().is_empty());


### PR DESCRIPTION
We don't support transactions before EIP-155 anymore.

<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `\run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
