### PR TITLE
feat(API): add get metadata rpc method

### DIFF
--- a/core/api/src/adapter.rs
+++ b/core/api/src/adapter.rs
@@ -5,9 +5,9 @@ use core_executor::{
 };
 use protocol::traits::{APIAdapter, Context, Executor, ExecutorAdapter, MemPool, Network, Storage};
 use protocol::types::{
-    Account, BigEndianHash, Block, BlockNumber, Bytes, ExecutorContext, Hash, Header, Metadata,
-    Proposal, Receipt, SignedTransaction, TxResp, H160, MAX_BLOCK_GAS_LIMIT, NIL_DATA, RLP_NULL,
-    U256,
+    Account, BigEndianHash, Block, BlockNumber, Bytes, CkbRelatedInfo, ExecutorContext, Hash,
+    Header, Metadata, Proposal, Receipt, SignedTransaction, TxResp, H160, MAX_BLOCK_GAS_LIMIT,
+    NIL_DATA, RLP_NULL, U256,
 };
 use protocol::{async_trait, codec::ProtocolCodec, trie, ProtocolResult};
 
@@ -242,5 +242,9 @@ where
 
         let num = self.storage.get_latest_block_header(ctx).await?.number;
         MetadataHandle::default().get_metadata_by_block_number(num)
+    }
+
+    async fn get_ckb_related_info(&self, ctx: Context) -> ProtocolResult<CkbRelatedInfo> {
+        MetadataHandle::default().get_ckb_related_info()
     }
 }

--- a/core/api/src/adapter.rs
+++ b/core/api/src/adapter.rs
@@ -244,7 +244,7 @@ where
         MetadataHandle::default().get_metadata_by_block_number(num)
     }
 
-    async fn get_ckb_related_info(&self, ctx: Context) -> ProtocolResult<CkbRelatedInfo> {
+    async fn get_ckb_related_info(&self, _ctx: Context) -> ProtocolResult<CkbRelatedInfo> {
         MetadataHandle::default().get_ckb_related_info()
     }
 }

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -4,7 +4,7 @@ use jsonrpsee::core::Error;
 
 use protocol::async_trait;
 use protocol::traits::{APIAdapter, Context};
-use protocol::types::{Block, Metadata, Proof, U256};
+use protocol::types::{Block, CkbRelatedInfo, Metadata, Proof, U256};
 
 use crate::jsonrpc::web3_types::BlockId;
 use crate::jsonrpc::{AxonRpcServer, RpcResult};
@@ -58,6 +58,16 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
         let ret = self
             .adapter
             .get_metadata_by_number(Context::new(), None)
+            .await
+            .map_err(|e| Error::Custom(e.to_string()))?;
+
+        Ok(ret)
+    }
+
+    async fn get_ckb_related_info(&self) -> RpcResult<CkbRelatedInfo> {
+        let ret = self
+            .adapter
+            .get_ckb_related_info(Context::new())
             .await
             .map_err(|e| Error::Custom(e.to_string()))?;
 

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -4,7 +4,7 @@ use jsonrpsee::core::Error;
 
 use protocol::async_trait;
 use protocol::traits::{APIAdapter, Context};
-use protocol::types::{Block, Proof};
+use protocol::types::{Block, Metadata, Proof, U256};
 
 use crate::jsonrpc::web3_types::BlockId;
 use crate::jsonrpc::{AxonRpcServer, RpcResult};
@@ -41,6 +41,26 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
             .get_block_by_id(block_id)
             .await?
             .map(|b| b.header.proof);
+        Ok(ret)
+    }
+
+    async fn get_metadata_by_number(&self, block_number: U256) -> RpcResult<Metadata> {
+        let ret = self
+            .adapter
+            .get_metadata_by_number(Context::new(), Some(block_number.as_u64()))
+            .await
+            .map_err(|e| Error::Custom(e.to_string()))?;
+
+        Ok(ret)
+    }
+
+    async fn get_current_metadata(&self) -> RpcResult<Metadata> {
+        let ret = self
+            .adapter
+            .get_metadata_by_number(Context::new(), None)
+            .await
+            .map_err(|e| Error::Custom(e.to_string()))?;
+
         Ok(ret)
     }
 }

--- a/core/api/src/jsonrpc/mod.rs
+++ b/core/api/src/jsonrpc/mod.rs
@@ -11,7 +11,7 @@ use jsonrpsee::{core::Error, proc_macros::rpc};
 
 use common_config_parser::types::Config;
 use protocol::traits::APIAdapter;
