### PR TITLE
refactor: allow image cell system contract to receive multiple blocks

### DIFF
--- a/core/executor/src/system_contract/image_cell/abi/image_cell_abi.json
+++ b/core/executor/src/system_contract/image_cell/abi/image_cell_abi.json
@@ -4,35 +4,42 @@
       {
         "components": [
           {
-            "internalType": "bytes32",
-            "name": "txHash",
-            "type": "bytes32"
+            "components": [
+              {
+                "internalType": "bytes32",
+                "name": "txHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint32",
+                "name": "index",
+                "type": "uint32"
+              }
+            ],
+            "internalType": "struct CkbType.OutPoint[]",
+            "name": "txInputs",
+            "type": "tuple[]"
           },
           {
-            "internalType": "uint32",
-            "name": "index",
-            "type": "uint32"
+            "components": [
+              {
+                "internalType": "bytes32",
+                "name": "txHash",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint32",
+                "name": "index",
+                "type": "uint32"
+              }
+            ],
+            "internalType": "struct CkbType.OutPoint[]",
+            "name": "txOutputs",
+            "type": "tuple[]"
           }
         ],
-        "internalType": "struct CkbType.OutPoint[]",
-        "name": "inputs",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
-          {
-            "internalType": "bytes32",
-            "name": "txHash",
-            "type": "bytes32"
-          },
-          {
-            "internalType": "uint32",
-            "name": "index",
-            "type": "uint32"
-          }
-        ],
-        "internalType": "struct CkbType.OutPoint[]",
-        "name": "outputs",
+        "internalType": "struct ImageCell.BlockRollBlack[]",
+        "name": "blocks",
         "type": "tuple[]"
       }
     ],
