### PR TITLE
refactor: change the cache size of system contract to 20

### DIFF
--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -38,10 +38,14 @@ jobs:
       with:
         token: ${{ secrets.TOKEN }}
         signoff: false
+<<<<<<< HEAD
         commit-message: "docs: automated update CHANGELOG.md"
         branch: bot-${{ github.repository }}
         title: "docs: automated update CHANGELOG.md"
         commit-message: "feat: automated pr to change config files"
+=======
+        commit-message: "docs: automated update CHANGELOG.mds"
+>>>>>>> 94bbc12 (ci: update commit message)
         branch: bot-${{ github.repository }}
         title: "feat: automated pr to change log"
         body: "automated pr to change log"

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -17,10 +17,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           headerLabel: "# 📑 Changelog"
 <<<<<<< HEAD
+<<<<<<< HEAD
           addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🔥 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
 =======
           addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🚀 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
 >>>>>>> c3ddb29 (ci: workflow to generate changlog)
+=======
+          addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🔥 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
+>>>>>>> 0308bf9 (ci: update prefix image)
           author: true
           compareLink: true
           stripGeneratorNotice: true
@@ -39,6 +43,7 @@ jobs:
         token: ${{ secrets.TOKEN }}
         signoff: false
 <<<<<<< HEAD
+<<<<<<< HEAD
         commit-message: "docs: automated update CHANGELOG.md"
         branch: bot-${{ github.repository }}
         title: "docs: automated update CHANGELOG.md"
@@ -46,6 +51,9 @@ jobs:
 =======
         commit-message: "docs: automated update CHANGELOG.mds"
 >>>>>>> 94bbc12 (ci: update commit message)
+=======
+        commit-message: "docs: automated update CHANGELOG.md"
+>>>>>>> 0308bf9 (ci: update prefix image)
         branch: bot-${{ github.repository }}
         title: "docs: automated update CHANGELOG.md"
         body: "automated pr to change log"

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -16,15 +16,7 @@ jobs:
       with:
           token: ${{ secrets.GITHUB_TOKEN }}
           headerLabel: "# 📑 Changelog"
-<<<<<<< HEAD
-<<<<<<< HEAD
           addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🔥 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
-=======
-          addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🚀 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
->>>>>>> c3ddb29 (ci: workflow to generate changlog)
-=======
-          addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🔥 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
->>>>>>> 0308bf9 (ci: update prefix image)
           author: true
           compareLink: true
           stripGeneratorNotice: true
@@ -42,18 +34,7 @@ jobs:
       with:
         token: ${{ secrets.TOKEN }}
         signoff: false
-<<<<<<< HEAD
-<<<<<<< HEAD
         commit-message: "docs: automated update CHANGELOG.md"
-        branch: bot-${{ github.repository }}
-        title: "docs: automated update CHANGELOG.md"
-        commit-message: "feat: automated pr to change config files"
-=======
-        commit-message: "docs: automated update CHANGELOG.mds"
->>>>>>> 94bbc12 (ci: update commit message)
-=======
-        commit-message: "docs: automated update CHANGELOG.md"
->>>>>>> 0308bf9 (ci: update prefix image)
         branch: bot-${{ github.repository }}
         title: "docs: automated update CHANGELOG.md"
         body: "automated pr to change log"

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -47,5 +47,5 @@ jobs:
         commit-message: "docs: automated update CHANGELOG.mds"
 >>>>>>> 94bbc12 (ci: update commit message)
         branch: bot-${{ github.repository }}
-        title: "feat: automated pr to change log"
+        title: "docs: automated update CHANGELOG.md"
         body: "automated pr to change log"

--- a/.github/workflows/generate_changlog_file.yml
+++ b/.github/workflows/generate_changlog_file.yml
@@ -16,7 +16,11 @@ jobs:
       with:
           token: ${{ secrets.GITHUB_TOKEN }}
           headerLabel: "# 📑 Changelog"
+<<<<<<< HEAD
           addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🔥 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
