### PR TITLE
chore(deps): bump dappeteer from 2.4.0-rc0 to 2.4.0-rc1

### DIFF
--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint src/*.js ./*.js"
   },
   "dependencies": {
-    "@chainsafe/dappeteer": "https://github.com/hongda3141/dappeteer.git#v2.4.0-rc0",
+    "@chainsafe/dappeteer": "https://github.com/hongda3141/dappeteer.git#v2.4.0-rc1",
     "ethereumjs-tx": "^2.1.2",
     "puppeteer": "^19.2.2",
     "web3": "^1.8.0",

--- a/tests/e2e/yarn.lock
+++ b/tests/e2e/yarn.lock
@@ -491,10 +491,9 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chainsafe/dappeteer@https://github.com/hongda3141/dappeteer.git#v2.4.0-rc0":
+"@chainsafe/dappeteer@https://github.com/hongda3141/dappeteer.git#v2.4.0-rc1":
   version "2.4.1"
-  uid "5debef94c65ef3af35e17ca8111291f2629d4dfe"
-  resolved "https://github.com/hongda3141/dappeteer.git#5debef94c65ef3af35e17ca8111291f2629d4dfe"
+  resolved "https://github.com/hongda3141/dappeteer.git#6df07816231b4c0eef9d3c45100d5c1e77896e9c"
   dependencies:
     node-stream-zip "^1.13.0"
 


### PR DESCRIPTION
update test/e2e

<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Chaos CI
- [x] Cargo Clippy
- [x] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
