### PR TITLE
fix: fix rpc get tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,6 +1691,7 @@ dependencies = [
  "futures",
  "jsonrpc-core",
  "reqwest",
+ "serde",
  "serde_json",
 ]
 

--- a/core/rpc-client/Cargo.toml
+++ b/core/rpc-client/Cargo.toml
@@ -12,5 +12,6 @@ futures = "0.3"
 jsonrpc-core = "18.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1.0"
+serde = { version = "1", features = ["derive"]}
 
 protocol = { path = "../../protocol", package = "axon-protocol" }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes RPC `get_transaction`, using the customized type `TransactionWithStatusResponse` because we use the default version of this method.

The raw type [`TransactionWithStatusResponse`](https://github.com/nervosnetwork/ckb/blob/develop/util/jsonrpc-types/src/blockchain.rs#L520) is not easy to use because the type [`Either<L, R>`](https://github.com/nervosnetwork/ckb/blob/develop/util/jsonrpc-types/src/lib.rs#L68)

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
