### PR TITLE
ci: fix set-output warning

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -57,9 +57,9 @@ jobs:
           ref=$(echo "${{ steps.get_sha.outputs.result }}" | awk -F ':' '{print $2}'| awk -F ',' '{print $1}')
           pr_number=$(echo "${{ steps.get_sha.outputs.result }}" | awk -F ':' '{print $3}'| awk -F ',' '{print $1}')
           sha=$(echo "${{ steps.get_sha.outputs.result }}" | awk -F ':' '{print $4}'| awk -F '}' '{print $1}')
-          echo "::set-output name=ref::$ref"
-          echo "::set-output name=pr_number::$pr_number"
-          echo "::set-output name=sha::$sha"
+          echo "ref=$ref" >> $GITHUB_OUTPUT
+          echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
+          echo "sha=$sha" >> $GITHUB_OUTPUT
          
       - name: Git checkout
         uses: actions/checkout@v3

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -54,7 +54,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
       - name: Git checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,7 +56,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
       - name: Git checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -55,7 +55,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
       - name: Git checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -56,7 +56,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
         with:
           ref: ${{ steps.escape_multiple_lines_test_inputs.outputs.result || 'main' }}

--- a/.github/workflows/openzeppelin_test_11.yml
+++ b/.github/workflows/openzeppelin_test_11.yml
@@ -61,7 +61,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
       - name: Git checkout
         uses: actions/checkout@v3
         with:
@@ -76,7 +76,7 @@ jobs:
           node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Node Cache
         uses: actions/cache@v3
         id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/openzeppelin_test_16_19.yml
+++ b/.github/workflows/openzeppelin_test_16_19.yml
@@ -61,7 +61,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
       - name: Git checkout
         uses: actions/checkout@v3
         with:
@@ -76,7 +76,7 @@ jobs:
           node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Node Cache
         uses: actions/cache@v3
         id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
+++ b/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
@@ -61,7 +61,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
       - name: Git checkout
         uses: actions/checkout@v3
         with:
@@ -76,7 +76,8 @@ jobs:
           node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+        
       - name: Node Cache
         uses: actions/cache@v3
         id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/openzeppelin_test_6_10.yml
+++ b/.github/workflows/openzeppelin_test_6_10.yml
@@ -61,7 +61,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
       - name: Git checkout
         uses: actions/checkout@v3
         with:
@@ -76,7 +76,7 @@ jobs:
           node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Node Cache
         uses: actions/cache@v3
         id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -59,7 +59,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
   Test:
     if: | 
        (contains(github.event_name, 'workflow_dispatch')) || 

--- a/.github/workflows/v3_core_test.yml
+++ b/.github/workflows/v3_core_test.yml
@@ -61,7 +61,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
       - name: Git checkout
         uses: actions/checkout@v3
         with:
@@ -75,7 +75,7 @@ jobs:
           node-version: 16.x
 
       - id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Deploy Local Network of Axon
         run: |

--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -60,7 +60,7 @@ jobs:
           inputs="${inputs//'%'/'%25'}"
           inputs="${inputs//'\n'/'%0A'}"
           inputs="${inputs//'\r'/'%0D'}"
-          echo "::set-output name=result::$inputs"
+          echo "result=$inputs" >> $GITHUB_OUTPUT
       - name: Git checkout
         uses: actions/checkout@v3
         with:
@@ -74,7 +74,7 @@ jobs:
           node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Node Cache
         uses: actions/cache@v3
         id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -154,7 +154,7 @@ jobs:
           node-version: "16"
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Node Cache
         uses: actions/cache@v3
         id: npm-and-yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
