### PR TITLE
fix: net version to string

### DIFF
--- a/core/api/src/jsonrpc/impl/node.rs
+++ b/core/api/src/jsonrpc/impl/node.rs
@@ -31,8 +31,8 @@ impl AxonNodeRpcServer for NodeRpcImpl {
         Ok((**CHAIN_ID.load()).into())
     }
 
-    fn net_version(&self) -> RpcResult<U256> {
-        self.chain_id()
+    fn net_version(&self) -> RpcResult<String> {
+        Ok((**CHAIN_ID.load()).to_string())
     }
 
     fn client_version(&self) -> RpcResult<String> {

--- a/core/api/src/jsonrpc/mod.rs
+++ b/core/api/src/jsonrpc/mod.rs
@@ -147,7 +147,7 @@ pub trait AxonNodeRpc {
     fn chain_id(&self) -> RpcResult<U256>;
 
     #[method(name = "net_version")]
-    fn net_version(&self) -> RpcResult<U256>;
+    fn net_version(&self) -> RpcResult<String>;
 
     #[method(name = "web3_clientVersion")]
     fn client_version(&self) -> RpcResult<String>;

--- a/tests/e2e/src/net_version.test.js
+++ b/tests/e2e/src/net_version.test.js
@@ -7,13 +7,13 @@ describe("net_version", () => {
     await goto.goto(page, pageName);
   });
 
-  it("should returns 0x05", async () => {
+  it("should returns version", async () => {
     await page.click("#getChainId");
 
     await page.waitForFunction(
       () => document.getElementById("chainId").innerText !== "",
     );
 
-    await expect(page.$eval("#chainId", (e) => e.innerText)).resolves.toBe("0x7e6");
+    await expect(page.$eval("#chainId", (e) => e.innerText)).resolves.toBe(2022);
   });
 });

--- a/tests/e2e/src/net_version.test.js
+++ b/tests/e2e/src/net_version.test.js
@@ -14,6 +14,6 @@ describe("net_version", () => {
       () => document.getElementById("chainId").innerText !== "",
     );
 
-    await expect(page.$eval("#chainId", (e) => e.innerText)).resolves.toBe(2022);
+    await expect(page.$eval("#chainId", (e) => e.innerText)).resolves.toBe("2022");
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR change net version type from H256 to String

**Which issue(s) this PR fixes**:
Fixes #967 

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [x] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
