### PR TITLE
refactor: change max_connections num type to u32

### DIFF
--- a/common/config-parser/src/types.rs
+++ b/common/config-parser/src/types.rs
@@ -17,10 +17,8 @@ pub const DEFAULT_CACHE_SIZE: usize = 100;
 pub struct ConfigApi {
     pub http_listening_address: Option<SocketAddr>,
     pub ws_listening_address:   Option<SocketAddr>,
-    #[serde(default)]
-    pub maxconn:                usize,
-    #[serde(default)]
-    pub max_payload_size:       usize,
+    pub maxconn:                u32,
+    pub max_payload_size:       u32,
     pub enable_dump_profile:    Option<bool>,
     #[serde(default)]
     pub client_version:         String,

--- a/core/api/src/jsonrpc/mod.rs
+++ b/core/api/src/jsonrpc/mod.rs
@@ -228,8 +228,9 @@ pub async fn run_jsonrpc_server<Adapter: APIAdapter + 'static>(
 
     if let Some(addr) = config.rpc.http_listening_address {
         let server = ServerBuilder::new()
-            .max_request_body_size(config.rpc.max_payload_size as u32)
-            .max_response_body_size(config.rpc.max_payload_size as u32)
+            .max_request_body_size(config.rpc.max_payload_size)
+            .max_response_body_size(config.rpc.max_payload_size)
+            .max_connections(config.rpc.maxconn)
             .build(addr)
             .await
             .map_err(|e| APIError::HttpServer(e.to_string()))?;
@@ -243,9 +244,9 @@ pub async fn run_jsonrpc_server<Adapter: APIAdapter + 'static>(
 
     if let Some(addr) = config.rpc.ws_listening_address {
         let server = ServerBuilder::new()
-            .max_request_body_size(config.rpc.max_payload_size as u32)
-            .max_request_body_size(config.rpc.max_payload_size as u32)
-            .max_connections((config.rpc.maxconn as u64).try_into().unwrap())
+            .max_request_body_size(config.rpc.max_payload_size)
+            .max_request_body_size(config.rpc.max_payload_size)
+            .max_connections(config.rpc.maxconn)
             .set_id_provider(HexIdProvider::default())
             .build(addr)
             .await


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [x] v3 Core Tests