@@ -57,29 +64,12 @@
   {
     "inputs": [
       {
-        "internalType": "uint64",
-        "name": "blockNumber",
-        "type": "uint64"
-      },
-      {
         "components": [
           {
-            "internalType": "bytes32",
-            "name": "txHash",
-            "type": "bytes32"
+            "internalType": "uint64",
+            "name": "blockNumber",
+            "type": "uint64"
           },
-          {
-            "internalType": "uint32",
-            "name": "index",
-            "type": "uint32"
-          }
-        ],
-        "internalType": "struct CkbType.OutPoint[]",
-        "name": "inputs",
-        "type": "tuple[]"
-      },
-      {
-        "components": [
           {
             "components": [
               {
@@ -93,74 +83,98 @@
                 "type": "uint32"
               }
             ],
-            "internalType": "struct CkbType.OutPoint",
-            "name": "outPoint",
-            "type": "tuple"
+            "internalType": "struct CkbType.OutPoint[]",
+            "name": "txInputs",
+            "type": "tuple[]"
           },
           {
             "components": [
               {
-                "internalType": "uint64",
-                "name": "capacity",
-                "type": "uint64"
-              },
-              {
                 "components": [
                   {
                     "internalType": "bytes32",
-                    "name": "codeHash",
+                    "name": "txHash",
                     "type": "bytes32"
                   },
                   {
-                    "internalType": "enum CkbType.ScriptHashType",
-                    "name": "hashType",
-                    "type": "uint8"
-                  },
-                  {
-                    "internalType": "bytes",
-                    "name": "args",
-                    "type": "bytes"
+                    "internalType": "uint32",
+                    "name": "index",
+                    "type": "uint32"
                   }
                 ],
-                "internalType": "struct CkbType.Script",
-                "name": "lock",
+                "internalType": "struct CkbType.OutPoint",
+                "name": "outPoint",
                 "type": "tuple"
               },
               {
                 "components": [
                   {
-                    "internalType": "bytes32",
-                    "name": "codeHash",
-                    "type": "bytes32"
+                    "internalType": "uint64",
+                    "name": "capacity",
+                    "type": "uint64"
                   },
                   {
-                    "internalType": "enum CkbType.ScriptHashType",
-                    "name": "hashType",
-                    "type": "uint8"
+                    "components": [
+                      {
+                        "internalType": "bytes32",
+                        "name": "codeHash",
+                        "type": "bytes32"
+                      },
+                      {
+                        "internalType": "enum CkbType.ScriptHashType",
+                        "name": "hashType",
+                        "type": "uint8"
+                      },
+                      {
+                        "internalType": "bytes",
+                        "name": "args",
+                        "type": "bytes"
+                      }
+                    ],
+                    "internalType": "struct CkbType.Script",
+                    "name": "lock",
+                    "type": "tuple"
                   },
                   {
-                    "internalType": "bytes",
-                    "name": "args",
-                    "type": "bytes"
+                    "components": [
+                      {
+                        "internalType": "bytes32",
+                        "name": "codeHash",
+                        "type": "bytes32"
+                      },
+                      {
+                        "internalType": "enum CkbType.ScriptHashType",
+                        "name": "hashType",
+                        "type": "uint8"
+                      },
+                      {
+                        "internalType": "bytes",
+                        "name": "args",
+                        "type": "bytes"
+                      }
+                    ],
+                    "internalType": "struct CkbType.Script[]",
+                    "name": "type_",
+                    "type": "tuple[]"
                   }
                 ],
-                "internalType": "struct CkbType.Script[]",
-                "name": "type_",
-                "type": "tuple[]"
+                "internalType": "struct CkbType.CellOutput",
+                "name": "output",
+                "type": "tuple"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
               }
             ],
-            "internalType": "struct CkbType.CellOutput",
-            "name": "output",
-            "type": "tuple"
-          },
-          {
-            "internalType": "bytes",
-            "name": "data",
-            "type": "bytes"
+            "internalType": "struct CkbType.CellInfo[]",
+            "name": "txOutputs",
+            "type": "tuple[]"
           }
         ],
-        "internalType": "struct CkbType.CellInfo[]",
-        "name": "outputs",
+        "internalType": "struct ImageCell.BlockUpdate[]",
+        "name": "blocks",
         "type": "tuple[]"
       }
     ],

--- a/core/executor/src/system_contract/image_cell/abi/image_cell_abi.rs
+++ b/core/executor/src/system_contract/image_cell/abi/image_cell_abi.rs
@@ -11,7 +11,7 @@ pub use image_cell_contract::*;
 )]
 pub mod image_cell_contract {
     #[rustfmt::skip]
-    const __ABI: &str = "[\n  {\n    \"inputs\": [\n      {\n        \"components\": [\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"txHash\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"uint32\",\n            \"name\": \"index\",\n            \"type\": \"uint32\"\n          }\n        ],\n        \"internalType\": \"struct CkbType.OutPoint[]\",\n        \"name\": \"inputs\",\n        \"type\": \"tuple[]\"\n      },\n      {\n        \"components\": [\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"txHash\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"uint32\",\n            \"name\": \"index\",\n            \"type\": \"uint32\"\n          }\n        ],\n        \"internalType\": \"struct CkbType.OutPoint[]\",\n        \"name\": \"outputs\",\n        \"type\": \"tuple[]\"\n      }\n    ],\n    \"name\": \"rollback\",\n    \"outputs\": [],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bool\",\n        \"name\": \"allowRead\",\n        \"type\": \"bool\"\n      }\n    ],\n    \"name\": \"setState\",\n    \"outputs\": [],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint64\",\n        \"name\": \"blockNumber\",\n        \"type\": \"uint64\"\n      },\n      {\n        \"components\": [\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"txHash\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"uint32\",\n            \"name\": \"index\",\n            \"type\": \"uint32\"\n          }\n        ],\n        \"internalType\": \"struct CkbType.OutPoint[]\",\n        \"name\": \"inputs\",\n        \"type\": \"tuple[]\"\n      },\n      {\n        \"components\": [\n          {\n            \"components\": [\n              {\n                \"internalType\": \"bytes32\",\n                \"name\": \"txHash\",\n                \"type\": \"bytes32\"\n              },\n              {\n                \"internalType\": \"uint32\",\n                \"name\": \"index\",\n                \"type\": \"uint32\"\n              }\n            ],\n            \"internalType\": \"struct CkbType.OutPoint\",\n            \"name\": \"outPoint\",\n            \"type\": \"tuple\"\n          },\n          {\n            \"components\": [\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"capacity\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"components\": [\n                  {\n                    \"internalType\": \"bytes32\",\n                    \"name\": \"codeHash\",\n                    \"type\": \"bytes32\"\n                  },\n                  {\n                    \"internalType\": \"enum CkbType.ScriptHashType\",\n                    \"name\": \"hashType\",\n                    \"type\": \"uint8\"\n                  },\n                  {\n                    \"internalType\": \"bytes\",\n                    \"name\": \"args\",\n                    \"type\": \"bytes\"\n                  }\n                ],\n                \"internalType\": \"struct CkbType.Script\",\n                \"name\": \"lock\",\n                \"type\": \"tuple\"\n              },\n              {\n                \"components\": [\n                  {\n                    \"internalType\": \"bytes32\",\n                    \"name\": \"codeHash\",\n                    \"type\": \"bytes32\"\n                  },\n                  {\n                    \"internalType\": \"enum CkbType.ScriptHashType\",\n                    \"name\": \"hashType\",\n                    \"type\": \"uint8\"\n                  },\n                  {\n                    \"internalType\": \"bytes\",\n                    \"name\": \"args\",\n                    \"type\": \"bytes\"\n                  }\n                ],\n                \"internalType\": \"struct CkbType.Script[]\",\n                \"name\": \"type_\",\n                \"type\": \"tuple[]\"\n              }\n            ],\n            \"internalType\": \"struct CkbType.CellOutput\",\n            \"name\": \"output\",\n            \"type\": \"tuple\"\n          },\n          {\n            \"internalType\": \"bytes\",\n            \"name\": \"data\",\n            \"type\": \"bytes\"\n          }\n        ],\n        \"internalType\": \"struct CkbType.CellInfo[]\",\n        \"name\": \"outputs\",\n        \"type\": \"tuple[]\"\n      }\n    ],\n    \"name\": \"update\",\n    \"outputs\": [],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  }\n]\n";
+    const __ABI: &str = "[\n  {\n    \"inputs\": [\n      {\n        \"components\": [\n          {\n            \"components\": [\n              {\n                \"internalType\": \"bytes32\",\n                \"name\": \"txHash\",\n                \"type\": \"bytes32\"\n              },\n              {\n                \"internalType\": \"uint32\",\n                \"name\": \"index\",\n                \"type\": \"uint32\"\n              }\n            ],\n            \"internalType\": \"struct CkbType.OutPoint[]\",\n            \"name\": \"txInputs\",\n            \"type\": \"tuple[]\"\n          },\n          {\n            \"components\": [\n              {\n                \"internalType\": \"bytes32\",\n                \"name\": \"txHash\",\n                \"type\": \"bytes32\"\n              },\n              {\n                \"internalType\": \"uint32\",\n                \"name\": \"index\",\n                \"type\": \"uint32\"\n              }\n            ],\n            \"internalType\": \"struct CkbType.OutPoint[]\",\n            \"name\": \"txOutputs\",\n            \"type\": \"tuple[]\"\n          }\n        ],\n        \"internalType\": \"struct ImageCell.BlockRollBlack[]\",\n        \"name\": \"blocks\",\n        \"type\": \"tuple[]\"\n      }\n    ],\n    \"name\": \"rollback\",\n    \"outputs\": [],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bool\",\n        \"name\": \"allowRead\",\n        \"type\": \"bool\"\n      }\n    ],\n    \"name\": \"setState\",\n    \"outputs\": [],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"components\": [\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"blockNumber\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"components\": [\n              {\n                \"internalType\": \"bytes32\",\n                \"name\": \"txHash\",\n                \"type\": \"bytes32\"\n              },\n              {\n                \"internalType\": \"uint32\",\n                \"name\": \"index\",\n                \"type\": \"uint32\"\n              }\n            ],\n            \"internalType\": \"struct CkbType.OutPoint[]\",\n            \"name\": \"txInputs\",\n            \"type\": \"tuple[]\"\n          },\n          {\n            \"components\": [\n              {\n                \"components\": [\n                  {\n                    \"internalType\": \"bytes32\",\n                    \"name\": \"txHash\",\n                    \"type\": \"bytes32\"\n                  },\n                  {\n                    \"internalType\": \"uint32\",\n                    \"name\": \"index\",\n                    \"type\": \"uint32\"\n                  }\n                ],\n                \"internalType\": \"struct CkbType.OutPoint\",\n                \"name\": \"outPoint\",\n                \"type\": \"tuple\"\n              },\n              {\n                \"components\": [\n                  {\n                    \"internalType\": \"uint64\",\n                    \"name\": \"capacity\",\n                    \"type\": \"uint64\"\n                  },\n                  {\n                    \"components\": [\n                      {\n                        \"internalType\": \"bytes32\",\n                        \"name\": \"codeHash\",\n                        \"type\": \"bytes32\"\n                      },\n                      {\n                        \"internalType\": \"enum CkbType.ScriptHashType\",\n                        \"name\": \"hashType\",\n                        \"type\": \"uint8\"\n                      },\n                      {\n                        \"internalType\": \"bytes\",\n                        \"name\": \"args\",\n                        \"type\": \"bytes\"\n                      }\n                    ],\n                    \"internalType\": \"struct CkbType.Script\",\n                    \"name\": \"lock\",\n                    \"type\": \"tuple\"\n                  },\n                  {\n                    \"components\": [\n                      {\n                        \"internalType\": \"bytes32\",\n                        \"name\": \"codeHash\",\n                        \"type\": \"bytes32\"\n                      },\n                      {\n                        \"internalType\": \"enum CkbType.ScriptHashType\",\n                        \"name\": \"hashType\",\n                        \"type\": \"uint8\"\n                      },\n                      {\n                        \"internalType\": \"bytes\",\n                        \"name\": \"args\",\n                        \"type\": \"bytes\"\n                      }\n                    ],\n                    \"internalType\": \"struct CkbType.Script[]\",\n                    \"name\": \"type_\",\n                    \"type\": \"tuple[]\"\n                  }\n                ],\n                \"internalType\": \"struct CkbType.CellOutput\",\n                \"name\": \"output\",\n                \"type\": \"tuple\"\n              },\n              {\n                \"internalType\": \"bytes\",\n                \"name\": \"data\",\n                \"type\": \"bytes\"\n              }\n            ],\n            \"internalType\": \"struct CkbType.CellInfo[]\",\n            \"name\": \"txOutputs\",\n            \"type\": \"tuple[]\"\n          }\n        ],\n        \"internalType\": \"struct ImageCell.BlockUpdate[]\",\n        \"name\": \"blocks\",\n        \"type\": \"tuple[]\"\n      }\n    ],\n    \"name\": \"update\",\n    \"outputs\": [],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  }\n]\n";
     /// The parsed JSON ABI of the contract.
     pub static IMAGECELLCONTRACT_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> =
         ::ethers::contract::Lazy::new(|| {
@@ -57,14 +57,13 @@ pub mod image_cell_contract {
             ))
         }
 
-        /// Calls the contract's `rollback` (0xec5d646a) function
+        /// Calls the contract's `rollback` (0x08c17228) function
         pub fn rollback(
             &self,
-            inputs: ::std::vec::Vec<OutPoint>,
-            outputs: ::std::vec::Vec<OutPoint>,
+            blocks: ::std::vec::Vec<BlockRollBlack>,
         ) -> ::ethers::contract::builders::ContractCall<M, ()> {
             self.0
-                .method_hash([236, 93, 100, 106], (inputs, outputs))
+                .method_hash([8, 193, 114, 40], blocks)
                 .expect("method not found (this should never happen)")
         }
 
@@ -78,15 +77,13 @@ pub mod image_cell_contract {
                 .expect("method not found (this should never happen)")
         }
 
-        /// Calls the contract's `update` (0x4d98c254) function
+        /// Calls the contract's `update` (0xafa74e04) function
         pub fn update(
             &self,
-            block_number: u64,
-            inputs: ::std::vec::Vec<OutPoint>,
-            outputs: ::std::vec::Vec<CellInfo>,
+            blocks: ::std::vec::Vec<BlockUpdate>,
         ) -> ::ethers::contract::builders::ContractCall<M, ()> {
             self.0
-                .method_hash([77, 152, 194, 84], (block_number, inputs, outputs))
+                .method_hash([175, 167, 78, 4], blocks)
                 .expect("method not found (this should never happen)")
         }
     }
