### PR TITLE
refactor: change keccak hash function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,13 +295,13 @@ dependencies = [
  "ckb-traits",
  "ckb-types",
  "common-crypto",
+ "common-hasher",
  "creep",
  "derive_more",
  "ethereum",
  "ethereum-types 0.14.1",
  "evm",
  "faster-hex",
- "hasher",
  "hex",
  "lazy_static",
  "ophelia",
@@ -1501,6 +1501,13 @@ dependencies = [
  "overlord",
  "rand 0.7.3",
  "rlp",
+]
+
+[[package]]
+name = "common-hasher"
+version = "0.1.0"
+dependencies = [
+ "tiny-keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "common/channel",
     "common/config-parser",
     "common/crypto",
+    "common/hasher",
     "common/logger",
     "common/memory-tracker",
     "common/merkle",

--- a/common/hasher/Cargo.toml
+++ b/common/hasher/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "common-hasher"
+version = "0.1.0"
+edition = "2021"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tiny-keccak = { version = "2.0", features = ["keccak"] }

--- a/common/hasher/src/lib.rs
+++ b/common/hasher/src/lib.rs
@@ -1,0 +1,9 @@
+use tiny_keccak::{Hasher, Keccak};
+
+pub fn keccak256<B: AsRef<[u8]>>(data: B) -> [u8; 32] {
+    let mut result = [0u8; 32];
+    let mut hasher = Keccak::v256();
+    hasher.update(data.as_ref());
+    hasher.finalize(&mut result);
+    result
+}

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -15,14 +15,12 @@ ckb-jsonrpc-types = "0.108"
 ckb-sdk = "2.5"
 ckb-traits = "0.108"
 ckb-types = "0.108"
-common-crypto = { path = "../common/crypto" }
 creep = "0.2"
 derive_more = "0.99"
 ethereum = { version = "0.14", features = ["with-codec", "with-serde"] }
 ethereum-types = { version = "0.14", features = ["arbitrary", "codec", "rlp", "serialize", "std"] }
 evm = { version = "0.37", features = ["with-serde"] }
 faster-hex = "0.6"
-hasher = { version = "0.1", features = ["hash-keccak"] }
 lazy_static = "1.4"
 ophelia = "0.3"
 ophelia-secp256k1 = "0.3"
@@ -34,6 +32,9 @@ rlp-derive = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.27", features = ["full"] }
 trie = { package = "cita_trie", version = "4.0" }
+
+common-crypto = { path = "../common/crypto" }
+common-hasher = { path = "../common/hasher" }
 
 [dev-dependencies]
 hex = "0.4"

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -6,20 +6,17 @@ pub use ethereum_types::{
     U512, U64,
 };
 
-use hasher::{Hasher as KeccakHasher, HasherKeccak};
 use ophelia::{PublicKey, UncompressedPublicKey};
 use ophelia_secp256k1::Secp256k1PublicKey;
 use overlord::DurationConfig;
 use rlp_derive::{RlpDecodable, RlpEncodable};
 use serde::{de, Deserialize, Serialize};
 
+use common_hasher::keccak256;
+
 use crate::codec::{hex_decode, hex_encode};
 use crate::types::{BlockNumber, Bytes, TypesError};
 use crate::{ProtocolError, ProtocolResult};
-
-lazy_static::lazy_static! {
-    static ref HASHER_INST: HasherKeccak = HasherKeccak::new();
-}
 
 pub type Hash = H256;
 pub type MerkleRoot = Hash;
@@ -55,10 +52,7 @@ impl Hasher {
             return NIL_DATA;
         }
 
-        let hash = HASHER_INST.digest(bytes.as_ref());
-        let mut ret = Hash::default();
-        ret.0.copy_from_slice(&hash[0..32]);
-        ret
+        H256(keccak256(bytes))
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR changes the keccak hash function.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
