### PR TITLE
feat(cli): add version compatible check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ name = "axon"
 version = "0.1.0"
 dependencies = [
  "axon-protocol",
+ "clap 4.2.1",
  "core-api",
  "core-cli",
  "core-consensus",
@@ -1656,6 +1657,7 @@ dependencies = [
  "common-config-parser",
  "common-logger",
  "core-run",
+ "semver",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 repository = "https://github.com/axonweb3/axon"
 
 [dependencies]
+clap = { version = "4.2", features = ["cargo"] }
+
 # byzantine = { path = "./byzantine" }
 core-api = { path = "./core/api" }
 core-cli = { path = "./core/cli" }

--- a/common/config-parser/src/types.rs
+++ b/common/config-parser/src/types.rs
@@ -61,13 +61,6 @@ impl Config {
         path_state
     }
 
-    pub fn data_path_for_crosschain(&self) -> PathBuf {
-        let mut path_state = self.data_path.clone();
-        path_state.push("rocksdb");
-        path_state.push("crosschain");
-        path_state
-    }
-
     pub fn data_path_for_txs_wal(&self) -> PathBuf {
         let mut path_state = self.data_path.clone();
         path_state.push("txs_wal");
@@ -77,6 +70,12 @@ impl Config {
     pub fn data_path_for_consensus_wal(&self) -> PathBuf {
         let mut path_state = self.data_path.clone();
         path_state.push("consensus_wal");
+        path_state
+    }
+
+    pub fn data_path_for_version(&self) -> PathBuf {
+        let mut path_state = self.data_path.clone();
+        path_state.push("axon.ver");
         path_state
     }
 }

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.0", features = ["cargo"] }
+clap = "4.2"
+semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,5 @@ use core_executor::FEE_ALLOCATOR;
 
 pub fn run(fee_allocator: impl FeeAllocate + 'static) {
     FEE_ALLOCATOR.swap(Arc::new(Box::new(fee_allocator)));
-    AxonCli::init().start();
+    AxonCli::init(clap::crate_version!()).start();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use core_cli::AxonCli;
 
 fn main() {
-    AxonCli::init().start();
+    AxonCli::init(clap::crate_version!()).start();
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR adds version compatible check.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [ ] Unit Tests
- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