@@ -98,8 +95,8 @@ pub mod image_cell_contract {
         }
     }
     /// Container type for all input parameters for the `rollback` function with
-    /// signature `rollback((bytes32,uint32)[],(bytes32,uint32)[])` and selector
-    /// `0xec5d646a`
+    /// signature `rollback(((bytes32,uint32)[],(bytes32,uint32)[])[])` and
+    /// selector `0x08c17228`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -112,11 +109,10 @@ pub mod image_cell_contract {
     )]
     #[ethcall(
         name = "rollback",
-        abi = "rollback((bytes32,uint32)[],(bytes32,uint32)[])"
+        abi = "rollback(((bytes32,uint32)[],(bytes32,uint32)[])[])"
     )]
     pub struct RollbackCall {
-        pub inputs:  ::std::vec::Vec<OutPoint>,
-        pub outputs: ::std::vec::Vec<OutPoint>,
+        pub blocks: ::std::vec::Vec<BlockRollBlack>,
     }
     /// Container type for all input parameters for the `setState` function with
     /// signature `setState(bool)` and selector `0xac9f0222`
@@ -135,9 +131,9 @@ pub mod image_cell_contract {
         pub allow_read: bool,
     }
     /// Container type for all input parameters for the `update` function with
-    /// signature `update(uint64,(bytes32,uint32)[],((bytes32,uint32),(uint64,
-    /// (bytes32,uint8,bytes),(bytes32,uint8,bytes)[]),bytes)[])` and selector
-    /// `0x4d98c254`
+    /// signature `update((uint64,(bytes32,uint32)[],((bytes32,uint32),(uint64,
+    /// (bytes32,uint8,bytes),(bytes32,uint8,bytes)[]),bytes)[])[])` and
+    /// selector `0xafa74e04`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -150,12 +146,10 @@ pub mod image_cell_contract {
     )]
     #[ethcall(
         name = "update",