-use protocol::types::{Block, Hash, Hex, Metadata, Proof, H160, H256, U256};
+use protocol::types::{Block, CkbRelatedInfo, Hash, Hex, Metadata, Proof, H160, H256, U256};
 use protocol::ProtocolResult;
 
 use crate::jsonrpc::web3_types::{
@@ -215,6 +215,9 @@ pub trait AxonRpc {
 
     #[method(name = "axon_getCurrentMetadata")]
     async fn get_current_metadata(&self) -> RpcResult<Metadata>;
+
+    #[method(name = "axon_getCkbRelatedInfo")]
+    async fn get_ckb_related_info(&self) -> RpcResult<CkbRelatedInfo>;
 }
 
 #[rpc(server)]

--- a/core/api/src/jsonrpc/mod.rs
+++ b/core/api/src/jsonrpc/mod.rs
@@ -11,7 +11,7 @@ use jsonrpsee::{core::Error, proc_macros::rpc};
 
 use common_config_parser::types::Config;
 use protocol::traits::APIAdapter;
-use protocol::types::{Block, Hash, Hex, Proof, H160, H256, U256};
+use protocol::types::{Block, Hash, Hex, Metadata, Proof, H160, H256, U256};
 use protocol::ProtocolResult;
 
 use crate::jsonrpc::web3_types::{
@@ -209,6 +209,12 @@ pub trait AxonRpc {
 
     #[method(name = "axon_getProofById")]
     async fn get_proof_by_id(&self, block_id: BlockId) -> RpcResult<Option<Proof>>;
+
+    #[method(name = "axon_getMetadataByNumber")]
+    async fn get_metadata_by_number(&self, block_number: U256) -> RpcResult<Metadata>;
+
+    #[method(name = "axon_getCurrentMetadata")]
+    async fn get_current_metadata(&self) -> RpcResult<Metadata>;
 }
 
 #[rpc(server)]

--- a/core/executor/src/debugger/mod.rs
+++ b/core/executor/src/debugger/mod.rs
@@ -78,7 +78,7 @@ impl EvmDebugger {
     pub fn exec(&mut self, number: u64, txs: Vec<SignedTransaction>) -> ExecResp {
         let mut backend = self.backend(number);
         let evm = AxonExecutor::default();
-        let res = evm.exec(&mut backend, &txs, &[]);
+        let res = evm.test_exec(&mut backend, &txs, &[]);
         self.state_root = res.state_root;
         res
     }

--- a/core/executor/src/system_contract/metadata/abi/mod.rs
+++ b/core/executor/src/system_contract/metadata/abi/mod.rs
@@ -145,7 +145,7 @@ mod tests {
         };
 
         let raw = AbiEncode::encode(call.clone());
-        let decode = metadata_abi::SetCkbRelatedInfoCall::decode(&raw).unwrap();
+        let decode = metadata_abi::SetCkbRelatedInfoCall::decode(raw).unwrap();
         assert_eq!(call, decode);
     }
 }

--- a/protocol/src/traits/api.rs
+++ b/protocol/src/traits/api.rs
@@ -1,6 +1,6 @@
 use crate::types::{
-    Account, Block, BlockNumber, Bytes, Hash, Header, Proposal, Receipt, SignedTransaction, TxResp,
-    H160, U256,
+    Account, Block, BlockNumber, Bytes, Hash, Header, Metadata, Proposal, Receipt,
+    SignedTransaction, TxResp, H160, U256,
 };
 use crate::{async_trait, traits::Context, ProtocolResult};
 
@@ -91,4 +91,10 @@ pub trait APIAdapter: Send + Sync {
         position: U256,
         state_root: Hash,
     ) -> ProtocolResult<Bytes>;
+
+    async fn get_metadata_by_number(
+        &self,
+        ctx: Context,
+        block_number: Option<u64>,
+    ) -> ProtocolResult<Metadata>;
 }

--- a/protocol/src/traits/api.rs
+++ b/protocol/src/traits/api.rs
@@ -1,5 +1,5 @@
 use crate::types::{
-    Account, Block, BlockNumber, Bytes, Hash, Header, Metadata, Proposal, Receipt,
+    Account, Block, BlockNumber, Bytes, CkbRelatedInfo, Hash, Header, Metadata, Proposal, Receipt,
     SignedTransaction, TxResp, H160, U256,
 };
 use crate::{async_trait, traits::Context, ProtocolResult};
@@ -97,4 +97,6 @@ pub trait APIAdapter: Send + Sync {
         ctx: Context,
         block_number: Option<u64>,
     ) -> ProtocolResult<Metadata>;
