### PR TITLE
ci: remove apply patch for config.toml due to some errors

### DIFF
--- a/.github/workflows/copy_config_to_devops.yml
+++ b/.github/workflows/copy_config_to_devops.yml
@@ -15,16 +15,6 @@ jobs:
         uses: actions/checkout@v3
         with:
          fetch-depth: 2
-      - name: get file patch and output current_commit
-        id: file_patch
-        run: |
-          current_commit=`git log -n 1 --pretty=format:%H`
-          echo $current_commit
-          last_commit=`git log HEAD^1 --pretty=format:%H`
-          echo $last_commit
-          git diff $last_commit $current_commit -- "${{ github.workspace}}/devtools/chain/config.toml" > config_toml.patch
-          cat ${{ github.workspace}}/config_toml.patch
-          echo "current_commit=$current_commit" >> $GITHUB_OUTPUT
       - name: Git checkout devops
         uses: actions/checkout@v3
         with:
@@ -39,37 +29,6 @@ jobs:
           cp ${{ github.workspace}}/devtools/chain/nodes/genesis_multi_nodes.json ${{ github.workspace}}/axon-devops/deploy/templates/genesis.json
           cp ${{ github.workspace}}/devtools/chain/nodes/genesis_multi_nodes.json ${{ github.workspace}}/axon-devops/docker-deploy/templates/genesis.json
           cp ${{ github.workspace}}/devtools/chain/nodes/genesis_multi_nodes.json ${{ github.workspace}}/axon-devops/k8s-deploy/k8s/axon/axon-config/genesis.json
-          if [[ -s ${{ github.workspace}}/config_toml.patch ]]; then
-            # take actions when config.toml changed
-            cp ${{ github.workspace}}/devtools/chain/config.toml ${{ github.workspace}}/axon-devops/deploy/templates
-            cp ${{ github.workspace}}/devtools/chain/config.toml ${{ github.workspace}}/axon-devops/docker-deploy/templates
-            sed -i 's/privkey =.*$/privkey = "#private_key"/g' ${{ github.workspace}}/axon-devops/deploy/templates/config.toml
-            sed -i 's/multi_address =.*$/multi_address = "\/ip4\/#bootstraps\/tcp\/8001\/p2p\/QmNk6bBwkLPuqnsrtxpp819XLZY3ymgjs3p1nKtxBVgqxj"/g' ${{ github.workspace}}/axon-devops/deploy/templates/config.toml
-            sed -i 's/mercury_uri =.*$/mercury_uri = "#mercury_uri"/g' ${{ github.workspace}}/axon-devops/deploy/templates/config.toml
-            sed -i "s/enable = .*$/enable = #enable_cross_client/g" ${{ github.workspace}}/axon-devops/deploy/templates/config.toml
-            sed -i 's/privkey =.*$/privkey = "#private_key"/g' ${{ github.workspace}}/axon-devops/docker-deploy/templates/config.toml
-            sed -i 's/multi_address =.*$/multi_address = "\/ip4\/#bootstraps\/tcp\/8001\/p2p\/QmNk6bBwkLPuqnsrtxpp819XLZY3ymgjs3p1nKtxBVgqxj"/g' ${{ github.workspace}}/axon-devops/docker-deploy/templates/config.toml
-            sed -i 's/mercury_uri =.*$/mercury_uri = "#mercury_uri"/g' ${{ github.workspace}}/axon-devops/docker-deploy/templates/config.toml
-            sed -i "s/enable = .*$/enable = #enable_cross_client/g" ${{ github.workspace}}/axon-devops/docker-deploy/templates/config.toml
-            cp ${{ github.workspace}}/config_toml.patch ${{ github.workspace}}/axon-devops/node_1.patch
-            cp ${{ github.workspace}}/config_toml.patch ${{ github.workspace}}/axon-devops/node_2.patch
-            cp ${{ github.workspace}}/config_toml.patch ${{ github.workspace}}/axon-devops/node_3.patch
-            cp ${{ github.workspace}}/config_toml.patch ${{ github.workspace}}/axon-devops/node_4.patch
-            sed -i "s/a\/devtools\/chain\/config.toml/a\/k8s-deploy\/k8s\/axon\/axon-config\/node_1.toml/g" ${{ github.workspace}}/axon-devops/node_1.patch
-            sed -i "s/b\/devtools\/chain\/config.toml/b\/k8s-deploy\/k8s\/axon\/axon_config\/node_1.toml/g" ${{ github.workspace}}/axon-devops/node_1.patch
-            sed -i "s/a\/devtools\/chain\/config.toml/a\/k8s-deploy\/k8s\/axon\/axon-config\/node_2.toml/g" ${{ github.workspace}}/axon-devops/node_2.patch
-            sed -i "s/b\/devtools\/chain\/config.toml/b\/k8s-deploy\/k8s\/axon\/axon_config\/node_2.toml/g" ${{ github.workspace}}/axon-devops/node_2.patch
-            sed -i "s/a\/devtools\/chain\/config.toml/a\/k8s-deploy\/k8s\/axon\/axon-config\/node_3.toml/g" ${{ github.workspace}}/axon-devops/node_3.patch
-            sed -i "s/b\/devtools\/chain\/config.toml/b\/k8s-deploy\/k8s\/axon\/axon_config\/node_3.toml/g" ${{ github.workspace}}/axon-devops/node_3.patch
-            sed -i "s/a\/devtools\/chain\/config.toml/a\/k8s-deploy\/k8s\/axon\/axon-config\/node_4.toml/g" ${{ github.workspace}}/axon-devops/node_4.patch
-            sed -i "s/b\/devtools\/chain\/config.toml/b\/k8s-deploy\/k8s\/axon\/axon_config\/node_4.toml/g" ${{ github.workspace}}/axon-devops/node_4.patch
-          fi
-          cd ${{ github.workspace}}/axon-devops
-          git apply --ignore-space-change --ignore-whitespace ${{ github.workspace}}/axon-devops/node_1.patch
-          git apply --ignore-space-change --ignore-whitespace ${{ github.workspace}}/axon-devops/node_2.patch
-          git apply --ignore-space-change --ignore-whitespace ${{ github.workspace}}/axon-devops/node_3.patch
-          git apply --ignore-space-change --ignore-whitespace ${{ github.workspace}}/axon-devops/node_4.patch
-          rm -rf ${{ github.workspace}}/axon-devops/node_*.patch
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