-        abi = "update(uint64,(bytes32,uint32)[],((bytes32,uint32),(uint64,(bytes32,uint8,bytes),(bytes32,uint8,bytes)[]),bytes)[])"
+        abi = "update((uint64,(bytes32,uint32)[],((bytes32,uint32),(uint64,(bytes32,uint8,bytes),(bytes32,uint8,bytes)[]),bytes)[])[])"
     )]
     pub struct UpdateCall {
-        pub block_number: u64,
-        pub inputs:       ::std::vec::Vec<OutPoint>,
-        pub outputs:      ::std::vec::Vec<CellInfo>,
+        pub blocks: ::std::vec::Vec<BlockUpdate>,
     }
     /// Container type for all of the contract's call
     #[derive(Clone, ::ethers::contract::EthAbiType, Debug, PartialEq, Eq, Hash)]
@@ -277,5 +271,37 @@ pub mod image_cell_contract {
         pub code_hash: [u8; 32],
         pub hash_type: u8,
         pub args:      ::ethers::core::types::Bytes,
+    }
+    /// `BlockRollBlack((bytes32,uint32)[],(bytes32,uint32)[])`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        ::ethers::contract::EthAbiCodec,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    pub struct BlockRollBlack {
+        pub tx_inputs:  ::std::vec::Vec<OutPoint>,
+        pub tx_outputs: ::std::vec::Vec<OutPoint>,
+    }
+    /// `BlockUpdate(uint64,(bytes32,uint32)[],((bytes32,uint32),(uint64,
+    /// (bytes32,uint8,bytes),(bytes32,uint8,bytes)[]),bytes)[])`
+    #[derive(
+        Clone,
+        ::ethers::contract::EthAbiType,
+        ::ethers::contract::EthAbiCodec,
+        Default,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+    )]
+    pub struct BlockUpdate {
+        pub block_number: u64,
+        pub tx_inputs:    ::std::vec::Vec<OutPoint>,
+        pub tx_outputs:   ::std::vec::Vec<CellInfo>,
     }
 }

