### PR TITLE
refactor: change the maximum RPC gas cap limit

### DIFF
--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -7,7 +7,7 @@ use protocol::lazy::PROTOCOL_VERSION;
 use protocol::traits::{APIAdapter, Context};
 use protocol::types::{
     Block, BlockNumber, Bytes, Hash, Header, Hex, Receipt, SignedTransaction, TxResp,
-    UnverifiedTransaction, H160, H256, H64, MAX_BLOCK_GAS_LIMIT, MIN_TRANSACTION_GAS_LIMIT, U256,
+    UnverifiedTransaction, H160, H256, H64, MAX_RPC_GAS_CAP, MIN_TRANSACTION_GAS_LIMIT, U256,
 };
 use protocol::{async_trait, codec::ProtocolCodec, ProtocolResult};
 
@@ -313,7 +313,7 @@ impl<Adapter: APIAdapter + 'static> AxonWeb3RpcServer for Web3RpcImpl<Adapter> {
             return Err(Error::Custom("The gas price is too large".to_string()));
         }
 
-        if req.gas.unwrap_or_default() > U256::from(MAX_BLOCK_GAS_LIMIT) {
+        if req.gas.unwrap_or_default() > U256::from(MAX_RPC_GAS_CAP) {
             return Err(Error::Custom("The gas limit is too large".to_string()));
         }
 

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -10,6 +10,7 @@ use crate::types::{
 pub type BlockNumber = u64;
 
 pub const MAX_BLOCK_GAS_LIMIT: u64 = 30_000_000;
+pub const MAX_RPC_GAS_CAP: u64 = 50_000_000;
 pub const BASE_FEE_PER_GAS: u64 = 0x539;
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #705

**Which docs this PR relation**:

Ref #705

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
