### PR TITLE
feat: update cargo clap to 4.0

### DIFF
--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "3.1", features = ["cargo"] }
+clap = { version = "4.0", features = ["cargo"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -20,7 +20,7 @@ impl AxonCli {
                     .long("config")
                     .help("Axon config path")
                     .required(true)
-                    .takes_value(true),
+                    .num_args(1),
             )
             .arg(
                 Arg::new("genesis_path")
@@ -28,7 +28,7 @@ impl AxonCli {
                     .long("genesis")
                     .help("Axon genesis path")
                     .required(true)
-                    .takes_value(true),
+                    .num_args(1),
             )
             .subcommand(Command::new("run").about("Run axon process"))
             .get_matches();
@@ -37,8 +37,7 @@ impl AxonCli {
     }
 
     pub fn start(&self) {
-        let config_path = self.matches.value_of("config_path").unwrap();
-        let path = Path::new(config_path).parent().unwrap();
+        let path = Path::new(self.matches.get_one::<String>("config_path").unwrap()).parent().unwrap();
 
         let mut config: Config = parse_file(config_path, false).unwrap();
 
@@ -46,7 +45,7 @@ impl AxonCli {
             *f = path.join(&f)
         }
         let genesis: RichBlock =
-            parse_file(self.matches.value_of("genesis_path").unwrap(), true).unwrap();
+            parse_file(self.matches.get_one::<String>("genesis_path").unwrap(), true).unwrap();
 
         register_log(&config);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