--- a/core/executor/src/system_contract/image_cell/contract/contracts/ImageCell.sol
+++ b/core/executor/src/system_contract/image_cell/contract/contracts/ImageCell.sol
@@ -8,16 +8,20 @@ contract ImageCell {
     using CkbType for CkbType.CellInfo;
     using CkbType for CkbType.OutPoint;
 
+    struct BlockUpdate {
+        uint64 blockNumber;
+        CkbType.OutPoint[] txInputs;
+        CkbType.CellInfo[] txOutputs;
+    }
+
+    struct BlockRollBlack {
+        CkbType.OutPoint[] txInputs;
+        CkbType.OutPoint[] txOutputs;
+    }
+
     function setState(bool allowRead) public view {}
 
-    function update(
-        uint64 blockNumber,
-        CkbType.OutPoint[] calldata inputs,
-        CkbType.CellInfo[] calldata outputs
-    ) public view {}
+    function update(BlockUpdate[] calldata blocks) public view {}
 
-    function rollback(
-        CkbType.OutPoint[] calldata inputs,
-        CkbType.OutPoint[] calldata outputs
-    ) public view {}
+    function rollback(BlockRollBlack[] calldata blocks) public view {}
 }

--- a/core/executor/src/system_contract/image_cell/contract/test/image-cell.js
+++ b/core/executor/src/system_contract/image_cell/contract/test/image-cell.js
@@ -14,46 +14,50 @@ describe("ImageCell", function () {
     });
 
     it("should test args of update()", async () => {
-        let inputs = [{
-            txHash: "0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37",
-            index: 0x0,
-        }];
-
-        let outputs = [{
-            outPoint: {
-                txHash: "0x65b253cdcb6226e7f8cffec5c47c959b3d74af2caf7970a1eb1500e9b92aa200",
+        let blocks = [{
+            blockNumber: 0x129d3,
+            txInputs: [{
+                txHash: "0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37",
                 index: 0x0,
-            },
-            output: {
-                capacity: 0x34e62ce00,
-                lock: {
-                    args: "0x927f3e74dceb87c81ba65a19da4f098b4de75a0d",
-                    codeHash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-                    hashType: 1
+            }],
+            txOutputs: [{
+                outPoint: {
+                    txHash: "0x65b253cdcb6226e7f8cffec5c47c959b3d74af2caf7970a1eb1500e9b92aa200",
+                    index: 0x0,
                 },
-                type_: [{
-                    args: "0x6e9b17739760ffc617017f157ed40641f7aa51b2af9ee017b35a0b35a1e2297b",
-                    codeHash: "0x48dbf59b4c7ee1547238021b4869bceedf4eea6b43772e5d66ef8865b6ae7212",
-                    hashType: 0
-                }]
-            },
-            data: "0x40420f00000000000000000000000000"
+                output: {
+                    capacity: 0x34e62ce00,
+                    lock: {
+                        args: "0x927f3e74dceb87c81ba65a19da4f098b4de75a0d",
+                        codeHash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+                        hashType: 1
+                    },
+                    type_: [{
+                        args: "0x6e9b17739760ffc617017f157ed40641f7aa51b2af9ee017b35a0b35a1e2297b",
+                        codeHash: "0x48dbf59b4c7ee1547238021b4869bceedf4eea6b43772e5d66ef8865b6ae7212",
+                        hashType: 0
+                    }]
+                },
+                data: "0x40420f00000000000000000000000000"
+            }],
         }];
 
-        await imageCell.update(0x129d3, inputs, outputs);
+        await imageCell.update(blocks);
     });
 
     it("should test args of rollback()", async () => {
-        let inputs = [{
-            txHash: "0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37",
-            index: 0x0,
+        let blocks = [{
+            txInputs: [{
+                txHash: "0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37",
+                index: 0x0,
+            }],
+            txOutputs: [{
+                txHash: "0x65b253cdcb6226e7f8cffec5c47c959b3d74af2caf7970a1eb1500e9b92aa200",
+                index: 0x0,
+            }],
+
         }];
 
-        let outputs = [{
-            txHash: "0x65b253cdcb6226e7f8cffec5c47c959b3d74af2caf7970a1eb1500e9b92aa200",
-            index: 0x0,
-        }];
-
-        await imageCell.rollback(inputs, outputs);
+        await imageCell.rollback(blocks);
     });
 });

--- a/core/executor/src/system_contract/image_cell/store.rs
+++ b/core/executor/src/system_contract/image_cell/store.rs
@@ -44,17 +44,19 @@ impl ImageCellStore {
     }
 
     pub fn update(&mut self, data: image_cell_abi::UpdateCall) -> ProtocolResult<()> {
-        self.save_cells(data.outputs, data.block_number)?;
-
-        self.mark_cells_consumed(data.inputs, data.block_number)?;
+        for block in data.blocks {
+            self.save_cells(block.tx_outputs, block.block_number)?;
+            self.mark_cells_consumed(block.tx_inputs, block.block_number)?;
+        }
 
         self.commit()
     }
 
     pub fn rollback(&mut self, data: image_cell_abi::RollbackCall) -> ProtocolResult<()> {
-        self.remove_cells(data.outputs)?;
-
-        self.mark_cells_not_consumed(data.inputs)?;
+        for block in data.blocks {
+            self.remove_cells(block.tx_outputs)?;
+            self.mark_cells_not_consumed(block.tx_inputs)?;
+        }
 
         self.commit()
     }

--- a/core/executor/src/tests/system_script/image_cell.rs
+++ b/core/executor/src/tests/system_script/image_cell.rs
@@ -32,9 +32,11 @@ fn test_write_functions() {
 
 fn test_update_first(backend: &mut MemoryBackend, executor: &ImageCellContract) {
     let data = image_cell_abi::UpdateCall {
-        block_number: 0x1,
-        inputs:       vec![],
-        outputs:      prepare_outputs(),
+        blocks: vec![image_cell_abi::BlockUpdate {
+            block_number: 0x1,
+            tx_inputs:    vec![],
+            tx_outputs:   prepare_outputs(),
+        }],
     };
 
     let r = exec(backend, executor, data.encode());
@@ -50,12 +52,14 @@ fn test_update_first(backend: &mut MemoryBackend, executor: &ImageCellContract) 
 
 fn test_update_second(backend: &mut MemoryBackend, executor: &ImageCellContract) {
     let data = image_cell_abi::UpdateCall {
-        block_number: 0x2,
-        inputs:       vec![image_cell_abi::OutPoint {
-            tx_hash: [7u8; 32],
-            index:   0x0,
+        blocks: vec![image_cell_abi::BlockUpdate {
+            block_number: 0x2,
+            tx_inputs:    vec![image_cell_abi::OutPoint {
+                tx_hash: [7u8; 32],
+                index:   0x0,
+            }],
+            tx_outputs:   vec![],
         }],
-        outputs:      vec![],
     };
 
     let r = exec(backend, executor, data.encode());
@@ -71,11 +75,13 @@ fn test_update_second(backend: &mut MemoryBackend, executor: &ImageCellContract)
 
 fn test_rollback_first(backend: &mut MemoryBackend, executor: &ImageCellContract) {
     let data = image_cell_abi::RollbackCall {
-        inputs:  vec![image_cell_abi::OutPoint {
-            tx_hash: [7u8; 32],
-            index:   0x0,
+        blocks: vec![image_cell_abi::BlockRollBlack {
+            tx_inputs:  vec![image_cell_abi::OutPoint {
+                tx_hash: [7u8; 32],
+                index:   0x0,
+            }],
+            tx_outputs: vec![],
         }],
-        outputs: vec![],
     };
 
     let r = exec(backend, executor, data.encode());
@@ -90,10 +96,12 @@ fn test_rollback_first(backend: &mut MemoryBackend, executor: &ImageCellContract
 
 fn test_rollback_second(backend: &mut MemoryBackend, executor: &ImageCellContract) {
     let data = image_cell_abi::RollbackCall {
-        inputs:  vec![],
-        outputs: vec![image_cell_abi::OutPoint {
-            tx_hash: [7u8; 32],
-            index:   0x0,
+        blocks: vec![image_cell_abi::BlockRollBlack {
+            tx_inputs:  vec![],
+            tx_outputs: vec![image_cell_abi::OutPoint {
+                tx_hash: [7u8; 32],
+                index:   0x0,
+            }],
         }],
     };
 

--- a/core/interoperation/src/tests/verify_in_mempool.rs
+++ b/core/interoperation/src/tests/verify_in_mempool.rs
@@ -149,9 +149,11 @@ async fn test_verify_joyid_with_sub_key() {
 
 async fn build_image_cell_payload<T: Into<ckb_types::H256>>(tx_hash: T) -> Vec<u8> {
     image_cell_abi::UpdateCall {
-        block_number: 0,
-        inputs:       vec![],
-        outputs:      get_tx_cells(tx_hash).await,
+        blocks: vec![image_cell_abi::BlockUpdate {
+            block_number: 0,
+            tx_inputs:    vec![],
+            tx_outputs:   get_tx_cells(tx_hash).await,
+        }],
     }
     .encode()
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR allows image cell system contract to receive multiple blocks

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
