### PR TITLE
refactor: change static merkle to trie merkle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,8 +1397,11 @@ name = "common-merkle"
 version = "0.2.1"
 dependencies = [
  "axon-protocol",
+ "cita_trie",
  "criterion",
+ "hasher",
  "rand 0.7.3",
+ "rlp",
  "static_merkle_tree",
 ]
 

--- a/common/merkle/Cargo.toml
+++ b/common/merkle/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cita_trie = "3.0"
+hasher = "0.1"
+rlp = "0.5"
 static_merkle_tree = "1.1.0"
 
 protocol = { path = "../../protocol", package = "axon-protocol" }

--- a/common/merkle/src/lib.rs
+++ b/common/merkle/src/lib.rs
@@ -81,7 +81,7 @@ impl<'a, C: ProtocolCodec + 'a> FromIterator<(usize, &'a C)> for TrieMerkle {
 }
 
 impl TrieMerkle {
-    pub fn root(&mut self) -> Result<Hash, Box<dyn Error + 'static>> {
+    pub fn root_hash(&mut self) -> Result<Hash, Box<dyn Error + 'static>> {
         Ok(Hash::from_slice(&self.0.root()?))
     }
 

--- a/common/merkle/src/lib.rs
+++ b/common/merkle/src/lib.rs
@@ -66,17 +66,14 @@ impl Default for TrieMerkle {
 }
 
 impl TrieMerkle {
-    pub fn from_iter<T: ProtocolCodec>(
-        iter: impl Iterator<Item = (usize, T)>,
+    pub fn from_iter<'a, T: ProtocolCodec + 'a>(
+        iter: impl Iterator<Item = (usize, &'a T)>,
     ) -> Result<Self, Box<dyn Error + 'static>> {
         let mut trie = Self::default();
 
         for (i, val) in iter {
             trie.0
-                .insert(
-                    rlp::encode(&i).to_vec(),
-                    val.encode().unwrap().to_vec(),
-                )?;
+                .insert(rlp::encode(&i).to_vec(), val.encode().unwrap().to_vec())?;
         }
 
         Ok(trie)
@@ -86,8 +83,12 @@ impl TrieMerkle {
         Ok(Hash::from_slice(&self.0.root()?))
     }
 
-    pub fn get_proof_by_index(&self, index: usize) -> Result<Hash, Box<dyn Error + 'static>> {
+    pub fn get_proof_by_index(
+        &self,
+        index: usize,
+    ) -> Result<Vec<Vec<u8>>, Box<dyn Error + 'static>> {
         let key = rlp::encode(&index).to_vec();
-        self.0.get_proof(&key)
+        let ret = self.0.get_proof(&key)?;
+        Ok(ret)
     }
 }

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -78,7 +78,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<Proposal> for ConsensusEngine<A
         let signed_txs = self.adapter.get_full_txs(ctx.clone(), &txs.hashes).await?;
         let txs_root = if !txs.hashes.is_empty() {
             TrieMerkle::from_iter(txs.hashes.iter().enumerate())
-                .root()
+                .root_hash()
                 .unwrap_or_default()
         } else {
             RLP_NULL
@@ -554,7 +554,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
         signed_txs: &[SignedTransaction],
     ) -> ProtocolResult<()> {
         let txs_root = TrieMerkle::from_iter(proposal.tx_hashes.iter().enumerate())
-            .root()
+            .root_hash()
             .unwrap_or(RLP_NULL);
 
         let stxs_hash = Hasher::digest(rlp::encode_list(signed_txs));

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -15,7 +15,7 @@ use common_apm::Instant;
 use common_apm_derive::trace_span;
 use common_crypto::BlsPublicKey;
 use common_logger::{json, log};
-use common_merkle::Merkle;
+use common_merkle::TrieMerkle;
 use protocol::traits::{ConsensusAdapter, Context, MessageTarget, NodeInfo};
 use protocol::types::{
     Block, Bytes, ExecResp, Hash, Hasher, Hex, Log, MerkleRoot, Metadata, Proof, Proposal, Receipt,
@@ -76,9 +76,10 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<Proposal> for ConsensusEngine<A
             )
             .await?;
         let signed_txs = self.adapter.get_full_txs(ctx.clone(), &txs.hashes).await?;
-        let order_root = if !txs.hashes.is_empty() {
-            Merkle::from_hashes(txs.hashes.clone())
-                .get_root_hash()
+        let txs_root = if !txs.hashes.is_empty() {
+            TrieMerkle::from_iter(txs.hashes.iter().enumerate())
+                .map_err(|e| ProtocolError::from(ConsensusError::BuildMerkle(e.to_string())))?
+                .root()
                 .unwrap_or_default()
         } else {
             RLP_NULL
@@ -87,7 +88,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<Proposal> for ConsensusEngine<A
         let proposal = Proposal {
             prev_hash:                  status.prev_hash,
             proposer:                   self.node_info.self_address.0,
-            transactions_root:          order_root,
+            transactions_root:          txs_root,
             signed_txs_hash:            digest_signed_transactions(&signed_txs),
             timestamp:                  time_now(),
             number:                     next_number,
@@ -553,8 +554,9 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
         proposal: &Proposal,
         signed_txs: &[SignedTransaction],
     ) -> ProtocolResult<()> {
-        let order_root = Merkle::from_hashes(proposal.tx_hashes.clone())
-            .get_root_hash()
+        let txs_root = TrieMerkle::from_iter(proposal.tx_hashes.iter().enumerate())
+            .map_err(|e| ProtocolError::from(ConsensusError::BuildMerkle(e.to_string())))?
+            .root()
             .unwrap_or(RLP_NULL);
 
         let stxs_hash = Hasher::digest(rlp::encode_list(signed_txs));
@@ -567,9 +569,9 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
             .into());
         }
 
-        if order_root != proposal.transactions_root {
+        if txs_root != proposal.transactions_root {
             return Err(ConsensusError::InvalidOrderRoot {
-                expect: order_root,
+                expect: txs_root,
                 actual: proposal.transactions_root,
             }
             .into());

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -78,7 +78,6 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<Proposal> for ConsensusEngine<A
         let signed_txs = self.adapter.get_full_txs(ctx.clone(), &txs.hashes).await?;
         let txs_root = if !txs.hashes.is_empty() {
             TrieMerkle::from_iter(txs.hashes.iter().enumerate())
-                .map_err(|e| ProtocolError::from(ConsensusError::BuildMerkle(e.to_string())))?
                 .root()
                 .unwrap_or_default()
         } else {
@@ -555,7 +554,6 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
         signed_txs: &[SignedTransaction],
     ) -> ProtocolResult<()> {
         let txs_root = TrieMerkle::from_iter(proposal.tx_hashes.iter().enumerate())
-            .map_err(|e| ProtocolError::from(ConsensusError::BuildMerkle(e.to_string())))?
             .root()
             .unwrap_or(RLP_NULL);
 

--- a/core/consensus/src/lib.rs
+++ b/core/consensus/src/lib.rs
@@ -186,6 +186,9 @@ pub enum ConsensusError {
 
     #[display(fmt = "Confused metadata range [{}, {})!", _0, _1)]
     ConfusedMetadata(u64, u64),
+
+    #[display(fmt = "Build trie merkle tree error {}", _0)]
+    BuildMerkle(String),
 }
 
 #[derive(Debug, Display)]

--- a/core/executor/benches/revm_adapter.rs
+++ b/core/executor/benches/revm_adapter.rs
@@ -4,7 +4,7 @@ use evm::{ExitReason, ExitSucceed};
 use hashbrown::HashMap;
 use revm::{AccountInfo, Bytecode, Database, DatabaseCommit};
 
-use common_merkle::Merkle;
+use common_merkle::TrieMerkle;
 use core_executor::{code_address, MPTTrie};
 use protocol::traits::{Context, Storage};
 use protocol::types::{
@@ -327,8 +327,9 @@ where
 
     ExecResp {
         state_root:   evm.db().unwrap().trie.commit().unwrap(),
-        receipt_root: Merkle::from_hashes(hashes)
-            .get_root_hash()
+        receipt_root: TrieMerkle::from_iter(hashes.iter().enumerate())
+            .unwrap()
+            .root()
             .unwrap_or_default(),
         gas_used:     total_gas_used,
         tx_resp:      tx_outputs,

--- a/core/executor/benches/revm_adapter.rs
+++ b/core/executor/benches/revm_adapter.rs
@@ -328,7 +328,6 @@ where
     ExecResp {
         state_root:   evm.db().unwrap().trie.commit().unwrap(),
         receipt_root: TrieMerkle::from_iter(hashes.iter().enumerate())
-            .unwrap()
             .root()
             .unwrap_or_default(),
         gas_used:     total_gas_used,

--- a/core/executor/benches/revm_adapter.rs
+++ b/core/executor/benches/revm_adapter.rs
@@ -328,7 +328,7 @@ where
     ExecResp {
         state_root:   evm.db().unwrap().trie.commit().unwrap(),
         receipt_root: TrieMerkle::from_iter(hashes.iter().enumerate())
-            .root()
+            .root_hash()
             .unwrap_or_default(),
         gas_used:     total_gas_used,
         tx_resp:      tx_outputs,

--- a/core/executor/src/adapter/trie.rs
+++ b/core/executor/src/adapter/trie.rs
@@ -7,20 +7,16 @@ use protocol::codec::hex_encode;
 use protocol::types::{Bytes, MerkleRoot};
 use protocol::{Display, From, ProtocolError, ProtocolErrorKind, ProtocolResult};
 
-lazy_static::lazy_static! {
-    static ref HASHER_INST: Arc<HasherKeccak> = Arc::new(HasherKeccak::new());
-}
-
 pub struct MPTTrie<DB: TrieDB>(PatriciaTrie<DB, HasherKeccak>);
 
 impl<DB: TrieDB> MPTTrie<DB> {
     pub fn new(db: Arc<DB>) -> Self {
-        MPTTrie(PatriciaTrie::new(db, Arc::clone(&HASHER_INST)))
+        MPTTrie(PatriciaTrie::new(db, Arc::new(HasherKeccak::new())))
     }
 
     pub fn from_root(root: MerkleRoot, db: Arc<DB>) -> ProtocolResult<Self> {
         Ok(MPTTrie(
-            PatriciaTrie::from(db, Arc::clone(&HASHER_INST), root.as_bytes())
+            PatriciaTrie::from(db, Arc::new(HasherKeccak::new()), root.as_bytes())
                 .map_err(MPTTrieError::from)?,
         ))
     }

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -22,7 +22,7 @@ use arc_swap::ArcSwap;
 use evm::executor::stack::{MemoryStackState, PrecompileFn, StackExecutor, StackSubstateMetadata};
 use evm::CreateScheme;
 
-use common_merkle::Merkle;
+use common_merkle::TrieMerkle;
 use protocol::codec::ProtocolCodec;
 use protocol::traits::{ApplyBackend, Backend, Executor, ExecutorAdapter as Adapter};
 use protocol::types::{
@@ -168,8 +168,9 @@ impl Executor for AxonExecutor {
 
         ExecResp {
             state_root:   new_state_root,
-            receipt_root: Merkle::from_hashes(hashes)
-                .get_root_hash()
+            receipt_root: TrieMerkle::from_iter(hashes.iter().enumerate())
+                .expect("should not panic when build receipts root")
+                .root()
                 .unwrap_or_default(),
             gas_used:     gas,
             tx_resp:      res,

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -170,7 +170,7 @@ impl Executor for AxonExecutor {
         ExecResp {
             state_root:   new_state_root,
             receipt_root: TrieMerkle::from_iter(hashes.iter().enumerate())
-                .root()
+                .root_hash()
                 .unwrap_or_default(),
             gas_used:     gas,
             tx_resp:      res,

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -17,6 +17,7 @@ pub use crate::utils::{
 };
 
 use std::collections::BTreeMap;
+use std::iter::FromIterator;
 
 use arc_swap::ArcSwap;
 use evm::executor::stack::{MemoryStackState, PrecompileFn, StackExecutor, StackSubstateMetadata};
@@ -169,7 +170,6 @@ impl Executor for AxonExecutor {
         ExecResp {
             state_root:   new_state_root,
             receipt_root: TrieMerkle::from_iter(hashes.iter().enumerate())
-                .expect("should not panic when build receipts root")
                 .root()
                 .unwrap_or_default(),
             gas_used:     gas,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR changes the calculation of transactions root and receipts root from static merkle to trie merkle.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Chaos CI
- [x] Cargo Clippy
- [x] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
