### PR TITLE
fix: decode interoperation transaction signature

### DIFF
--- a/protocol/src/codec/transaction.rs
+++ b/protocol/src/codec/transaction.rs
@@ -43,7 +43,7 @@ impl SignatureComponents {
         let signature_r_and_s_size =
             rlp.at(signature_r_offset)?.size() + rlp.at(signature_s_offset)?.size();
 
-        let eth_tx_flag = signature_r_and_s_size == 63 || signature_r_and_s_size == 64;
+        let eth_tx_flag = signature_r_and_s_size <= 64;
         let (r, s) = match eth_tx_flag {
             true => {
                 let tmp_r: U256 = rlp.val_at(signature_r_offset)?;

--- a/protocol/src/codec/transaction.rs
+++ b/protocol/src/codec/transaction.rs
@@ -118,15 +118,13 @@ impl LegacyTransaction {
             value:     r.val_at(4)?,
             data:      r.val_at(5)?,
         };
-
         let v: u64 = r.val_at(6)?;
-        let id = SignatureComponents::extract_chain_id(v)
-            .ok_or(DecoderError::Custom("Missing chain id"))?;
 
         Ok(UnverifiedTransaction {
             unsigned:  UnsignedTransaction::Legacy(tx),
             signature: Some(SignatureComponents::rlp_decode(r, 6, Some(v))?),
-            chain_id:  id,
+            chain_id:  SignatureComponents::extract_chain_id(v)
+                .ok_or(DecoderError::Custom("Missing chain id"))?,
             hash:      Hasher::digest(r.as_raw()),
         })
     }
@@ -523,7 +521,7 @@ mod tests {
         assert!(utx.unsigned.gas_price().is_zero());
         assert!(utx.unsigned.max_priority_fee_per_gas().is_zero());
         assert!(utx.chain_id == 5);
-        // assert!(sig.standard_v == 27);
+        assert_eq!(sig.standard_v, 0);
         assert_eq!(sig.r, hex_decode("02f860e3a0f35178c7a1a5a4e5b164157aa549a493cebc9a3079b6a9ede7ae5207adb3f4d48001c0f839a0d23761b364210735c19c60561d213fb3beae2fd6172743719eff6920e020baac9600016091d93dbab12f16640fb3a0a8f1e77e03fbc51c02").unwrap());
         assert_eq!(sig.s, hex_decode("0xf9015ff9015cb90157014599a5795423d54ab8e1f44f5c6ef5be9b1829beddb787bc732e4469d25f8c93e94afa393617f905bf1765c35dc38501a862b4b2f794a88b4f9010da02411a852d147a369b9ba6de71bf065f4831cc1ff9c4887c2dcfa669d6e4b9d24f0937c154974fd8399405052fdc8a6605a86040d670d47db1a092916aa5679b2e8604b449960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630162f9fb777b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a22593255355a544d324d545135595445775a5745345a6a64684e6a4a694e47526c4d574d7a4d5755784f44686c4e6a597a4d5745784d6d46685a44566d597a426a596d4e6d4f4746694d6a45774f4751334d6a646d4f51222c226f726967696e223a22687474703a2f2f6c6f63616c686f73743a38303030222c2263726f73734f726967696e223a66616c73657dc0c0").unwrap());
     }

--- a/protocol/src/codec/transaction.rs
+++ b/protocol/src/codec/transaction.rs
@@ -4,7 +4,6 @@ use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 
 use common_crypto::secp256k1_recover;
 
-use crate::lazy::CHAIN_ID;
 use crate::types::{
     public_to_address, AccessList, AccessListItem, Bytes, BytesMut, Eip1559Transaction,
     Eip2930Transaction, Hasher, LegacyTransaction, Public, SignatureComponents, SignedTransaction,
@@ -121,7 +120,8 @@ impl LegacyTransaction {
         };
 
         let v: u64 = r.val_at(6)?;
-        let id = SignatureComponents::extract_chain_id(v).unwrap_or_else(|| **CHAIN_ID.load());
+        let id = SignatureComponents::extract_chain_id(v)
+            .ok_or(DecoderError::Custom("Missing chain id"))?;
 
         Ok(UnverifiedTransaction {
             unsigned:  UnsignedTransaction::Legacy(tx),

--- a/protocol/src/types/transaction.rs
+++ b/protocol/src/types/transaction.rs
@@ -351,6 +351,7 @@ pub struct SignatureComponents {
     pub standard_v: u8,
 }
 
+/// This is only use for test.
 impl From<Bytes> for SignatureComponents {
     // assume that all the bytes data are in Ethereum-like format
     fn from(bytes: Bytes) -> Self {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR fix decode interoperation transaction signature component.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
