### PR TITLE
refactor(API): total difficulty in header always be zero

### DIFF
--- a/core/api/src/jsonrpc/web3_types.rs
+++ b/core/api/src/jsonrpc/web3_types.rs
@@ -289,7 +289,7 @@ impl From<Block> for Web3Block {
             receipts_root:     b.header.receipts_root,
             miner:             b.header.proposer,
             difficulty:        b.header.difficulty,
-            total_difficulty:  None,
+            total_difficulty:  Some(U256::zero()),
             seal_fields:       vec![],
             base_fee_per_gas:  b.header.base_fee_per_gas,
             extra_data:        Hex::encode(&b.header.extra_data),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [x] Code Format
- [ ] Unit Tests
- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [x] v3 Core Tests
