### PR TITLE
refactor: change some rlp impl into proc macro

### DIFF
--- a/protocol/src/codec/block.rs
+++ b/protocol/src/codec/block.rs
@@ -3,9 +3,7 @@ use std::error::Error;
 use overlord::Codec;
 use rlp::{Decodable, DecoderError, Encodable, Prototype, Rlp, RlpStream};
 
-use crate::types::{
-    Block, Bytes, Header, Proof, Proposal, Validator, BASE_FEE_PER_GAS, MAX_BLOCK_GAS_LIMIT,
-};
+use crate::types::{Bytes, Proposal, BASE_FEE_PER_GAS, MAX_BLOCK_GAS_LIMIT};
 use crate::{codec::error::CodecError, lazy::CHAIN_ID, ProtocolError};
 
 impl Encodable for Proposal {
@@ -61,133 +59,10 @@ impl Codec for Proposal {
     }
 }
 
-impl Encodable for Header {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(20)
-            .append(&self.prev_hash)
-            .append(&self.proposer)
-            .append(&self.state_root)
-            .append(&self.transactions_root)
-            .append(&self.signed_txs_hash)
-            .append(&self.receipts_root)
-            .append(&self.log_bloom)
-            .append(&self.difficulty)
-            .append(&self.timestamp)
-            .append(&self.number)
-            .append(&self.gas_used)
-            .append(&self.gas_limit)
-            .append(&self.extra_data)
-            .append(&self.mixed_hash)
-            .append(&self.nonce)
-            .append(&self.base_fee_per_gas)
-            .append(&self.proof)
-            .append(&self.last_checkpoint_block_hash)
-            .append(&self.call_system_script_count)
-            .append(&self.chain_id);
-    }
-}
-
-impl Decodable for Header {
-    fn decode(r: &Rlp) -> Result<Self, DecoderError> {
-        match r.prototype()? {
-            Prototype::List(20) => Ok(Header {
-                prev_hash:                  r.val_at(0)?,
-                proposer:                   r.val_at(1)?,
-                state_root:                 r.val_at(2)?,
-                transactions_root:          r.val_at(3)?,
-                signed_txs_hash:            r.val_at(4)?,
-                receipts_root:              r.val_at(5)?,
-                log_bloom:                  r.val_at(6)?,
-                difficulty:                 r.val_at(7)?,
-                timestamp:                  r.val_at(8)?,
-                number:                     r.val_at(9)?,
-                gas_used:                   r.val_at(10)?,
-                gas_limit:                  r.val_at(11)?,
-                extra_data:                 r.val_at(12)?,
-                mixed_hash:                 r.val_at(13)?,
-                nonce:                      r.val_at(14)?,
-                base_fee_per_gas:           r.val_at(15)?,
-                proof:                      r.val_at(16)?,
-                last_checkpoint_block_hash: r.val_at(17)?,
-                call_system_script_count:   r.val_at(18)?,
-                chain_id:                   r.val_at(19)?,
-            }),
-            _ => Err(DecoderError::RlpExpectedToBeList),
-        }
-    }
-}
-
-impl Encodable for Block {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(2)
-            .append(&self.header)
-            .append_list(&self.tx_hashes);
-    }
-}
-
-impl Decodable for Block {
-    fn decode(r: &Rlp) -> Result<Self, DecoderError> {
-        match r.prototype()? {
-            Prototype::List(2) => Ok(Block {
-                header:    r.val_at(0)?,
-                tx_hashes: r.list_at(1)?,
-            }),
-            _ => Err(DecoderError::RlpExpectedToBeList),
-        }
-    }
-}
-
-impl Encodable for Proof {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(5)
-            .append(&self.number)
-            .append(&self.round)
-            .append(&self.block_hash)
-            .append(&self.signature)
-            .append(&self.bitmap);
-    }
-}
-
-impl Decodable for Proof {
-    fn decode(r: &Rlp) -> Result<Self, DecoderError> {
-        match r.prototype()? {
-            Prototype::List(5) => Ok(Proof {
-                number:     r.val_at(0)?,
-                round:      r.val_at(1)?,
-                block_hash: r.val_at(2)?,
-                signature:  r.val_at(3)?,
-                bitmap:     r.val_at(4)?,
-            }),
-            _ => Err(DecoderError::RlpExpectedToBeList),
-        }
-    }
-}
-
-impl Encodable for Validator {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(3)
-            .append(&self.pub_key)
-            .append(&self.propose_weight)
-            .append(&self.vote_weight);
-    }
-}
-
-impl Decodable for Validator {
-    fn decode(r: &Rlp) -> Result<Self, DecoderError> {
-        match r.prototype()? {
-            Prototype::List(3) => Ok(Validator {
-                pub_key:        r.val_at(0)?,
-                propose_weight: r.val_at(1)?,
-                vote_weight:    r.val_at(2)?,
-            }),
-            _ => Err(DecoderError::RlpExpectedToBeList),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::traits::MessageCodec;
+    use crate::types::{Block, Header, Proof};
 
     use super::*;
 

--- a/protocol/src/codec/executor.rs
+++ b/protocol/src/codec/executor.rs
@@ -1,6 +1,6 @@
 use rlp::{Decodable, DecoderError, Encodable, Prototype, Rlp, RlpStream};
 
-use crate::types::{TxResp, H160, H256, U256};
+use crate::types::TxResp;
 
 impl Encodable for TxResp {
     fn rlp_append(&self, s: &mut RlpStream) {

--- a/protocol/src/codec/executor.rs
+++ b/protocol/src/codec/executor.rs
@@ -1,6 +1,6 @@
 use rlp::{Decodable, DecoderError, Encodable, Prototype, Rlp, RlpStream};
 
-use crate::types::{ExecutorContext, Log, TxResp, H160, H256, U256};
+use crate::types::{TxResp, H160, H256, U256};
 
 impl Encodable for TxResp {
     fn rlp_append(&self, s: &mut RlpStream) {
@@ -38,61 +38,10 @@ impl Decodable for TxResp {
     }
 }
 
-impl Encodable for ExecutorContext {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(11)
-            .append(&self.block_number)
-            .append(&self.block_hash)
-            .append(&self.block_coinbase)
-            .append(&self.block_timestamp)
-            .append(&self.chain_id)
-            .append(&self.difficulty)
-            .append(&self.origin)
-            .append(&self.gas_price)
-            .append(&self.block_gas_limit)
-            .append(&self.block_base_fee_per_gas)
-            .append_list(&self.logs);
-    }
-}
-
-impl Decodable for ExecutorContext {
-    fn decode(r: &Rlp) -> Result<Self, DecoderError> {
-        match r.prototype()? {
-            Prototype::List(11) => {
-                let block_number: U256 = r.val_at(0)?;
-                let block_hash: H256 = r.val_at(1)?;
-                let block_coinbase: H160 = r.val_at(2)?;
-                let block_timestamp: U256 = r.val_at(3)?;
-                let chain_id: U256 = r.val_at(4)?;
-                let difficulty: U256 = r.val_at(5)?;
-                let origin: H160 = r.val_at(6)?;
-                let gas_price: U256 = r.val_at(7)?;
-                let block_gas_limit: U256 = r.val_at(8)?;
-                let block_base_fee_per_gas: U256 = r.val_at(9)?;
-                let logs: Vec<Log> = r.list_at(10)?;
-
-                Ok(ExecutorContext {
-                    block_number,
-                    block_hash,
-                    block_coinbase,
-                    block_timestamp,
-                    chain_id,
-                    difficulty,
-                    origin,
-                    gas_price,
-                    block_gas_limit,
-                    block_base_fee_per_gas,
-                    logs,
-                })
-            }
-            _ => Err(DecoderError::RlpExpectedToBeList),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::ExecutorContext;
 
     #[test]
     fn test_exec_ctx_codec() {

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -1,3 +1,4 @@
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use serde::{Deserialize, Serialize};
 
 use crate::codec::ProtocolCodec;
@@ -85,7 +86,9 @@ pub struct PackedTxHashes {
     pub call_system_script_count: u32,
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[derive(
+    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
+)]
 pub struct Block {
     pub header:    Header,
     pub tx_hashes: Vec<Hash>,
@@ -134,7 +137,9 @@ impl Block {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[derive(
+    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
+)]
 pub struct Header {
     pub prev_hash:                  Hash,
     pub proposer:                   H160,
@@ -164,7 +169,9 @@ impl Header {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[derive(
+    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
+)]
 pub struct Proof {
     pub number:     u64,
     pub round:      u64,

--- a/protocol/src/types/executor.rs
+++ b/protocol/src/types/executor.rs
@@ -1,7 +1,7 @@
 pub use ethereum::{AccessList, AccessListItem, Account};
 pub use evm::{backend::Log, Config, ExitError, ExitFatal, ExitReason, ExitRevert, ExitSucceed};
 
-use rlp_derive::{RlpEncodable, RlpDecodable};
+use rlp_derive::{RlpDecodable, RlpEncodable};
 
 use crate::codec::ProtocolCodec;
 use crate::types::{Hash, Hasher, Header, MerkleRoot, Proposal, H160, U256};

--- a/protocol/src/types/executor.rs
+++ b/protocol/src/types/executor.rs
@@ -1,6 +1,8 @@
 pub use ethereum::{AccessList, AccessListItem, Account};
 pub use evm::{backend::Log, Config, ExitError, ExitFatal, ExitReason, ExitRevert, ExitSucceed};
 
+use rlp_derive::{RlpEncodable, RlpDecodable};
+
 use crate::codec::ProtocolCodec;
 use crate::types::{Hash, Hasher, Header, MerkleRoot, Proposal, H160, U256};
 
@@ -39,7 +41,7 @@ impl Default for TxResp {
     }
 }
 
-#[derive(Default, Clone, Debug, PartialEq, Eq)]
+#[derive(RlpEncodable, RlpDecodable, Default, Clone, Debug, PartialEq, Eq)]
 pub struct ExecutorContext {
     pub block_number:           U256,
     pub block_hash:             Hash,

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -294,7 +294,9 @@ impl fmt::Display for Address {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(
+    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, Copy, PartialEq, Eq,
+)]
 pub struct MetadataVersion {
     pub start: BlockNumber,
     pub end:   BlockNumber,
@@ -310,7 +312,9 @@ impl MetadataVersion {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[derive(
+    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
+)]
 pub struct Metadata {
     pub version:                    MetadataVersion,
     pub epoch:                      u64,
@@ -346,7 +350,7 @@ pub struct Validator {
     pub vote_weight:    u32,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+#[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
 pub struct ValidatorExtend {
     pub bls_pub_key:    Hex,
     pub pub_key:        Hex,

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -5,10 +5,12 @@ pub use ethereum_types::{
     BigEndianHash, Bloom, Public, Secret, Signature, H128, H160, H256, H512, H520, H64, U128, U256,
     U512, U64,
 };
+
 use hasher::{Hasher as KeccakHasher, HasherKeccak};
 use ophelia::{PublicKey, UncompressedPublicKey};
 use ophelia_secp256k1::Secp256k1PublicKey;
 use overlord::DurationConfig;
+use rlp_derive::{RlpDecodable, RlpEncodable};
 use serde::{de, Deserialize, Serialize};
 
 use crate::codec::{hex_decode, hex_encode};
@@ -337,7 +339,7 @@ impl From<Metadata> for DurationConfig {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(RlpEncodable, RlpDecodable, Clone, Debug, PartialEq, Eq)]
 pub struct Validator {
     pub pub_key:        Bytes,
     pub propose_weight: u32,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR changes the rlp `Encodable` and `Decodable` implement of some types in protocol to proc-macro.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