+
+    async fn get_ckb_related_info(&self, ctx: Context) -> ProtocolResult<CkbRelatedInfo>;
 }

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -312,28 +312,28 @@ impl MetadataVersion {
     RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
 )]
 pub struct Metadata {
-    pub version:                    MetadataVersion,
+    pub version:         MetadataVersion,
     #[serde(serialize_with = "serialize_uint")]
-    pub epoch:                      u64,
+    pub epoch:           u64,
     #[serde(serialize_with = "serialize_uint")]
-    pub gas_limit:                  u64,
+    pub gas_limit:       u64,
     #[serde(serialize_with = "serialize_uint")]
-    pub gas_price:                  u64,
+    pub gas_price:       u64,
     #[serde(serialize_with = "serialize_uint")]
-    pub interval:                   u64,
-    pub verifier_list:              Vec<ValidatorExtend>,
+    pub interval:        u64,
+    pub verifier_list:   Vec<ValidatorExtend>,
     #[serde(serialize_with = "serialize_uint")]
-    pub propose_ratio:              u64,
+    pub propose_ratio:   u64,
     #[serde(serialize_with = "serialize_uint")]
-    pub prevote_ratio:              u64,
+    pub prevote_ratio:   u64,
     #[serde(serialize_with = "serialize_uint")]
-    pub precommit_ratio:            u64,
+    pub precommit_ratio: u64,
     #[serde(serialize_with = "serialize_uint")]
-    pub brake_ratio:                u64,
+    pub brake_ratio:     u64,
     #[serde(serialize_with = "serialize_uint")]
-    pub tx_num_limit:               u64,
+    pub tx_num_limit:    u64,
     #[serde(serialize_with = "serialize_uint")]
-    pub max_tx_size:                u64,
+    pub max_tx_size:     u64,
     #[serde(skip_deserializing)]
     pub propose_counter: Vec<ProposeCount>,
 }
@@ -352,6 +352,7 @@ impl From<Metadata> for DurationConfig {
 #[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ProposeCount {
     pub address: H160,
+    #[serde(serialize_with = "serialize_uint")]
     pub count:   u64,
 }
 
@@ -478,6 +479,7 @@ pub fn checksum(address: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn test_eip55() {
@@ -512,5 +514,20 @@ mod tests {
         let bytes = Hex::empty();
         let hash = Hasher::digest(bytes.as_bytes());
         assert_eq!(hash, NIL_DATA);
+    }
+
+    #[test]
+    fn test_metadata_json_serialize() {
+        let metadata: Metadata = serde_json::from_slice(
+            &fs::read("../devtools/genesis-generator/metadata.json").unwrap(),
+        )
+        .unwrap();
+        let json = serde_json::to_value(metadata).unwrap();
+
+        println!("{:?}", json.to_string());
+
+        assert!(json.get("version").unwrap().is_object());
+        assert!(json.get("epoch").unwrap().is_string());
+        assert!(json.get("propose_counter").unwrap().is_array());
     }
 }

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -14,7 +14,7 @@ use serde::{de, Deserialize, Serialize};
 
 use common_hasher::keccak256;
 
-use crate::codec::{hex_decode, hex_encode};
+use crate::codec::{hex_decode, hex_encode, serialize_uint};
 use crate::types::{BlockNumber, Bytes, TypesError};
 use crate::{ProtocolError, ProtocolResult};
 
@@ -292,7 +292,9 @@ impl fmt::Display for Address {
     RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, Copy, PartialEq, Eq,
 )]
 pub struct MetadataVersion {
+    #[serde(serialize_with = "serialize_uint")]
     pub start: BlockNumber,
+    #[serde(serialize_with = "serialize_uint")]
     pub end:   BlockNumber,
 }
 
@@ -310,18 +312,28 @@ impl MetadataVersion {
     RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
 )]
 pub struct Metadata {
-    pub version:         MetadataVersion,
-    pub epoch:           u64,
-    pub gas_limit:       u64,
-    pub gas_price:       u64,
-    pub interval:        u64,
-    pub verifier_list:   Vec<ValidatorExtend>,
-    pub propose_ratio:   u64,
-    pub prevote_ratio:   u64,
-    pub precommit_ratio: u64,
-    pub brake_ratio:     u64,
-    pub tx_num_limit:    u64,
-    pub max_tx_size:     u64,
+    pub version:                    MetadataVersion,
+    #[serde(serialize_with = "serialize_uint")]
+    pub epoch:                      u64,
+    #[serde(serialize_with = "serialize_uint")]
+    pub gas_limit:                  u64,
+    #[serde(serialize_with = "serialize_uint")]
+    pub gas_price:                  u64,
+    #[serde(serialize_with = "serialize_uint")]
+    pub interval:                   u64,
+    pub verifier_list:              Vec<ValidatorExtend>,
+    #[serde(serialize_with = "serialize_uint")]
+    pub propose_ratio:              u64,
+    #[serde(serialize_with = "serialize_uint")]
+    pub prevote_ratio:              u64,
+    #[serde(serialize_with = "serialize_uint")]
+    pub precommit_ratio:            u64,
+    #[serde(serialize_with = "serialize_uint")]
+    pub brake_ratio:                u64,
+    #[serde(serialize_with = "serialize_uint")]
+    pub tx_num_limit:               u64,
+    #[serde(serialize_with = "serialize_uint")]
+    pub max_tx_size:                u64,
     #[serde(skip_deserializing)]
     pub propose_counter: Vec<ProposeCount>,
 }
@@ -370,7 +382,9 @@ pub struct ValidatorExtend {
     pub bls_pub_key:    Hex,
     pub pub_key:        Hex,
     pub address:        H160,
+    #[serde(serialize_with = "serialize_uint")]
     pub propose_weight: u32,
+    #[serde(serialize_with = "serialize_uint")]
     pub vote_weight:    u32,
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR adds `axon_getMetadata` and `axon_getCkbRelatedInfo` rpc method.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
