### PR TITLE
feat: custom network key provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6390,9 +6390,9 @@ dependencies = [
 
 [[package]]
 name = "tentacle"
-version = "0.4.2"
+version = "0.5.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffbbdb4f54a9605ceda168884efcf5fb24ef655103362af211e6cfe61eff832"
+checksum = "1b1eebddd8969d511b3af3706b75e0b134b79a3204c888b4cc8b7b19cd858f1f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6432,10 +6432,11 @@ dependencies = [
 
 [[package]]
 name = "tentacle-secio"
-version = "0.5.7"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a41abd9ae459d1f744f59670d8f4e9a25c4597b12b9060740fbd17bf9687fc"
+checksum = "0fe69efa3a97ce5d308c445ddbeb3f50c7601e965569abd3e3bb06650df057dd"
 dependencies = [
+ "async-trait",
  "bs58",
  "bytes",
  "chacha20poly1305",

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -7,7 +7,7 @@ use clap::{Arg, ArgMatches, Command};
 use semver::Version;
 
 use common_config_parser::{parse_file, types::Config};
-use core_run::Axon;
+use core_run::{Axon, KeyProvider, SecioKeyPair};
 use protocol::types::RichBlock;
 
 pub struct AxonCli {
@@ -44,6 +44,10 @@ impl AxonCli {
     }
 
     pub fn start(&self) {
+        self.start_with_custom_key_provider::<SecioKeyPair>(None)
+    }
+
+    pub fn start_with_custom_key_provider<K: KeyProvider>(&self, key_provider: Option<K>) {
         let config_path = self.matches.get_one::<String>("config_path").unwrap();
         let path = Path::new(&config_path).parent().unwrap();
         let mut config: Config = parse_file(config_path, false).unwrap();
@@ -61,7 +65,7 @@ impl AxonCli {
 
         register_log(&config);
 
-        Axon::new(config, genesis).run().unwrap();
+        Axon::new(config, genesis).run(key_provider).unwrap();
     }
 
     fn check_version(&self, config: &Config) {

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snap = "1.0"
 socket2 = "0.4"
-tentacle = { version = "0.4.2", features = ["parking_lot"] }
+tentacle = { version = "0.5.0-alpha.1", features = ["parking_lot", "secio-async-trait"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 
 common-apm = { path = "../../common/apm" }

--- a/core/network/examples/simple.rs
+++ b/core/network/examples/simple.rs
@@ -82,7 +82,7 @@ async fn main() {
         let bt_conf = NetworkConfig::new()
             .listen_addr("/ip4/127.0.0.1/tcp/1337".parse().unwrap())
             .secio_keypair(&bt_seckey);
-        let mut bootstrap = NetworkService::new(bt_conf);
+        let mut bootstrap = NetworkService::new(bt_conf, bt_keypair);
         let handle = bootstrap.handle();
 
         let check_out = Checkout {
@@ -119,7 +119,7 @@ async fn main() {
                 .parse()
                 .unwrap()]);
 
-        let mut peer = NetworkService::new(peer_conf);
+        let mut peer = NetworkService::new(peer_conf, bt_keypair);
         let handle = peer.handle();
 
         let take_my_money = TakeMyMoney { shop: handle };

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -17,7 +17,10 @@ mod traits;
 pub use self::config::NetworkConfig;
 pub use self::service::{NetworkService, NetworkServiceHandle};
 pub use self::traits::NetworkContext;
-pub use tentacle::{multiaddr, secio::PeerId};
+pub use tentacle::{
+    multiaddr,
+    secio::{error::SecioError, KeyProvider, PeerId, SecioKeyPair},
+};
 
 use crate::error::NetworkError;
 use protocol::types::Bytes;
@@ -25,10 +28,9 @@ use tentacle::secio::PublicKey;
 
 pub trait PeerIdExt {
     fn from_pubkey_bytes<'a, B: AsRef<[u8]> + 'a>(bytes: B) -> Result<PeerId, NetworkError> {
-        let pubkey = PublicKey::secp256k1_raw_key(bytes.as_ref())
-            .map_err(|_| NetworkError::InvalidPublicKey)?;
-
-        Ok(PeerId::from_public_key(&pubkey))
+        Ok(PeerId::from_public_key(&PublicKey::from_raw_key(
+            bytes.as_ref().to_vec(),
+        )))
     }
 
     fn from_bytes<'a, B: AsRef<[u8]> + 'a>(bytes: B) -> Result<PeerId, NetworkError> {

--- a/devtools/keypair/Cargo.toml
+++ b/devtools/keypair/Cargo.toml
@@ -14,4 +14,4 @@ protocol = { path = "../../protocol", package = "axon-protocol" }
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tentacle-secio = "0.5"
+tentacle-secio = "0.6"

--- a/examples/custom_chain.rs
+++ b/examples/custom_chain.rs
@@ -1,4 +1,4 @@
-use axon::{FeeAllocate, FeeInlet, ValidatorExtend, H160, U256};
+use axon::{async_trait, FeeAllocate, FeeInlet, KeyProvider, ValidatorExtend, H160, U256};
 
 #[derive(Default, Clone, Debug)]
 struct CustomFeeAllocator;
@@ -16,6 +16,38 @@ impl FeeAllocate for CustomFeeAllocator {
     }
 }
 
+#[derive(Default, Clone, Debug)]
+struct CustomKey;
+
+#[async_trait]
+impl KeyProvider for CustomKey {
+    type Error = std::io::Error;
+
+    async fn sign_ecdsa_async<T: AsRef<[u8]> + Send>(
+        &self,
+        _message: T,
+    ) -> Result<Vec<u8>, Self::Error> {
+        todo!()
+    }
+
+    fn sign_ecdsa<T: AsRef<[u8]>>(&self, _message: T) -> Result<Vec<u8>, Self::Error> {
+        todo!()
+    }
+
+    fn pubkey(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn verify_ecdsa<P, T, F>(&self, _pubkey: P, _message: T, _signature: F) -> bool
+    where
+        P: AsRef<[u8]>,
+        T: AsRef<[u8]>,
+        F: AsRef<[u8]>,
+    {
+        todo!()
+    }
+}
+
 fn main() {
-    axon::run(CustomFeeAllocator::default())
+    axon::run(CustomFeeAllocator::default(), CustomKey::default())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,16 @@
 pub use core_executor::{DefaultFeeAllocator, FeeAllocate, FeeInlet};
-pub use protocol::types::{ValidatorExtend, H160, U256};
+pub use core_run::KeyProvider;
+pub use protocol::{
+    async_trait,
+    types::{ValidatorExtend, H160, U256},
+};
 
 use std::sync::Arc;
 
 use core_cli::AxonCli;
 use core_executor::FEE_ALLOCATOR;
 
-pub fn run(fee_allocator: impl FeeAllocate + 'static) {
+pub fn run(fee_allocator: impl FeeAllocate + 'static, key_provider: impl KeyProvider) {
     FEE_ALLOCATOR.swap(Arc::new(Box::new(fee_allocator)));
-    AxonCli::init(clap::crate_version!()).start();
+    AxonCli::init(clap::crate_version!()).start_with_custom_key_provider(Some(key_provider));
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allow users custom key provider on netowork handshake

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
