### PR TITLE
refactor: change the default feature of protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   </a>
   <p align="center">
 	<a href="https://github.com/axonweb3/axon/releases"><img src="https://img.shields.io/github/v/release/axonweb3/axon?sort=semver"></a>
+    <a href = "https://hub.docker.com/r/axonweb3/axon/tags"><img src = "https://img.shields.io/docker/pulls/axonweb3/axon"></a>
     <a href="https://github.com/axonweb3/axon/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green.svg"></a>
     <a href="https://github.com/axonweb3/axon"><img src="https://github.com/axonweb3/axon/actions/workflows/web3_compatible.yml/badge.svg?branch=main"></a>
     <a href="https://github.com/axonweb3/axon"><img src="https://img.shields.io/github/contributors/axonweb3/axon"></a>

--- a/common/apm/Cargo.toml
+++ b/common/apm/Cargo.toml
@@ -21,4 +21,4 @@ rustracing_jaeger = { git = "http://github.com/KaoImin/rustracing_jaeger", branc
 trackable = "1.2"
 
 common-apm-derive = { path = "../apm-derive" }
-protocol = { path = "../../protocol", package = "axon-protocol" }
+protocol = { path = "../../protocol", package = "axon-protocol", default-features = false }

--- a/common/config-parser/Cargo.toml
+++ b/common/config-parser/Cargo.toml
@@ -13,4 +13,4 @@ stringreader = "0.1"
 tentacle-multiaddr = "0.3"
 toml = "0.7"
 
-protocol = { path = "../../protocol", package = "axon-protocol" }
+protocol = { path = "../../protocol", package = "axon-protocol", default-features = false }

--- a/common/crypto/Cargo.toml
+++ b/common/crypto/Cargo.toml
@@ -16,7 +16,7 @@ overlord = "0.4"
 rand = "0.7"
 rlp = "0.5"
 
-protocol = { path = "../../protocol", package = "axon-protocol" }
+protocol = { path = "../../protocol", package = "axon-protocol", default-features = false }
 
 [[bench]]
 harness = false

--- a/common/merkle/Cargo.toml
+++ b/common/merkle/Cargo.toml
@@ -10,7 +10,7 @@ hasher = "0.1"
 rlp = "0.5"
 static_merkle_tree = "1.1"
 
-protocol = { path = "../../protocol", package = "axon-protocol" }
+protocol = { path = "../../protocol", package = "axon-protocol", default-features = false }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/core/executor/Cargo.toml
+++ b/core/executor/Cargo.toml
@@ -26,7 +26,7 @@ lru = "0.10"
 molecule = "0.7"
 once_cell = "1.17"
 parking_lot = "0.12"
-protocol = { path = "../../protocol", package = "axon-protocol" }
+protocol = { path = "../../protocol", package = "axon-protocol", default-features = false }
 ripemd = "0.1"
 rlp = "0.5"
 rlp-derive = "0.1"

--- a/core/interoperation/Cargo.toml
+++ b/core/interoperation/Cargo.toml
@@ -15,7 +15,7 @@ ckb-vm = { version = "0.22.2", features = ["asm"] }
 lazy_static = "1.4"
 log = "0.4"
 
-protocol = { path = "../../protocol", package = "axon-protocol" }
+protocol = { path = "../../protocol", package = "axon-protocol", default-features = false }
 
 [dev-dependencies]
 cardano-serialization-lib = "7.0"

--- a/devtools/genesis-generator/Cargo.toml
+++ b/devtools/genesis-generator/Cargo.toml
@@ -13,7 +13,7 @@ common-crypto = { path = "../../common/crypto" }
 core-executor = { path = "../../core/executor" }
 ethers-core = "2.0"
 ophelia = "0.3"
-protocol = { path = "../../protocol", package = "axon-protocol" }
+protocol = { path = "../../protocol", package = "axon-protocol", default-features = false }
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -40,3 +40,7 @@ common-hasher = { path = "../common/hasher" }
 hex = "0.4"
 serde_json = "1.0"
 toml = "0.7"
+
+[features]
+default = ["hex-serialize"]
+hex-serialize = []

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -1,7 +1,9 @@
 use rlp_derive::{RlpDecodable, RlpEncodable};
 use serde::{Deserialize, Serialize};
 
-use crate::codec::{serialize_bytes, serialize_uint, ProtocolCodec};
+use crate::codec::ProtocolCodec;
+#[cfg(feature = "hex-serialize")]
+use crate::codec::{serialize_bytes, serialize_uint};
 use crate::types::{
     Bloom, BloomInput, Bytes, ExecResp, Hash, Hasher, MerkleRoot, SignedTransaction, H160, H64,
     U256,
@@ -20,19 +22,19 @@ pub struct Proposal {
     pub prev_state_root:          MerkleRoot,
     pub transactions_root:        MerkleRoot,
     pub signed_txs_hash:          Hash,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub timestamp:                u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub number:                   BlockNumber,
     pub gas_limit:                U256,
-    #[serde(serialize_with = "serialize_bytes")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_bytes"))]
     pub extra_data:               Bytes,
     pub mixed_hash:               Option<Hash>,
     pub base_fee_per_gas:         U256,
     pub proof:                    Proof,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub chain_id:                 u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub call_system_script_count: u32,
     pub tx_hashes:                Vec<Hash>,
 }
@@ -150,21 +152,21 @@ pub struct Header {
     pub receipts_root:            MerkleRoot,
     pub log_bloom:                Bloom,
     pub difficulty:               U256,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub timestamp:                u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub number:                   BlockNumber,
     pub gas_used:                 U256,
     pub gas_limit:                U256,
-    #[serde(serialize_with = "serialize_bytes")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_bytes"))]
     pub extra_data:               Bytes,
     pub mixed_hash:               Option<Hash>,
     pub nonce:                    H64,
     pub base_fee_per_gas:         U256,
     pub proof:                    Proof,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub call_system_script_count: u32,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub chain_id:                 u64,
 }
 
@@ -182,14 +184,14 @@ impl Header {
     RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
 )]
 pub struct Proof {
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub number:     u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub round:      u64,
     pub block_hash: Hash,
-    #[serde(serialize_with = "serialize_bytes")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_bytes"))]
     pub signature:  Bytes,
-    #[serde(serialize_with = "serialize_bytes")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_bytes"))]
     pub bitmap:     Bytes,
 }
 

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -292,9 +292,9 @@ impl fmt::Display for Address {
     RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, Copy, PartialEq, Eq,
 )]
 pub struct MetadataVersion {
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub start: BlockNumber,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub end:   BlockNumber,
 }
 
@@ -313,26 +313,26 @@ impl MetadataVersion {
 )]
 pub struct Metadata {
     pub version:         MetadataVersion,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub epoch:           u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub gas_limit:       u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub gas_price:       u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub interval:        u64,
     pub verifier_list:   Vec<ValidatorExtend>,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub propose_ratio:   u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub prevote_ratio:   u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub precommit_ratio: u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub brake_ratio:     u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub tx_num_limit:    u64,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub max_tx_size:     u64,
     #[serde(skip_deserializing)]
     pub propose_counter: Vec<ProposeCount>,
@@ -352,7 +352,7 @@ impl From<Metadata> for DurationConfig {
 #[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ProposeCount {
     pub address: H160,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub count:   u64,
 }
 
@@ -383,9 +383,9 @@ pub struct ValidatorExtend {
     pub bls_pub_key:    Hex,
     pub pub_key:        Hex,
     pub address:        H160,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub propose_weight: u32,
-    #[serde(serialize_with = "serialize_uint")]
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub vote_weight:    u32,
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
