### PR TITLE
ci: workflow to generate changlog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,7 +9,7 @@ template: |
 categories:
   - title: '🚀 Features'
     label: 'feature'
-  - title: '🚀 Enhancement'
+  - title: '🔥 Enhancement'
     label: 'enhancement'
   - title: '🐛 Bug Fixes'
     label: 'bugfix'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
 name: Coverage Test
 on:
-  push:
+  # push:
     # branches:
     #   - main
   workflow_dispatch:

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -1,0 +1,40 @@
+name: Generate changelog
+on:
+  release:
+    types: [created, edited]
+
+jobs:
+  generate-changelog:
+    runs-on: ubuntu-latest
+    outputs:
+      changelog: ${{ steps.changelog.outputs.changelog }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: "✏️ Generate release changelog"
+      id: changelog
+      uses: liya2017/auto-generator-changelog@main
+      with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          headerLabel: "# 📑 Changelog"
+          addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🚀 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
+          author: true
+          compareLink: true
+          stripGeneratorNotice: true
+  create-changelog-pr:
+    runs-on: ubuntu-latest
+    needs: generate-changelog
+    steps:
+    - uses: actions/checkout@v3
+      with: 
+        ref: main
+    - run: |
+       echo "${{ needs.generate-changelog.outputs.changelog }}" >${{ github.workspace }}/CHANGELOG.md
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        token: ${{ secrets.TOKEN }}
+        signoff: false
+        commit-message: "feat: automated pr to change config files"
+        branch: bot-${{ github.repository }}
+        title: "feat: automated pr to change log"
+        body: "automated pr to change log"

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -16,7 +16,7 @@ jobs:
       with:
           token: ${{ secrets.GITHUB_TOKEN }}
           headerLabel: "# 📑 Changelog"
-          addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🚀 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
+          addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🔥 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
           author: true
           compareLink: true
           stripGeneratorNotice: true
@@ -34,7 +34,7 @@ jobs:
       with:
         token: ${{ secrets.TOKEN }}
         signoff: false
-        commit-message: "docs: automated update CHANGELOG.mds"
+        commit-message: "docs: automated update CHANGELOG.md"
         branch: bot-${{ github.repository }}
         title: "docs: automated update CHANGELOG.md"
         body: "automated pr to change log"

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -36,5 +36,5 @@ jobs:
         signoff: false
         commit-message: "docs: automated update CHANGELOG.mds"
         branch: bot-${{ github.repository }}
-        title: "feat: automated pr to change log"
+        title: "docs: automated update CHANGELOG.md"
         body: "automated pr to change log"

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         token: ${{ secrets.TOKEN }}
         signoff: false
-        commit-message: "feat: automated pr to change config files"
+        commit-message: "docs: automated update CHANGELOG.mds"
         branch: bot-${{ github.repository }}
         title: "feat: automated pr to change log"
         body: "automated pr to change log"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
