### PR TITLE
feat(interoperation): add dummy input mode of cell verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "bincode",
  "bytes",
  "cita_trie",
+ "ckb-always-success-script",
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-sdk",
@@ -819,6 +820,12 @@ dependencies = [
  "parking_lot 0.12.1",
  "rlp",
 ]
+
+[[package]]
+name = "ckb-always-success-script"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3b72a38c9920a29990df12002c4d069a147c8782f0c211f8a01b2df8f42bfd"
 
 [[package]]
 name = "ckb-chain-spec"
@@ -1614,6 +1621,7 @@ dependencies = [
  "axon-protocol",
  "az",
  "bytemuck",
+ "ckb-always-success-script",
  "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-rocksdb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,6 +1683,7 @@ dependencies = [
  "cardano-message-signing",
  "cardano-serialization-lib",
  "ckb-error",
+ "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-script",
  "ckb-traits",
@@ -1705,6 +1706,8 @@ name = "core-mempool"
 version = "0.1.0"
 dependencies = [
  "axon-protocol",
+ "ckb-hash",
+ "ckb-types",
  "common-apm",
  "common-apm-derive",
  "common-config-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,6 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "axon-protocol",
- "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-sdk",
  "ckb-types",
@@ -1622,7 +1621,6 @@ dependencies = [
  "az",
  "bytemuck",
  "ckb-always-success-script",
- "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-rocksdb",
  "ckb-traits",
@@ -1691,7 +1689,6 @@ dependencies = [
  "cardano-message-signing",
  "cardano-serialization-lib",
  "ckb-error",
- "ckb-hash",
  "ckb-jsonrpc-types",
  "ckb-script",
  "ckb-traits",
@@ -1714,7 +1711,6 @@ name = "core-mempool"
 version = "0.1.0"
 dependencies = [
  "axon-protocol",
- "ckb-hash",
  "ckb-types",
  "common-apm",
  "common-apm-derive",

--- a/core/cross-client/Cargo.toml
+++ b/core/cross-client/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 arc-swap = "1.6"
-ckb-hash = "0.106"
 ckb-jsonrpc-types = "0.106"
 ckb-sdk = "2.4"
 ckb-types = "0.106"

--- a/core/executor/Cargo.toml
+++ b/core/executor/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 arc-swap = "1.6"
 az = "1.2"
 bn = { package = "substrate-bn", version = "0.6" }
+ckb-always-success-script = "0.0.1"
 ckb-hash = "0.106"
 ckb-traits = "0.106"
 ckb-types = "0.106"

--- a/core/executor/Cargo.toml
+++ b/core/executor/Cargo.toml
@@ -9,7 +9,6 @@ arc-swap = "1.6"
 az = "1.2"
 bn = { package = "substrate-bn", version = "0.6" }
 ckb-always-success-script = "0.0.1"
-ckb-hash = "0.106"
 ckb-traits = "0.106"
 ckb-types = "0.106"
 common-apm = { path = "../../common/apm" }

--- a/core/executor/src/precompiles/verify_by_ckb_vm.rs
+++ b/core/executor/src/precompiles/verify_by_ckb_vm.rs
@@ -40,7 +40,7 @@ impl PrecompileContract for CkbVM {
                 Default::default(),
                 &DataProvider::default(),
                 &InteroperationImpl::dummy_transaction(
-                    SignatureR::new_reality(cell_deps, header_deps, inputs, Default::default()),
+                    SignatureR::new_by_ref(cell_deps, header_deps, inputs, Default::default()),
                     SignatureS::new(witnesses),
                 ),
                 None,

--- a/core/executor/src/precompiles/verify_by_ckb_vm.rs
+++ b/core/executor/src/precompiles/verify_by_ckb_vm.rs
@@ -3,7 +3,7 @@ use evm::{Context, ExitError, ExitSucceed};
 use rlp::Rlp;
 
 use protocol::traits::Interoperation;
-use protocol::types::{CellDep, OutPoint, Witness, H160, H256};
+use protocol::types::{CellDep, OutPoint, SignatureR, SignatureS, Witness, H160, H256};
 
 use core_interoperation::{cycle_to_gas, gas_to_cycle, InteroperationImpl};
 
@@ -39,7 +39,11 @@ impl PrecompileContract for CkbVM {
             let res = InteroperationImpl::verify_by_ckb_vm(
                 Default::default(),
                 &DataProvider::default(),
-                &InteroperationImpl::dummy_transaction(cell_deps, header_deps, inputs, witnesses),
+                &InteroperationImpl::dummy_transaction(
+                    SignatureR::new_reality(cell_deps, header_deps, inputs, Default::default()),
+                    SignatureS::new(witnesses),
+                ),
+                None,
                 gas_to_cycle(gas),
             )
             .map_err(|e| err!(_, e.to_string()))?;

--- a/core/executor/src/system_contract/image_cell/data_provider.rs
+++ b/core/executor/src/system_contract/image_cell/data_provider.rs
@@ -2,6 +2,7 @@ use ckb_traits::{CellDataProvider, HeaderProvider};
 use ckb_types::core::cell::{CellProvider, CellStatus};
 use ckb_types::{core::HeaderView, packed, prelude::*};
 
+use protocol::ckb_blake2b_256;
 use protocol::types::{Bytes, H256};
 
 use crate::system_contract::image_cell::ImageCellContract;
@@ -37,7 +38,7 @@ impl CellDataProvider for DataProvider {
             if data.is_empty() {
                 packed::Byte32::zero()
             } else {
-                ckb_hash::blake2b_256(data).pack()
+                ckb_blake2b_256(data).pack()
             }
         })
     }

--- a/core/executor/src/system_contract/image_cell/exec.rs
+++ b/core/executor/src/system_contract/image_cell/exec.rs
@@ -35,7 +35,7 @@ pub fn rollback(
     commit(mpt)
 }
 
-pub fn save_cells(
+pub(crate) fn save_cells(
     mpt: &mut MPTTrie<RocksTrieDB>,
     outputs: Vec<image_cell_abi::CellInfo>,
     created_number: u64,

--- a/core/executor/src/system_contract/image_cell/exec.rs
+++ b/core/executor/src/system_contract/image_cell/exec.rs
@@ -35,7 +35,7 @@ pub fn rollback(
     commit(mpt)
 }
 
-fn save_cells(
+pub fn save_cells(
     mpt: &mut MPTTrie<RocksTrieDB>,
     outputs: Vec<image_cell_abi::CellInfo>,
     created_number: u64,

--- a/core/executor/src/system_contract/image_cell/store.rs
+++ b/core/executor/src/system_contract/image_cell/store.rs
@@ -1,6 +1,7 @@
 use ckb_types::{bytes::Bytes, core::cell::CellMeta, packed, prelude::*};
 use rlp::{RlpDecodable, RlpEncodable};
 
+use protocol::ckb_blake2b_256;
 use protocol::types::{MerkleRoot, H256};
 
 use crate::system_contract::error::{SystemScriptError, SystemScriptResult};
@@ -141,7 +142,7 @@ pub fn get_cell(mpt: &MPTTrie<RocksTrieDB>, key: &CellKey) -> SystemScriptResult
 
 fn cell_data_hash(data: &Bytes) -> packed::Byte32 {
     if !data.is_empty() {
-        return ckb_hash::blake2b_256(data).pack();
+        return ckb_blake2b_256(data).pack();
     }
 
     packed::Byte32::zero()

--- a/core/executor/src/tests/system_script/image_cell.rs
+++ b/core/executor/src/tests/system_script/image_cell.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use ckb_types::{bytes::Bytes, packed, prelude::*};
 use ethers::abi::AbiEncode;
 
@@ -24,11 +22,7 @@ fn test_write_functions() {
     let mut backend = MemoryBackend::new(&vicinity, BTreeMap::new());
 
     let executor = ImageCellContract::default();
-    init(
-        ROCKSDB_PATH,
-        ConfigRocksDB::default(),
-        Arc::new(backend.clone()),
-    );
+    init(ROCKSDB_PATH, ConfigRocksDB::default(), backend.clone());
 
     test_update_first(&mut backend, &executor);
     test_update_second(&mut backend, &executor);

--- a/core/interoperation/Cargo.toml
+++ b/core/interoperation/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 arc-swap = "1.5"
 ckb-error = "0.106"
-ckb-hash = "0.106"
 ckb-script = "0.106"
 ckb-traits = "0.106"
 ckb-types = "0.106"

--- a/core/interoperation/Cargo.toml
+++ b/core/interoperation/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 arc-swap = "1.5"
 ckb-error = "0.106"
+ckb-hash = "0.106"
 ckb-script = "0.106"
 ckb-traits = "0.106"
 ckb-types = "0.106"

--- a/core/interoperation/src/lib.rs
+++ b/core/interoperation/src/lib.rs
@@ -14,7 +14,7 @@ use ckb_vm::machine::{asm::AsmCoreMachine, DefaultMachineBuilder, SupportMachine
 use ckb_vm::{Error as VMError, ISA_B, ISA_IMC, ISA_MOP};
 
 use protocol::traits::{Context, Interoperation};
-use protocol::types::{Bytes, CellDep, InputLock, OutPoint, VMResp};
+use protocol::types::{Bytes, CellDep, CellWithData, OutPoint, VMResp};
 use protocol::{Display, ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 use crate::utils::resolve_transaction;
@@ -79,7 +79,7 @@ impl Interoperation for InteroperationImpl {
         _ctx: Context,
         data_loader: &DL,
         mocked_tx: &TransactionView,
-        dummy_input: Option<InputLock>,
+        dummy_input: Option<CellWithData>,
         max_cycles: u64,
     ) -> ProtocolResult<Cycle> {
         TransactionScriptsVerifier::new(

--- a/core/interoperation/src/tests/mod.rs
+++ b/core/interoperation/src/tests/mod.rs
@@ -60,7 +60,7 @@ impl TestHandle {
         core_executor::system_contract::image_cell::init(
             path + &salt.to_string() + "/sc",
             Default::default(),
-            Arc::new(backend),
+            backend,
         );
 
         handle

--- a/core/interoperation/src/tests/verify_in_mempool.rs
+++ b/core/interoperation/src/tests/verify_in_mempool.rs
@@ -14,6 +14,7 @@ const JOYID_MAIN_KEY_TEST_TX_HASH: ckb_types::H256 =
 const JOYID_SUB_KEY_TEST_TX_HASH: ckb_types::H256 =
     h256!("0xb18f9d2a719a77a85d73535acaf871950b99cd481ad2ceaafae009dbb6d46f69");
 
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_verify_joyid_with_main_key() {
     let mut handle = TestHandle::new(0).await;
@@ -70,6 +71,7 @@ async fn test_verify_joyid_with_main_key() {
     assert!(r.is_ok());
 }
 
+#[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_verify_joyid_with_sub_key() {
     let mut handle = TestHandle::new(1).await;

--- a/core/interoperation/src/tests/verify_in_mempool.rs
+++ b/core/interoperation/src/tests/verify_in_mempool.rs
@@ -32,7 +32,7 @@ async fn test_verify_joyid_with_main_key() {
     let witness = build_witness("0x830100001000000083010000830100006f01000001780326dedc58aef92d9a76f46e3517eb90e84e966360db25ed128500368c02cbc3a7d5af2f8805ead57f7effa9dba177911abde069838cdd03aaaaf5a8ba5da067ae11e8a7282b178d133b183f32450d413c2ed5231d6e47785aa659bf112cfb492042e7f9cc68e1a8097ea068f3a305424ee33c712aa067a2ac65ea7db542825913119670aa30099572b168ab0df94c4478648f2501f5f3c823023cff3529dc05000000477b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a224e6a517959544e6d5a44597a4d7a6c6d4d5755354e5451304f54466b5954637a4d7a6c6a4e57457a4e6d4d355a44526c597a4932596d497a4d3245334d6a45784e57566a4e4451784e3256695a4452684e324a6a5951222c226f726967696e223a2268747470733a5c2f5c2f6170702e6a6f7969642e646576222c22616e64726f69645061636b6167654e616d65223a22636f6d2e616e64726f69642e6368726f6d65227d");
 
     let mock_tx = InteroperationImpl::dummy_transaction(
-        SignatureR::new_reality(
+        SignatureR::new_by_ref(
             vec![CellDep {
                 tx_hash:  H256(
                     h256!("0xe778611f59d65bc0c558a0a14a7fe12c4a937712f9cae6ca7aa952802703bd5a").0,
@@ -89,7 +89,7 @@ async fn test_verify_joyid_with_sub_key() {
 
     let mock_tx =
         InteroperationImpl::dummy_transaction(
-            SignatureR::new_reality(
+            SignatureR::new_by_ref(
                 vec![
             CellDep {
                 tx_hash:  H256(

--- a/core/interoperation/src/utils.rs
+++ b/core/interoperation/src/utils.rs
@@ -1,14 +1,16 @@
 use ckb_types::core::cell::{CellMeta, CellProvider, CellStatus, ResolvedTransaction};
 use ckb_types::core::{DepType, TransactionView};
-use ckb_types::{packed, prelude::Entity};
+use ckb_types::{packed, prelude::*};
 
-use protocol::ProtocolResult;
+use protocol::types::InputLock;
+use protocol::{lazy::DUMMY_INPUT_OUT_POINT, ProtocolResult};
 
 use crate::InteroperationError;
 
 pub fn resolve_transaction<CL: CellProvider>(
     cell_loader: &CL,
     tx: &TransactionView,
+    dummy_input: Option<InputLock>,
 ) -> ProtocolResult<ResolvedTransaction> {
     let resolve_cell = |out_point: &packed::OutPoint| -> ProtocolResult<CellMeta> {
         match cell_loader.cell(out_point, true) {
@@ -23,8 +25,32 @@ pub fn resolve_transaction<CL: CellProvider>(
         Vec::with_capacity(tx.cell_deps().len()),
     );
 
-    for out_point in tx.input_pts_iter() {
-        resolved_inputs.push(resolve_cell(&out_point)?);
+    for outpoint in tx.input_pts_iter() {
+        if is_dummy_out_point(&outpoint) {
+            if let Some(ref lock) = dummy_input {
+                let input_lock = packed::ScriptBuilder::default()
+                    .code_hash(lock.lock_code_hash.0.pack())
+                    .args(lock.lock_args.pack())
+                    .hash_type(lock.hash_type.into())
+                    .build();
+
+                resolved_inputs.push(CellMeta {
+                    cell_output:        packed::CellOutputBuilder::default()
+                        .lock(input_lock)
+                        .capacity(lock.capacity().pack())
+                        .build(),
+                    out_point:          outpoint,
+                    transaction_info:   None,
+                    data_bytes:         lock.data.len() as u64,
+                    mem_cell_data_hash: Some(ckb_hash::blake2b_256(&lock.data).pack()),
+                    mem_cell_data:      Some(lock.data.clone()),
+                });
+            } else {
+                return Err(InteroperationError::InvalidDummyInput.into());
+            }
+        } else {
+            resolved_inputs.push(resolve_cell(&outpoint)?);
+        }
     }
 
     for cell_dep in tx.cell_deps_iter() {
@@ -66,4 +92,8 @@ pub fn parse_dep_group_data(slice: &[u8]) -> Result<packed::OutPointVec, String>
             Err(err) => Err(err.to_string()),
         }
     }
+}
+
+pub fn is_dummy_out_point(out_point: &packed::OutPoint) -> bool {
+    *out_point == *DUMMY_INPUT_OUT_POINT
 }

--- a/core/interoperation/src/utils.rs
+++ b/core/interoperation/src/utils.rs
@@ -2,8 +2,7 @@ use ckb_types::core::cell::{CellMeta, CellProvider, CellStatus, ResolvedTransact
 use ckb_types::core::{DepType, TransactionView};
 use ckb_types::{packed, prelude::*};
 
-use protocol::types::CellWithData;
-use protocol::{lazy::DUMMY_INPUT_OUT_POINT, ProtocolResult};
+use protocol::{ckb_blake2b_256, lazy::DUMMY_INPUT_OUT_POINT, types::CellWithData, ProtocolResult};
 
 use crate::InteroperationError;
 
@@ -36,7 +35,7 @@ pub fn resolve_transaction<CL: CellProvider>(
                     out_point:          outpoint,
                     transaction_info:   None,
                     data_bytes:         cell.data.len() as u64,
-                    mem_cell_data_hash: Some(ckb_hash::blake2b_256(&cell.data).pack()),
+                    mem_cell_data_hash: Some(ckb_blake2b_256(&cell.data).pack()),
                     mem_cell_data:      Some(cell.data.clone()),
                 });
             } else {

--- a/core/mempool/Cargo.toml
+++ b/core/mempool/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-hash = "0.106"
 ckb-types = "0.106"
 crossbeam-queue = "0.3"
 dashmap = { version = "5.4", features = ["rayon"] }

--- a/core/mempool/Cargo.toml
+++ b/core/mempool/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ckb-hash = "0.106"
+ckb-types = "0.106"
 crossbeam-queue = "0.3"
 dashmap = { version = "5.4", features = ["rayon"] }
 futures = { version = "0.3", features = [ "async-await" ] }

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -232,10 +232,10 @@ where
                     cell.type_script_hash().unwrap()
                 };
 
-                let right_sender: H160 = Hasher::digest(script_hash).into();
-                if right_sender != sender {
+                let expect_sender: H160 = Hasher::digest(script_hash).into();
+                if expect_sender != sender {
                     return Err(MemPoolError::InvalidSender {
-                        expect: right_sender,
+                        expect: expect_sender,
                         actual: sender,
                     }
                     .into());
@@ -257,10 +257,10 @@ where
                     return Err(MemPoolError::InvalidAddressSource(address_source).into());
                 };
 
-                let right_sender: H160 = Hasher::digest(script_hash).into();
-                if right_sender != sender {
+                let expect_sender: H160 = Hasher::digest(script_hash).into();
+                if expect_sender != sender {
                     return Err(MemPoolError::InvalidSender {
-                        expect: right_sender,
+                        expect: expect_sender,
                         actual: sender,
                     }
                     .into());

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -15,13 +15,6 @@ use futures::{
 use log::{debug, error};
 use parking_lot::Mutex;
 
-use common_apm_derive::trace_span;
-use common_crypto::{Crypto, Secp256k1Recoverable};
-use core_executor::{
-    is_call_system_script, system_contract::image_cell::DataProvider, AxonExecutor,
-    AxonExecutorAdapter,
-};
-use core_interoperation::{utils::is_dummy_out_point, InteroperationImpl};
 use protocol::traits::{
     Context, Executor, Gossip, Interoperation, MemPoolAdapter, MetadataControl, PeerTrust,
     Priority, Rpc, Storage, TrustFeedback,
@@ -31,9 +24,17 @@ use protocol::types::{
     Hasher, MerkleRoot, SignatureComponents, SignatureR, SignatureS, SignedTransaction, H160, U256,
 };
 use protocol::{
-    async_trait, codec::ProtocolCodec, lazy::CURRENT_STATE_ROOT, tokio, trie, Display,
-    ProtocolError, ProtocolErrorKind, ProtocolResult,
+    async_trait, ckb_blake2b_256, codec::ProtocolCodec, lazy::CURRENT_STATE_ROOT, tokio, trie,
+    Display, ProtocolError, ProtocolErrorKind, ProtocolResult,
 };
+
+use common_apm_derive::trace_span;
+use common_crypto::{Crypto, Secp256k1Recoverable};
+use core_executor::{
+    is_call_system_script, system_contract::image_cell::DataProvider, AxonExecutor,
+    AxonExecutorAdapter,
+};
+use core_interoperation::{utils::is_dummy_out_point, InteroperationImpl};
 
 use crate::adapter::message::{MsgPullTxs, END_GOSSIP_NEW_TXS, RPC_PULL_TXS};
 use crate::MemPoolError;
@@ -250,9 +251,9 @@ where
         match DataProvider.cell(&input.previous_output(), true) {
             CellStatus::Live(cell) => {
                 let script_hash = if address_source.type_ == 0 {
-                    ckb_hash::blake2b_256(cell.cell_output.lock().as_slice())
+                    ckb_blake2b_256(cell.cell_output.lock().as_slice())
                 } else if let Some(type_script) = cell.cell_output.type_().to_opt() {
-                    ckb_hash::blake2b_256(type_script.as_slice())
+                    ckb_blake2b_256(type_script.as_slice())
                 } else {
                     return Err(MemPoolError::InvalidAddressSource(address_source).into());
                 };

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -486,7 +486,7 @@ where
                 .map_err(|e| AdapterError::VerifySignature(e.to_string()))?;
             }
             _ => {
-                let r = SignatureR::from_raw(&signature.r)?;
+                let r = SignatureR::decode(&signature.r)?;
                 let s = SignatureS::decode(&signature.s)?;
 
                 if r.input_len() != s.witnesses.len() {

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -27,7 +27,9 @@ use common_apm::Instant;
 use core_executor::{is_call_system_script, is_transaction_call};
 use core_network::NetworkContext;
 use protocol::traits::{Context, MemPool, MemPoolAdapter};
-use protocol::types::{BlockNumber, Hash, PackedTxHashes, SignedTransaction, H160, H256, U256};
+use protocol::types::{
+    AddressMapping, BlockNumber, Hash, PackedTxHashes, SignedTransaction, H160, H256, U256,
+};
 use protocol::{async_trait, tokio, Display, ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 use crate::context::TxContext;
@@ -453,6 +455,12 @@ pub enum MemPoolError {
 
     #[display(fmt = "Encode transaction to JSON failed")]
     EncodeJson,
+
+    #[display(fmt = "Invalid address mapping {:?}", _0)]
+    InvalidAddressMapping(AddressMapping),
+
+    #[display(fmt = "Invalid sender, expect: {:?}, get: {:?}", expect, actual)]
+    InvalidSender { expect: H160, actual: H160 },
 }
 
 impl Error for MemPoolError {}

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -28,7 +28,7 @@ use core_executor::{is_call_system_script, is_transaction_call};
 use core_network::NetworkContext;
 use protocol::traits::{Context, MemPool, MemPoolAdapter};
 use protocol::types::{
-    AddressMapping, BlockNumber, Hash, PackedTxHashes, SignedTransaction, H160, H256, U256,
+    AddressSource, BlockNumber, Hash, PackedTxHashes, SignedTransaction, H160, H256, U256,
 };
 use protocol::{async_trait, tokio, Display, ProtocolError, ProtocolErrorKind, ProtocolResult};
 
@@ -457,7 +457,7 @@ pub enum MemPoolError {
     EncodeJson,
 
     #[display(fmt = "Invalid address mapping {:?}", _0)]
-    InvalidAddressMapping(AddressMapping),
+    InvalidAddressMapping(AddressSource),
 
     #[display(fmt = "Invalid sender, expect: {:?}, get: {:?}", expect, actual)]
     InvalidSender { expect: H160, actual: H160 },

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -456,8 +456,8 @@ pub enum MemPoolError {
     #[display(fmt = "Encode transaction to JSON failed")]
     EncodeJson,
 
-    #[display(fmt = "Invalid address mapping {:?}", _0)]
-    InvalidAddressMapping(AddressSource),
+    #[display(fmt = "Invalid address source {:?}", _0)]
+    InvalidAddressSource(AddressSource),
 
     #[display(fmt = "Invalid sender, expect: {:?}, get: {:?}", expect, actual)]
     InvalidSender { expect: H160, actual: H160 },

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -319,7 +319,7 @@ impl Axon {
             Arc::clone(&storage),
             Proposal::from(current_block.header.clone()).into(),
         )?;
-        image_cell::init(path_state, config.rocksdb.clone(), Arc::new(backend));
+        image_cell::init(path_state, config.rocksdb.clone(), backend);
 
         let metadata_adapter = MetadataAdapterImpl::new(Arc::clone(&storage), Arc::clone(&trie_db));
         let metadata_controller = Arc::new(MetadataController::new(

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -9,6 +9,7 @@ arc-swap = "1.6"
 async-trait = "0.1"
 bincode = "1.3"
 bytes = { version = "1.4", features = ["serde"] }
+ckb-always-success-script = "0.0.1"
 ckb-hash = "0.106"
 ckb-jsonrpc-types = "0.106"
 ckb-sdk = "2.4"

--- a/protocol/src/lazy.rs
+++ b/protocol/src/lazy.rs
@@ -2,13 +2,12 @@ use arc_swap::ArcSwap;
 use ckb_always_success_script::ALWAYS_SUCCESS;
 use ckb_types::{packed, prelude::*};
 
-use crate::types::{Hasher, MerkleRoot, Hex};
+use crate::types::{Hasher, Hex, MerkleRoot};
 
 lazy_static::lazy_static! {
     pub static ref CURRENT_STATE_ROOT: ArcSwap<MerkleRoot> = ArcSwap::from_pointee(Default::default());
     pub static ref CHAIN_ID: ArcSwap<u64> = ArcSwap::from_pointee(Default::default());
     pub static ref PROTOCOL_VERSION: ArcSwap<Hex> = ArcSwap::from_pointee(Default::default());
-    pub static ref CELL_VERIFIER_CODE_HASH: H256 = Hasher::digest("AxonCellVerifier");
     pub static ref ALWAYS_SUCCESS_CODE_HASH: [u8; 32] = ckb_hash::blake2b_256(ALWAYS_SUCCESS);
     pub static ref ALWAYS_SUCCESS_DEPLOY_TX_HASH: [u8; 32] = Hasher::digest("AlwaysSuccessDeployTx").0;
     pub static ref DUMMY_INPUT_OUT_POINT: packed::OutPoint

--- a/protocol/src/lazy.rs
+++ b/protocol/src/lazy.rs
@@ -1,6 +1,6 @@
 use arc_swap::ArcSwap;
 use ckb_always_success_script::ALWAYS_SUCCESS;
-use ckb_types::{packed, prelude::*};
+use ckb_types::{core::ScriptHashType, packed, prelude::*};
 
 use crate::types::{Hasher, Hex, MerkleRoot};
 
@@ -8,8 +8,12 @@ lazy_static::lazy_static! {
     pub static ref CURRENT_STATE_ROOT: ArcSwap<MerkleRoot> = ArcSwap::from_pointee(Default::default());
     pub static ref CHAIN_ID: ArcSwap<u64> = ArcSwap::from_pointee(Default::default());
     pub static ref PROTOCOL_VERSION: ArcSwap<Hex> = ArcSwap::from_pointee(Default::default());
-    pub static ref ALWAYS_SUCCESS_CODE_HASH: [u8; 32] = ckb_hash::blake2b_256(ALWAYS_SUCCESS);
     pub static ref ALWAYS_SUCCESS_DEPLOY_TX_HASH: [u8; 32] = Hasher::digest("AlwaysSuccessDeployTx").0;
+    pub static ref ALWAYS_SUCCESS_TYPE_SCRIPT: packed::Script
+        = packed::ScriptBuilder::default()
+            .code_hash(ckb_hash::blake2b_256(ALWAYS_SUCCESS).pack())
+            .hash_type(ScriptHashType::Data1.into())
+            .build();
     pub static ref DUMMY_INPUT_OUT_POINT: packed::OutPoint
         = packed::OutPointBuilder::default()
             .tx_hash(Hasher::digest("DummyInputOutpointTxHash").0.pack())

--- a/protocol/src/lazy.rs
+++ b/protocol/src/lazy.rs
@@ -1,4 +1,5 @@
 use arc_swap::ArcSwap;
+use ckb_always_success_script::ALWAYS_SUCCESS;
 use ckb_types::{packed, prelude::*};
 
 use crate::types::{Hasher, MerkleRoot, Hex};
@@ -8,4 +9,10 @@ lazy_static::lazy_static! {
     pub static ref CHAIN_ID: ArcSwap<u64> = ArcSwap::from_pointee(Default::default());
     pub static ref PROTOCOL_VERSION: ArcSwap<Hex> = ArcSwap::from_pointee(Default::default());
     pub static ref CELL_VERIFIER_CODE_HASH: H256 = Hasher::digest("AxonCellVerifier");
+    pub static ref ALWAYS_SUCCESS_CODE_HASH: [u8; 32] = ckb_hash::blake2b_256(ALWAYS_SUCCESS);
+    pub static ref ALWAYS_SUCCESS_DEPLOY_TX_HASH: [u8; 32] = Hasher::digest("AlwaysSuccessDeployTx").0;
+    pub static ref DUMMY_INPUT_OUT_POINT: packed::OutPoint
+        = packed::OutPointBuilder::default()
+            .tx_hash(Hasher::digest("DummyInputOutpointTxHash").0.pack())
+            .index(0u32.pack()).build();
 }

--- a/protocol/src/lazy.rs
+++ b/protocol/src/lazy.rs
@@ -1,9 +1,11 @@
 use arc_swap::ArcSwap;
+use ckb_types::{packed, prelude::*};
 
-use crate::types::{Hex, MerkleRoot};
+use crate::types::{Hasher, MerkleRoot, Hex};
 
 lazy_static::lazy_static! {
     pub static ref CURRENT_STATE_ROOT: ArcSwap<MerkleRoot> = ArcSwap::from_pointee(Default::default());
     pub static ref CHAIN_ID: ArcSwap<u64> = ArcSwap::from_pointee(Default::default());
     pub static ref PROTOCOL_VERSION: ArcSwap<Hex> = ArcSwap::from_pointee(Default::default());
+    pub static ref CELL_VERIFIER_CODE_HASH: H256 = Hasher::digest("AxonCellVerifier");
 }

--- a/protocol/src/lazy.rs
+++ b/protocol/src/lazy.rs
@@ -2,6 +2,7 @@ use arc_swap::ArcSwap;
 use ckb_always_success_script::ALWAYS_SUCCESS;
 use ckb_types::{core::ScriptHashType, packed, prelude::*};
 
+use crate::ckb_blake2b_256;
 use crate::types::{Hasher, Hex, MerkleRoot};
 
 lazy_static::lazy_static! {
@@ -11,7 +12,7 @@ lazy_static::lazy_static! {
     pub static ref ALWAYS_SUCCESS_DEPLOY_TX_HASH: [u8; 32] = Hasher::digest("AlwaysSuccessDeployTx").0;
     pub static ref ALWAYS_SUCCESS_TYPE_SCRIPT: packed::Script
         = packed::ScriptBuilder::default()
-            .code_hash(ckb_hash::blake2b_256(ALWAYS_SUCCESS).pack())
+            .code_hash(ckb_blake2b_256(ALWAYS_SUCCESS).pack())
             .hash_type(ScriptHashType::Data1.into())
             .build();
     pub static ref DUMMY_INPUT_OUT_POINT: packed::OutPoint

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -12,6 +12,7 @@ pub mod types;
 
 use std::error::Error;
 
+pub use ckb_hash::blake2b_256 as ckb_blake2b_256;
 pub use derive_more::{Constructor, Display, From};
 pub use {async_trait::async_trait, tokio, trie};
 

--- a/protocol/src/traits/interoperation.rs
+++ b/protocol/src/traits/interoperation.rs
@@ -2,7 +2,7 @@ use ckb_traits::{CellDataProvider, HeaderProvider};
 use ckb_types::core::{cell::CellProvider, Cycle, ScriptHashType, TransactionView};
 use ckb_types::{packed, prelude::*};
 
-use crate::lazy::{CELL_VERIFIER_CODE_HASH, DUMMY_INPUT_OUT_POINT};
+use crate::lazy::{ALWAYS_SUCCESS_CODE_HASH, DUMMY_INPUT_OUT_POINT};
 use crate::types::{Bytes, CellDep, CellWithData, SignatureR, SignatureS, VMResp};
 use crate::{traits::Context, ProtocolResult};
 
@@ -72,7 +72,7 @@ pub trait Interoperation: Sync + Send {
                         .type_(
                             Some(
                                 packed::ScriptBuilder::default()
-                                    .code_hash(CELL_VERIFIER_CODE_HASH.0.pack())
+                                    .code_hash(ALWAYS_SUCCESS_CODE_HASH.pack())
                                     .hash_type(ScriptHashType::Data1.into())
                                     .build(),
                             )
@@ -91,7 +91,7 @@ pub trait Interoperation: Sync + Send {
                     .type_(
                         Some(
                             packed::ScriptBuilder::default()
-                                .code_hash(CELL_VERIFIER_CODE_HASH.0.pack())
+                                .code_hash(ALWAYS_SUCCESS_CODE_HASH.pack())
                                 .hash_type(ScriptHashType::Data1.into())
                                 .build(),
                         )

--- a/protocol/src/traits/interoperation.rs
+++ b/protocol/src/traits/interoperation.rs
@@ -3,7 +3,7 @@ use ckb_types::core::{cell::CellProvider, Cycle, ScriptHashType, TransactionView
 use ckb_types::{packed, prelude::*};
 
 use crate::lazy::{CELL_VERIFIER_CODE_HASH, DUMMY_INPUT_OUT_POINT};
-use crate::types::{Bytes, CellDep, InputLock, SignatureR, SignatureS, VMResp};
+use crate::types::{Bytes, CellDep, CellWithData, SignatureR, SignatureS, VMResp};
 use crate::{traits::Context, ProtocolResult};
 
 const OUTPUT_CAPACITY_OF_REALITY_INPUT: u64 = 100;
@@ -21,7 +21,7 @@ pub trait Interoperation: Sync + Send {
         ctx: Context,
         data_loader: &DL,
         mocked_tx: &TransactionView,
-        dummy_input: Option<InputLock>,
+        dummy_input: Option<CellWithData>,
         max_cycles: u64,
     ) -> ProtocolResult<Cycle>;
 
@@ -56,9 +56,9 @@ pub trait Interoperation: Sync + Send {
                     .pack()
             }));
 
-        if r.is_reality() {
+        if r.is_only_by_ref() {
             return tx_builder
-                .inputs(r.reality_inputs().iter().map(|i| {
+                .inputs(r.out_points().iter().map(|i| {
                     packed::CellInput::new(
                         packed::OutPointBuilder::default()
                             .tx_hash(i.tx_hash.0.pack())

--- a/protocol/src/traits/interoperation.rs
+++ b/protocol/src/traits/interoperation.rs
@@ -1,8 +1,8 @@
 use ckb_traits::{CellDataProvider, HeaderProvider};
-use ckb_types::core::{cell::CellProvider, Cycle, ScriptHashType, TransactionView};
+use ckb_types::core::{cell::CellProvider, Cycle, TransactionView};
 use ckb_types::{packed, prelude::*};
 
-use crate::lazy::{ALWAYS_SUCCESS_CODE_HASH, DUMMY_INPUT_OUT_POINT};
+use crate::lazy::{ALWAYS_SUCCESS_TYPE_SCRIPT, DUMMY_INPUT_OUT_POINT};
 use crate::types::{Bytes, CellDep, CellWithData, SignatureR, SignatureS, VMResp};
 use crate::{traits::Context, ProtocolResult};
 
@@ -69,15 +69,7 @@ pub trait Interoperation: Sync + Send {
                 }))
                 .output(
                     packed::CellOutputBuilder::default()
-                        .type_(
-                            Some(
-                                packed::ScriptBuilder::default()
-                                    .code_hash(ALWAYS_SUCCESS_CODE_HASH.pack())
-                                    .hash_type(ScriptHashType::Data1.into())
-                                    .build(),
-                            )
-                            .pack(),
-                        )
+                        .type_(Some(ALWAYS_SUCCESS_TYPE_SCRIPT.clone()).pack())
                         .capacity(OUTPUT_CAPACITY_OF_REALITY_INPUT.pack())
                         .build(),
                 )
@@ -88,15 +80,7 @@ pub trait Interoperation: Sync + Send {
             .input(packed::CellInput::new(DUMMY_INPUT_OUT_POINT.clone(), 0u64))
             .output(
                 packed::CellOutputBuilder::default()
-                    .type_(
-                        Some(
-                            packed::ScriptBuilder::default()
-                                .code_hash(ALWAYS_SUCCESS_CODE_HASH.pack())
-                                .hash_type(ScriptHashType::Data1.into())
-                                .build(),
-                        )
-                        .pack(),
-                    )
+                    .type_(Some(ALWAYS_SUCCESS_TYPE_SCRIPT.clone()).pack())
                     .capacity((r.dummy_input().unwrap().capacity() - 1).pack())
                     .build(),
             )

--- a/protocol/src/types/interoperation.rs
+++ b/protocol/src/types/interoperation.rs
@@ -4,22 +4,158 @@ use ethereum_types::H256;
 use rlp_derive::{RlpDecodable, RlpEncodable};
 use serde::{Deserialize, Serialize};
 
+use crate::{codec::ProtocolCodec, types::TypesError, ProtocolResult};
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct VMResp {
     pub exit_code: i8,
     pub cycles:    u64,
 }
 
+/// The address mapping for calculate an Axon address by the input cell, which
+/// is `keccak(input[index].content).into()`. The `type_` field means the type
+/// of content to calculate hash with the following rules:
+/// 0u8 => use type script hash.
+/// 1u8 => use lock script hash.
+#[derive(
+    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, Eq,
+)]
+pub struct AddressMapping {
+    pub type_: u8,
+    pub index: u32,
+}
+
+#[derive(Clone, Debug)]
+pub enum SignatureR {
+    RealityInput(RealityInput),
+    DummyInput(DummyInput),
+}
+
+impl SignatureR {
+    pub fn new_reality(
+        cell_deps: Vec<CellDep>,
+        header_deps: Vec<H256>,
+        out_points: Vec<OutPoint>,
+        address_map: AddressMapping,
+    ) -> Self {
+        SignatureR::RealityInput(RealityInput {
+            cell_deps,
+            header_deps,
+            out_points,
+            address_map,
+        })
+    }
+
+    pub fn from_raw(data: &[u8]) -> ProtocolResult<Self> {
+        if data.is_empty() {
+            return Err(TypesError::SignatureRIsEmpty.into());
+        }
+
+        match data[0] {
+            1u8 => Ok(SignatureR::RealityInput(RealityInput::decode(&data[1..])?)),
+            2u8 => Ok(SignatureR::DummyInput(DummyInput::decode(&data[1..])?)),
+            _ => Err(TypesError::InvalidSignatureRType.into()),
+        }
+    }
+
+    pub fn input_len(&self) -> usize {
+        match self {
+            SignatureR::RealityInput(i) => i.out_points.len(),
+            SignatureR::DummyInput(_) => 0usize,
+        }
+    }
+
+    pub fn address_mapping(&self) -> AddressMapping {
+        match self {
+            SignatureR::RealityInput(i) => i.address_map,
+            SignatureR::DummyInput(i) => i.address_map,
+        }
+    }
+
+    pub fn cell_deps(&self) -> &[CellDep] {
+        match self {
+            SignatureR::RealityInput(i) => &i.cell_deps,
+            SignatureR::DummyInput(i) => &i.cell_deps,
+        }
+    }
+
+    pub fn header_deps(&self) -> &[H256] {
+        match self {
+            SignatureR::RealityInput(i) => &i.header_deps,
+            SignatureR::DummyInput(i) => &i.header_deps,
+        }
+    }
+
+    pub(crate) fn reality_inputs(&self) -> &[OutPoint] {
+        match self {
+            SignatureR::RealityInput(i) => &i.out_points,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn dummy_input(&self) -> Option<InputLock> {
+        match self {
+            SignatureR::DummyInput(i) => Some(i.input_lock.clone()),
+            SignatureR::RealityInput(_) => None,
+        }
+    }
+
+    pub fn is_reality(&self) -> bool {
+        match self {
+            SignatureR::RealityInput(_) => true,
+            SignatureR::DummyInput(_) => false,
+        }
+    }
+}
+
 #[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct SignatureR {
+pub struct RealityInput {
     pub cell_deps:   Vec<CellDep>,
     pub header_deps: Vec<H256>,
     pub out_points:  Vec<OutPoint>,
+    pub address_map: AddressMapping,
+}
+
+#[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct DummyInput {
+    pub cell_deps:   Vec<CellDep>,
+    pub header_deps: Vec<H256>,
+    pub input_lock:  InputLock,
+    pub address_map: AddressMapping,
+}
+
+#[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct InputLock {
+    pub lock_code_hash: H256,
+    pub lock_args:      Bytes,
+    pub hash_type:      u8,
+    pub data:           Bytes,
+}
+
+impl InputLock {
+    pub fn capacity(&self) -> u64 {
+        let capacity = 32 + self.lock_args.len() + 1 + self.data.len();
+        capacity as u64
+    }
+
+    pub fn as_script(&self) -> packed::Script {
+        packed::ScriptBuilder::default()
+            .code_hash(self.lock_code_hash.0.pack())
+            .args(self.lock_args.pack())
+            .hash_type(self.hash_type.into())
+            .build()
+    }
 }
 
 #[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct SignatureS {
     pub witnesses: Vec<Witness>,
+}
+
+impl SignatureS {
+    pub fn new(witnesses: Vec<Witness>) -> Self {
+        SignatureS { witnesses }
+    }
 }
 
 #[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -57,8 +193,8 @@ pub struct CellDep {
     pub dep_type: u8,
 }
 
-impl From<CellDep> for packed::CellDep {
-    fn from(dep: CellDep) -> packed::CellDep {
+impl From<&CellDep> for packed::CellDep {
+    fn from(dep: &CellDep) -> packed::CellDep {
         packed::CellDepBuilder::default()
             .out_point(
                 packed::OutPointBuilder::default()

--- a/protocol/src/types/interoperation.rs
+++ b/protocol/src/types/interoperation.rs
@@ -15,8 +15,10 @@ pub struct VMResp {
 /// The address mapping for calculate an Axon address by the input cell, which
 /// is `keccak(input[index].content).into()`. The `type_` field means the type
 /// of content to calculate hash with the following rules:
-/// 0u8 => use type script hash.
-/// 1u8 => use lock script hash.
+/// `0u8`: use lock script hash.
+/// `1u8`: use type script hash.
+/// So that the default value of `AddressMapping` means using
+/// `blake2b_256(input[0].lock().as_bytes())` as `keccak()` input.
 #[derive(
     RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, Eq,
 )]
@@ -46,7 +48,7 @@ impl SignatureR {
         })
     }
 
-    pub fn from_raw(data: &[u8]) -> ProtocolResult<Self> {
+    pub fn decode(data: &[u8]) -> ProtocolResult<Self> {
         if data.is_empty() {
             return Err(TypesError::SignatureRIsEmpty.into());
         }
@@ -68,7 +70,7 @@ impl SignatureR {
     pub fn address_mapping(&self) -> AddressMapping {
         match self {
             SignatureR::RealityInput(i) => i.address_map,
-            SignatureR::DummyInput(i) => i.address_map,
+            SignatureR::DummyInput(_) => AddressMapping::default(),
         }
     }
 
@@ -121,7 +123,7 @@ pub struct DummyInput {
     pub cell_deps:   Vec<CellDep>,
     pub header_deps: Vec<H256>,
     pub input_lock:  InputLock,
-    pub address_map: AddressMapping,
+    // pub address_map: AddressMapping,
 }
 
 #[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/protocol/src/types/interoperation.rs
+++ b/protocol/src/types/interoperation.rs
@@ -63,7 +63,7 @@ impl SignatureR {
     pub fn input_len(&self) -> usize {
         match self {
             SignatureR::RealityInput(i) => i.out_points.len(),
-            SignatureR::DummyInput(_) => 0usize,
+            SignatureR::DummyInput(_) => 1usize,
         }
     }
 

--- a/protocol/src/types/mod.rs
+++ b/protocol/src/types/mod.rs
@@ -76,6 +76,9 @@ pub enum TypesError {
 
     #[display(fmt = "Invalid signature R type")]
     InvalidSignatureRType,
+
+    #[display(fmt = "Invalid address source type")]
+    InvalidAddressSourceType,
 }
 
 impl Error for TypesError {}

--- a/protocol/src/types/mod.rs
+++ b/protocol/src/types/mod.rs
@@ -70,6 +70,12 @@ pub enum TypesError {
 
     #[display(fmt = "Invalid crosschain direction")]
     InvalidDirection,
+
+    #[display(fmt = "Signature R is empty")]
+    SignatureRIsEmpty,
+
+    #[display(fmt = "Invalid signature R type")]
+    InvalidSignatureRType,
 }
 
 impl Error for TypesError {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR adds dummy input mode of cell verify. The in detailed changes are shown below:
1. The ICSC inserts an `always success deployed cell` at the first time of initiation. The deployed transaction hash is `keccak("AlwaysSuccessDeployTx")` and the output index is `0`.
2. One dummy input is allowed when verify interoperation signature. The dummy cell input has a fixed out point
```yml
OutPoint:
    tx_hash: keccak("DummyInputOutpointTxHash")
    index: 0
```
3. The `always success cell output` capacity is changed as if the input is dummy, use `dummy_input_cell_len - 1` otherwise use `100`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
