### PR TITLE
chore: bump cita_trie version to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bytes",
+ "cita_trie",
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-sdk",
@@ -807,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "cita_trie"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bef4b9e0e4b3c642551260ee5284d6756dfa8c845fba3bf043bd836b16ebdc"
+checksum = "afe7baab47f510f52ca8dc9c0eb9082020c627c7f22285bea30edc3511f7ee29"
 dependencies = [
  "hasher",
  "parking_lot 0.12.1",
@@ -1390,7 +1391,6 @@ name = "common-merkle"
 version = "0.2.1"
 dependencies = [
  "axon-protocol",
- "cita_trie",
  "criterion",
  "hasher",
  "rand 0.7.3",
@@ -1429,7 +1429,6 @@ version = "0.1.0"
 dependencies = [
  "axon-protocol",
  "beef",
- "cita_trie",
  "common-apm",
  "common-config-parser",
  "core-consensus",
@@ -1464,7 +1463,6 @@ dependencies = [
  "arc-swap",
  "axon-protocol",
  "bit-vec",
- "cita_trie",
  "common-apm",
  "common-apm-derive",
  "common-crypto",
@@ -1497,7 +1495,6 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "axon-protocol",
- "cita_trie",
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-sdk",
@@ -1533,7 +1530,6 @@ dependencies = [
  "axon-protocol",
  "az",
  "bytemuck",
- "cita_trie",
  "ckb-jsonrpc-types",
  "ckb-rocksdb",
  "ckb-types",
@@ -1623,7 +1619,6 @@ name = "core-mempool"
 version = "0.1.0"
 dependencies = [
  "axon-protocol",
- "cita_trie",
  "common-apm",
  "common-apm-derive",
  "common-config-parser",
@@ -1648,7 +1643,6 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "axon-protocol",
- "cita_trie",
  "common-apm",
  "core-executor",
  "core-storage",
@@ -1708,7 +1702,6 @@ version = "0.1.0"
 dependencies = [
  "axon-protocol",
  "backtrace",
- "cita_trie",
  "common-apm",
  "common-apm-derive",
  "common-config-parser",

--- a/common/merkle/Cargo.toml
+++ b/common/merkle/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cita_trie = "3.0"
 hasher = "0.1"
 rlp = "0.5"
 static_merkle_tree = "1.1"

--- a/common/merkle/src/lib.rs
+++ b/common/merkle/src/lib.rs
@@ -2,11 +2,11 @@ use std::error::Error;
 use std::iter::FromIterator;
 use std::sync::Arc;
 
-use cita_trie::{MemoryDB, PatriciaTrie, Trie};
 use hasher::HasherKeccak;
 use static_merkle_tree::Tree;
 
 use protocol::codec::ProtocolCodec;
+use protocol::trie::{MemoryDB, PatriciaTrie, Trie};
 use protocol::types::{Bytes, Hash, Hasher};
 
 #[derive(Debug, Clone)]

--- a/core/api/Cargo.toml
+++ b/core/api/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 # async-graphql = { version = "3.0", features = ["tracing"] }
 beef = "0.5"
-cita_trie = "3.0"
+
 jsonrpsee = { version = "0.15", features = ["http-server", "macros", "ws-server"] }
 log = "0.4"
 parking_lot = "0.12"

--- a/core/api/src/adapter.rs
+++ b/core/api/src/adapter.rs
@@ -7,7 +7,7 @@ use protocol::types::{
     Header, Proposal, Receipt, SignedTransaction, TxResp, H160, MAX_BLOCK_GAS_LIMIT, NIL_DATA,
     RLP_NULL, U256,
 };
-use protocol::{async_trait, codec::ProtocolCodec, ProtocolResult};
+use protocol::{async_trait, codec::ProtocolCodec, trie, ProtocolResult};
 
 use crate::APIError;
 
@@ -23,7 +23,7 @@ impl<M, S, DB, Net> DefaultAPIAdapter<M, S, DB, Net>
 where
     M: MemPool + 'static,
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
     Net: Network + 'static,
 {
     pub fn new(mempool: Arc<M>, storage: Arc<S>, trie_db: Arc<DB>, net: Arc<Net>) -> Self {
@@ -60,7 +60,7 @@ impl<M, S, DB, Net> APIAdapter for DefaultAPIAdapter<M, S, DB, Net>
 where
     M: MemPool + 'static,
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
     Net: Network + 'static,
 {
     async fn insert_signed_txs(

--- a/core/consensus/Cargo.toml
+++ b/core/consensus/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 arc-swap = "1.5"
-cita_trie = "3.0"
+
 creep = "0.2"
 futures = { version = "0.3", features = ["async-await"] }
 json = "0.12"

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -18,7 +18,7 @@ use protocol::types::{
     BatchSignedTxs, Block, BlockNumber, Bytes, ExecResp, Hash, Header, Hex, Log, MerkleRoot,
     Metadata, PackedTxHashes, Proof, Proposal, Receipt, SignedTransaction, Validator, U256,
 };
-use protocol::{async_trait, tokio::task, ProtocolResult};
+use protocol::{async_trait, tokio::task, trie, ProtocolResult};
 
 use crate::consensus::gen_overlord_status;
 use crate::message::{
@@ -36,7 +36,7 @@ pub struct OverlordConsensusAdapter<
     S: Storage,
     CS: CrossChain,
     MT: MetadataControl,
-    DB: cita_trie::DB,
+    DB: trie::DB,
 > {
     network: Arc<N>,
     mempool: Arc<M>,
@@ -57,7 +57,7 @@ where
     S: Storage + 'static,
     CS: CrossChain + 'static,
     MT: MetadataControl + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     #[trace_span(kind = "consensus.adapter")]
     async fn get_txs_from_mempool(
@@ -136,7 +136,7 @@ where
     S: Storage + 'static,
     CS: CrossChain + 'static,
     MT: MetadataControl + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     #[trace_span(kind = "consensus.adapter")]
     fn update_status(
@@ -239,7 +239,7 @@ where
     S: Storage + 'static,
     CS: CrossChain + 'static,
     MT: MetadataControl + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     /// Save a block to the database.
     #[trace_span(kind = "consensus.adapter", logs = "{txs_len: block.tx_hashes.len()}")]
@@ -635,7 +635,7 @@ where
     S: Storage + 'static,
     CS: CrossChain + 'static,
     MT: MetadataControl + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     pub fn new(
         network: Arc<N>,

--- a/core/cross-client/Cargo.toml
+++ b/core/cross-client/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 arc-swap = "1.5"
-cita_trie = "3.0"
 ckb-hash = "0.105"
 ckb-jsonrpc-types = "0.105"
 ckb-sdk = "2.3"

--- a/core/cross-client/src/adapter/mod.rs
+++ b/core/cross-client/src/adapter/mod.rs
@@ -8,6 +8,7 @@ use ckb_jsonrpc_types::OutputsValidator;
 use ckb_types::core::TransactionView;
 
 use common_crypto::{BlsPublicKey, BlsSignature};
+use core_executor::{AxonExecutor, AxonExecutorAdapter};
 use protocol::traits::{
     Backend, CkbClient, Context, CrossAdapter, Executor, MemPool, MessageTarget, MetadataControl,
     Storage, TxAssembler,
@@ -15,9 +16,7 @@ use protocol::traits::{
 use protocol::types::{
     Metadata, RequestTxHashes, SignedTransaction, Transfer, TxResp, H160, H256, U256,
 };
-use protocol::{async_trait, lazy::CURRENT_STATE_ROOT, ProtocolResult};
-
-use core_executor::{AxonExecutor, AxonExecutorAdapter};
+use protocol::{async_trait, lazy::CURRENT_STATE_ROOT, trie, ProtocolResult};
 
 pub trait CrossChainDB: Sync + Send {
     fn get(&self, key: &[u8]) -> ProtocolResult<Option<Vec<u8>>>;
@@ -47,7 +46,7 @@ where
     D: MetadataControl + 'static,
     S: Storage + 'static,
     A: TxAssembler + 'static,
-    TrieDB: cita_trie::DB + 'static,
+    TrieDB: trie::DB + 'static,
     DB: CrossChainDB + 'static,
     Rpc: CkbClient + 'static,
 {
@@ -181,7 +180,7 @@ where
     D: MetadataControl + 'static,
     S: Storage + 'static,
     A: TxAssembler + 'static,
-    TrieDB: cita_trie::DB + 'static,
+    TrieDB: trie::DB + 'static,
     DB: CrossChainDB + 'static,
     Rpc: CkbClient + 'static,
 {

--- a/core/executor/Cargo.toml
+++ b/core/executor/Cargo.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 arc-swap = "1.5"
 az = "1.2"
 bn = { package = "substrate-bn", version = "0.6" }
-cita_trie = "3.0"
 
 common-apm = { path = "../../common/apm" }
 common-config-parser = { path = "../../common/config-parser" }
@@ -33,7 +32,6 @@ sha2 = "0.10"
 [dev-dependencies]
 bytemuck = "1.12"
 ckb-jsonrpc-types = "0.105"
-
 ckb-types = "0.105"
 common-crypto = { path = "../../common/crypto" }
 core-cross-client = { path = "../cross-client" }

--- a/core/executor/benches/bench_vm.rs
+++ b/core/executor/benches/bench_vm.rs
@@ -9,6 +9,7 @@ use core_executor::{AxonExecutor, AxonExecutorAdapter, MPTTrie};
 use protocol::{
     codec::ProtocolCodec,
     traits::{Executor, Storage},
+    trie,
     types::{Account, Address, ExecutorContext},
 };
 
@@ -17,7 +18,7 @@ use crate::mock::{
 };
 use crate::revm_adapter::{revm_exec, RevmAdapter};
 
-trait BackendInit<S: Storage + 'static, DB: cita_trie::DB + 'static> {
+trait BackendInit<S: Storage + 'static, DB: trie::DB + 'static> {
     fn init(
         storage: S,
         db: DB,
@@ -30,7 +31,7 @@ trait BackendInit<S: Storage + 'static, DB: cita_trie::DB + 'static> {
 impl<S, DB> BackendInit<S, DB> for RevmAdapter<S, DB>
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     fn init(
         storage: S,
@@ -48,7 +49,7 @@ where
 impl<S, DB> BackendInit<S, DB> for AxonExecutorAdapter<S, DB>
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     fn init(
         storage: S,

--- a/core/executor/benches/revm_adapter.rs
+++ b/core/executor/benches/revm_adapter.rs
@@ -11,7 +11,7 @@ use protocol::types::{
     Account, Address, Bytes, ExecResp, ExecutorContext, Hasher, Proposal, SignedTransaction,
     TransactionAction, TxResp, H160, H256, NIL_DATA, RLP_NULL, U256,
 };
-use protocol::{codec::ProtocolCodec, ProtocolError};
+use protocol::{codec::ProtocolCodec, trie, ProtocolError};
 
 lazy_static::lazy_static! {
     static ref DISTRIBUTE_ADDRESS: Address = Address::from_hex("0x35e70c3f5a794a77efc2ec5ba964bffcc7fd2c0a").unwrap();
@@ -28,7 +28,7 @@ macro_rules! blocking_async {
     }};
 }
 
-pub struct RevmAdapter<S, DB: cita_trie::DB> {
+pub struct RevmAdapter<S, DB: trie::DB> {
     exec_ctx: ExecutorContext,
     trie:     MPTTrie<DB>,
     storage:  Arc<S>,
@@ -38,7 +38,7 @@ pub struct RevmAdapter<S, DB: cita_trie::DB> {
 impl<S, DB> Database for RevmAdapter<S, DB>
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     type Error = ProtocolError;
 
@@ -116,7 +116,7 @@ where
 impl<S, DB> DatabaseCommit for RevmAdapter<S, DB>
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     fn commit(&mut self, changes: HashMap<H160, revm::Account>) {
         changes.into_iter().for_each(|(addr, change)| {
@@ -180,7 +180,7 @@ where
 impl<S, DB> RevmAdapter<S, DB>
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     pub fn init_mpt(&mut self, account: Account, addr: Address) {
         let mut mpt = MPTTrie::new(Arc::clone(&self.db));
@@ -278,7 +278,7 @@ pub fn revm_exec<S, DB>(
 ) -> ExecResp
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     let txs_len = txs.len();
     let mut tx_outputs = Vec::with_capacity(txs_len);

--- a/core/executor/src/adapter/mod.rs
+++ b/core/executor/src/adapter/mod.rs
@@ -1,8 +1,8 @@
-mod trie;
 mod trie_db;
+mod wrapped_trie;
 
-pub use trie::MPTTrie;
 pub use trie_db::RocksTrieDB;
+pub use wrapped_trie::MPTTrie;
 
 use std::sync::Arc;
 
@@ -13,7 +13,7 @@ use protocol::types::{
     Account, Bytes, ExecutorContext, Hasher, Log, MerkleRoot, Proposal, H160, H256, NIL_DATA,
     RLP_NULL, U256,
 };
-use protocol::{codec::ProtocolCodec, ProtocolResult};
+use protocol::{codec::ProtocolCodec, trie, ProtocolResult};
 
 const GET_BLOCK_HASH_NUMBER_RANGE: u64 = 256;
 
@@ -28,7 +28,7 @@ macro_rules! blocking_async {
     }};
 }
 
-pub struct AxonExecutorAdapter<S, DB: cita_trie::DB> {
+pub struct AxonExecutorAdapter<S, DB: trie::DB> {
     exec_ctx: ExecutorContext,
     trie:     MPTTrie<DB>,
     storage:  Arc<S>,
@@ -38,7 +38,7 @@ pub struct AxonExecutorAdapter<S, DB: cita_trie::DB> {
 impl<S, DB> ExecutorAdapter for AxonExecutorAdapter<S, DB>
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     fn get_ctx(&self) -> ExecutorContext {
         self.exec_ctx.clone()
@@ -89,7 +89,7 @@ where
 impl<S, DB> Backend for AxonExecutorAdapter<S, DB>
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     fn gas_price(&self) -> U256 {
         self.exec_ctx.gas_price
@@ -218,7 +218,7 @@ where
 impl<S, DB> ApplyBackend for AxonExecutorAdapter<S, DB>
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     fn apply<A, I, L>(&mut self, values: A, logs: L, delete_empty: bool)
     where
@@ -253,7 +253,7 @@ where
 impl<S, DB> AxonExecutorAdapter<S, DB>
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     pub fn new(db: Arc<DB>, storage: Arc<S>, exec_ctx: ExecutorContext) -> ProtocolResult<Self> {
         let trie = MPTTrie::new(Arc::clone(&db));

--- a/core/executor/src/adapter/trie_db.rs
+++ b/core/executor/src/adapter/trie_db.rs
@@ -8,7 +8,7 @@ use rocksdb::{FullOptions, Options, WriteBatch, DB};
 use common_apm::metrics::storage::{on_storage_get_state, on_storage_put_state};
 use common_apm::Instant;
 use common_config_parser::types::ConfigRocksDB;
-use protocol::{Display, From, ProtocolError, ProtocolErrorKind, ProtocolResult};
+use protocol::{trie, Display, From, ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 // 49999 is the largest prime number within 50000.
 const RAND_SEED: u64 = 49999;
@@ -45,7 +45,7 @@ impl RocksTrieDB {
     }
 
     fn inner_get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, RocksTrieDBError> {
-        use cita_trie::DB;
+        use trie::DB;
 
         let res = { self.cache.read().get(key).cloned() };
 
@@ -78,7 +78,7 @@ impl RocksTrieDB {
     }
 }
 
-impl cita_trie::DB for RocksTrieDB {
+impl trie::DB for RocksTrieDB {
     type Error = RocksTrieDBError;
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -239,8 +239,8 @@ fn to_store_err(e: rocksdb::Error) -> RocksTrieDBError {
 
 #[cfg(test)]
 mod tests {
-    use cita_trie::DB;
     use getrandom::getrandom;
+    use trie::DB;
 
     use super::*;
 

--- a/core/executor/src/adapter/wrapped_trie.rs
+++ b/core/executor/src/adapter/wrapped_trie.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
-use cita_trie::{PatriciaTrie, Trie, TrieError, DB as TrieDB};
 use hasher::HasherKeccak;
 
-use protocol::codec::hex_encode;
+use protocol::trie::{PatriciaTrie, Trie, TrieError, DB as TrieDB};
 use protocol::types::{Bytes, MerkleRoot};
-use protocol::{Display, From, ProtocolError, ProtocolErrorKind, ProtocolResult};
+use protocol::{
+    codec::hex_encode, Display, From, ProtocolError, ProtocolErrorKind, ProtocolResult,
+};
 
 pub struct MPTTrie<DB: TrieDB>(PatriciaTrie<DB, HasherKeccak>);
 

--- a/core/mempool/Cargo.toml
+++ b/core/mempool/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cita_trie = "3.0"
 crossbeam-queue = "0.3"
 dashmap = { version = "5.4", features = ["rayon"] }
 futures = { version = "0.3", features = [ "async-await" ] }

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -25,8 +25,8 @@ use protocol::types::{
     recover_intact_pub_key, BatchSignedTxs, Bytes, Hash, MerkleRoot, SignedTransaction, H160, U256,
 };
 use protocol::{
-    async_trait, codec::ProtocolCodec, lazy::CURRENT_STATE_ROOT, tokio, Display, ProtocolError,
-    ProtocolErrorKind, ProtocolResult,
+    async_trait, codec::ProtocolCodec, lazy::CURRENT_STATE_ROOT, tokio, trie, Display,
+    ProtocolError, ProtocolErrorKind, ProtocolResult,
 };
 
 use crate::adapter::message::{MsgPullTxs, END_GOSSIP_NEW_TXS, RPC_PULL_TXS};
@@ -133,7 +133,7 @@ where
     C: Crypto,
     N: Rpc + PeerTrust + Gossip + Clone + Unpin + 'static,
     S: Storage,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
     M: MetadataControl + 'static,
     I: Interoperation + 'static,
 {
@@ -208,7 +208,7 @@ where
     C: Crypto + Send + Sync + 'static,
     N: Rpc + PeerTrust + Gossip + Clone + Unpin + 'static,
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
     M: MetadataControl + 'static,
     I: Interoperation + 'static,
 {

--- a/core/metadata/Cargo.toml
+++ b/core/metadata/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 arc-swap = "1.5"
-cita_trie = "3.0"
 common-apm = { path = "../../common/apm" }
 ethers-contract = { version = "1.0", features = ["abigen"] }
 ethers-core = "1.0"

--- a/core/metadata/src/adapter.rs
+++ b/core/metadata/src/adapter.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use core_executor::{AxonExecutor, AxonExecutorAdapter};
 use protocol::traits::{Context, Executor, MetadataControlAdapter, Storage};
 use protocol::types::{Header, TxResp, H160};
-use protocol::ProtocolResult;
+use protocol::{trie, ProtocolResult};
 
 pub struct MetadataAdapterImpl<S, DB> {
     storage: Arc<S>,
@@ -13,7 +13,7 @@ pub struct MetadataAdapterImpl<S, DB> {
 impl<S, DB> MetadataControlAdapter for MetadataAdapterImpl<S, DB>
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     fn call_evm(
         &self,
@@ -43,7 +43,7 @@ where
 impl<S, DB> MetadataAdapterImpl<S, DB>
 where
     S: Storage + 'static,
-    DB: cita_trie::DB + 'static,
+    DB: trie::DB + 'static,
 {
     pub fn new(storage: Arc<S>, trie_db: Arc<DB>) -> Self {
         MetadataAdapterImpl { storage, trie_db }

--- a/core/run/Cargo.toml
+++ b/core/run/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 backtrace = "0.3"
-cita_trie = "3.0"
+
 ethers-signers = "1.0"
 futures = "0.3"
 log = "0.4"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -32,6 +32,7 @@ rlp = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 tendermint-proto = { version = "0.23", optional = true }
 tokio = { version = "1.21", features = ["full"] }
+trie = { package = "cita_trie", version = "4.0" }
 
 [dev-dependencies]
 getrandom = "0.2"

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -7,9 +7,8 @@ pub mod types;
 
 use std::error::Error;
 
-pub use async_trait::async_trait;
 pub use derive_more::{Constructor, Display, From};
-pub use tokio;
+pub use {async_trait::async_trait, tokio, trie};
 
 #[derive(Debug, Clone)]
 pub enum ProtocolErrorKind {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