+=======
+          addSections: '{"documentation":{"prefix":"### 📖 Documentation","labels":["document"]},"Features":{"prefix":"### 🚀 Features","labels":["feature"]},"Enhancement":{"prefix":"### 🚀 Enhancement","labels":["enhancement"]},"bugfix":{"prefix":"🐛 Bug Fixes","labels":["bugfix"]},"refactor":{"prefix":"### 🐝  refactor","labels":["refactor"]},"chore":{"prefix":"### 🧰 Chore","labels":["chore"]},"Otherchanges":{"prefix":"✨ Other changes","labels":[""]},"dependencies":{"prefix":"⬆️ Dependency Updates","labels":["dependencies"]},"style":{"prefix":"🌈 Style","labels":["style"]}}'
+>>>>>>> c3ddb29 (ci: workflow to generate changlog)
           author: true
           compareLink: true
           stripGeneratorNotice: true
@@ -37,4 +41,7 @@ jobs:
         commit-message: "docs: automated update CHANGELOG.md"
         branch: bot-${{ github.repository }}
         title: "docs: automated update CHANGELOG.md"
+        commit-message: "feat: automated pr to change config files"
+        branch: bot-${{ github.repository }}
+        title: "feat: automated pr to change log"
         body: "automated pr to change log"

--- a/core/executor/src/system_contract/image_cell/mod.rs
+++ b/core/executor/src/system_contract/image_cell/mod.rs
@@ -34,24 +34,22 @@ use crate::MPTTrie;
 static ALLOW_READ: AtomicBool = AtomicBool::new(false);
 static TRIE_DB: OnceCell<Arc<RocksTrieDB>> = OnceCell::new();
 
+const DEFAULE_CACHE_SIZE: usize = 20;
+
 lazy_static::lazy_static! {
     static ref CELL_ROOT_KEY: H256 = Hasher::digest("cell_mpt_root");
     static ref CURRENT_CELL_ROOT: ArcSwap<H256> = ArcSwap::from_pointee(H256::default());
 }
 
-pub fn init<P: AsRef<Path>, B: Backend>(
-    path: P,
-    config: ConfigRocksDB,
-    cache_size: usize,
-    backend: Arc<B>,
-) {
+pub fn init<P: AsRef<Path>, B: Backend>(path: P, config: ConfigRocksDB, backend: Arc<B>) {
     let current_cell_root = backend.storage(ImageCellContract::ADDRESS, *CELL_ROOT_KEY);
 
     CURRENT_CELL_ROOT.store(Arc::new(current_cell_root));
 
     TRIE_DB.get_or_init(|| {
         Arc::new(
-            RocksTrieDB::new(path, config, cache_size).expect("[image cell] new rocksdb error"),
+            RocksTrieDB::new(path, config, DEFAULE_CACHE_SIZE)
+                .expect("[image cell] new rocksdb error"),
         )
     });
 }

--- a/core/executor/src/tests/system_script/image_cell.rs
+++ b/core/executor/src/tests/system_script/image_cell.rs
@@ -27,7 +27,6 @@ fn test_write_functions() {
     init(
         ROCKSDB_PATH,
         ConfigRocksDB::default(),
-        100,
         Arc::new(backend.clone()),
     );
 

--- a/core/interoperation/src/tests/mod.rs
+++ b/core/interoperation/src/tests/mod.rs
@@ -60,7 +60,6 @@ impl TestHandle {
         core_executor::system_contract::image_cell::init(
             path + &salt.to_string() + "/sc",
             Default::default(),
-            50,
             Arc::new(backend),
         );
 

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -319,12 +319,7 @@ impl Axon {
             Arc::clone(&storage),
             Proposal::from(current_block.header.clone()).into(),
         )?;
-        image_cell::init(
-            path_state,
-            config.rocksdb.clone(),
-            config.executor.triedb_cache_size,
-            Arc::new(backend),
-        );
+        image_cell::init(path_state, config.rocksdb.clone(), Arc::new(backend));
 
         let metadata_adapter = MetadataAdapterImpl::new(Arc::clone(&storage), Arc::clone(&trie_db));
         let metadata_controller = Arc::new(MetadataController::new(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
