### PR TITLE
ci: locked the runner versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     #   - "main"
 jobs:
   version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       tag: ${{ steps.version.outputs.tag }}
       major: ${{ steps.version.outputs.major }}
@@ -46,7 +46,7 @@ jobs:
             target: aarch64-apple-darwin
             use-cross: false
             REL_PKG: aarch64-apple-darwin.zip
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             use-cross: false
             REL_PKG: x86_64-unknown-linux-gnu.tar.gz
@@ -112,7 +112,7 @@ jobs:
           name: axon_${{ needs.version.outputs.tag }}_${{ matrix.job.REL_PKG }}
           path: axon_${{ needs.version.outputs.tag }}_${{ matrix.job.REL_PKG }}
   Upload-release-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
@@ -139,7 +139,7 @@ jobs:
           asset_path: ${{ github.workspace }}/axon_${{ needs.version.outputs.tag }}_${{ matrix.REL_PKG }}
           asset_content_type: application/octet-stream
   force-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - version
       - Upload-release-files
@@ -152,7 +152,7 @@ jobs:
 
 
   trigger-somking-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - version
       - package
@@ -172,7 +172,7 @@ jobs:
           inputs: '{ "axon_linux_release_tag": "${{ needs.version.outputs.tag }}" }'
 
   trigger-build-docker-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - version
     steps:

--- a/.github/workflows/somking_test.yml
+++ b/.github/workflows/somking_test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
    Smoking-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Download&Unzip
@@ -22,7 +22,7 @@ jobs:
         mv axon_* axon
     - name: Start axon
       run: |
-         cd ${{ github.workspace }}/axon 
+         cd ${{ github.workspace }}/axon
          ./axon --config ${{ github.workspace }}/axon/config.toml --genesis ${{ github.workspace }}/axon/genesis_single_node.json > /tmp/log 2>&1 &
          sleep 120
     - name: Check Axon Status


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**Which issue(s) this PR fixes**:
The runner runs-on ubuntu-latest , the latest version is ubuntu-22.04,  running below this version may encounter errors, so locked the version as ubuntu-20.04

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
