### PR TITLE
[WIP]  joyId POC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,6 +1776,7 @@ dependencies = [
  "ckb-types",
  "common-crypto",
  "core-rpc-client",
+ "hasher",
  "lazy_static",
  "log",
  "molecule",

--- a/core/tx-assembler/Cargo.toml
+++ b/core/tx-assembler/Cargo.toml
@@ -10,6 +10,7 @@ ckb-jsonrpc-types = "0.105"
 ckb-sdk = "2.3"
 ckb-types = "0.105"
 common-crypto = { path = "../../common/crypto" }
+hasher = "0.1"
 lazy_static = "1.4"
 log = "0.4"
 molecule = "0.7"

--- a/core/tx-assembler/src/account.rs
+++ b/core/tx-assembler/src/account.rs
@@ -1,0 +1,63 @@
+use ckb_types::{
+    core::Capacity,
+    packed::{CellOutput, Script},
+    prelude::Entity,
+};
+use hasher::{Hasher as KeccakHasher, HasherKeccak};
+use protocol::types::{Account, H160, NIL_DATA, RLP_NULL, U256, H256};
+
+lazy_static::lazy_static! {
+    static ref HASHER_INST: HasherKeccak = HasherKeccak::new();
+}
+
+#[warn(dead_code)]
+pub struct EthereumAccount {
+    _lock_script: Script,
+    _eth_address: H160,
+    _eth_account: Account,
+    _cell:        CellOutput,
+}
+
+impl EthereumAccount {
+    #[allow(unused)]
+    pub fn new(lock_script: Script) -> Self {
+        let cell = CellOutput::new_builder()
+            .lock(lock_script.clone())
+            .build_exact_capacity(Capacity::zero())
+            .unwrap();
+        let eth_account = Account {
+            nonce:        U256::zero(),
+            balance:      U256::zero(),
+            storage_root: RLP_NULL,
+            code_hash:    NIL_DATA,
+        };
+        let raw_address = H256::from_slice(&HASHER_INST.digest(&lock_script.as_bytes()));
+        let eth_address = H160::from(raw_address);
+        EthereumAccount {
+            _lock_script: lock_script,
+            _eth_address: eth_address,
+            _eth_account: eth_account,
+            _cell: cell,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn get_account() {}
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::util;
+
+    use super::*;
+
+    #[test]
+    fn test_gen_account() {
+        let mock_arg = protocol::types::Hash::random();
+        let account = EthereumAccount::new(util::build_acs_lock_script(mock_arg));
+        println!("{:?}", account._eth_address);
+        // 0xdbcbe8e1f26ad869c5ff455bca16ec4349e8c6b2
+    }
+
+}

--- a/core/tx-assembler/src/lib.rs
+++ b/core/tx-assembler/src/lib.rs
@@ -1,3 +1,4 @@
+mod account;
 mod indexer;
 #[allow(clippy::all)]
 mod molecule;


### PR DESCRIPTION
converse cell info to eth account id

<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
