### PR TITLE
fix(API): update eth fee history rpc method

### DIFF
--- a/core/api/README.md
+++ b/core/api/README.md
@@ -605,10 +605,11 @@ Request
 {
   "id": 1,
   "jsonrpc": "2.0",
-  "method": "eth_getTransactionReceipt",
+  "method": "eth_feeHistory",
   "params": [
-    "0x8",
-	"0x1b4"
+    "0x1",
+	"latest"
+	[20, 30],
   ]
 }
 ```
@@ -622,9 +623,9 @@ Response
 	"jsonrpc": "2.0",
 	"result": {
 		"oldestBlock": "0x0",
-		"reward": null,
-		"baseFeePerGas": [],
-		"gasUsedRatio": []
+		"baseFeePerGas": ["0x539","0x539"],
+		"gasUsedRatio": [0.0],
+		"reward": [["0x0"]]
 	},
 	"id": 2
 }

--- a/core/api/src/jsonrpc/mod.rs
+++ b/core/api/src/jsonrpc/mod.rs
@@ -21,6 +21,8 @@ use crate::jsonrpc::web3_types::{
 use crate::jsonrpc::ws_subscription::{ws_subscription_module, HexIdProvider};
 use crate::APIError;
 
+use self::web3_types::BlockCount;
+
 type RpcResult<T> = Result<T, Error>;
 
 #[rpc(server)]
@@ -85,7 +87,7 @@ pub trait Web3Rpc {
     #[method(name = "eth_feeHistory")]
     async fn fee_history(
         &self,
-        block_count: U256,
+        block_count: BlockCount,
         newest_block: BlockId,
         reward_percentiles: Option<Vec<f64>>,
     ) -> RpcResult<Web3FeeHistory>;

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -12,6 +12,10 @@ use crate::types::{
 pub type BlockNumber = u64;
 
 pub const MAX_BLOCK_GAS_LIMIT: u64 = 30_000_000;
+// MAX_FEE_HISTORY is the maximum number of blocks that can be retrieved for a
+// fee history request. Between 1 and 1024 blocks can be requested in a single
+// query. reference: https://docs.infura.io/infura/networks/ethereum/json-rpc-methods/eth_feehistory/
+pub const MAX_FEE_HISTORY: u64 = 1024;
 pub const MAX_RPC_GAS_CAP: u64 = 50_000_000;
 pub const BASE_FEE_PER_GAS: u64 = 0x539;
 

--- a/protocol/src/types/transaction.rs
+++ b/protocol/src/types/transaction.rs
@@ -88,7 +88,7 @@ impl UnsignedTransaction {
         match self {
             UnsignedTransaction::Legacy(tx) => tx.gas_price,
             UnsignedTransaction::Eip2930(tx) => tx.gas_price,
-            UnsignedTransaction::Eip1559(tx) => tx.gas_price.min(tx.max_priority_fee_per_gas),
+            UnsignedTransaction::Eip1559(tx) => tx.gas_price.max(tx.max_priority_fee_per_gas),
         }
     }
 

--- a/tests/e2e/src/eth_feeHistory.html
+++ b/tests/e2e/src/eth_feeHistory.html
@@ -1,18 +1,45 @@
 <html>
   <body>
-    <div>
-      <button id="getFeeHistory">Get fee history</button>
-      <div>Fee history: <span id="feeHistory"></span></div>
+    <button id="btn">eth_feeHistory</button>
+    <div><input type="text" id="testType" value="" /></div>
+    <div> value: <span id="ret"></span></div>
     </div>
   </body>
   <script>
-    document.getElementById("getFeeHistory").addEventListener("click", () => {
-      ethereum
-        .request({ method: "eth_feeHistory", params: ["0x1", "latest", []] })
+    document.getElementById("btn").addEventListener("click", () => {
+      const t_type = document.getElementById("testType").value;
+      if (t_type === "1") {
+        ethereum
+        .request({ method: "eth_feeHistory", params: ["0x1", "earliest", [25, 75]] })
         .then((result) => {
-          document.getElementById("feeHistory").innerHTML =
+          document.getElementById("ret").innerHTML =
             JSON.stringify(result);
         });
+      }
+      if (t_type === "2") {
+        ethereum
+        .request({ method: "eth_feeHistory", params: ["0x1", "earliest", []] })
+        .then((result) => {
+          document.getElementById("ret").innerHTML =
+            JSON.stringify(result);
+        });
+      }
+      if (t_type === "3") {
+        ethereum
+        .request({ method: "eth_feeHistory", params: ["0x0", "earliest", [25, 75]] })
+        .then((result) => {
+          document.getElementById("ret").innerHTML =
+            JSON.stringify(result);
+        });
+      }
+      if (t_type === "4") {
+        ethereum
+        .request({ method: "eth_feeHistory", params: ["0x1", "0x0", [25, 75]] })
+        .then((result) => {
+          document.getElementById("ret").innerHTML =
+            JSON.stringify(result);
+        });
+      }
     });
   </script>
 </html>

--- a/tests/e2e/src/eth_feeHistory.test.js
+++ b/tests/e2e/src/eth_feeHistory.test.js
@@ -8,21 +8,78 @@ describe("eth_feeHistory", () => {
     await goto.goto(page, pageName);
   });
 
-  it("should returns empty fee history", async () => {
-    await page.click("#getFeeHistory");
+  it("should returns normal fee history", async () => {
+    const testType = await page.$(goto.pageIds.testTypeId);
+    await testType.type("1");
+    await page.click("#btn");
 
     await page.waitForFunction(
-      () => document.getElementById("feeHistory").innerText !== "",
+      () => document.getElementById("ret").innerText !== "",
     );
 
-    const result = page.$eval("#feeHistory", (e) => e.innerText);
+    const result = page.$eval("#ret", (e) => e.innerText);
 
     await expect(result).resolves.not.toThrow();
     expect(JSON.parse(await result)).toMatchObject({
-      baseFeePerGas: [],
-      gasUsedRatio: [],
+      baseFeePerGas: ["0x539", "0x539"],
+      gasUsedRatio: [0],
       oldestBlock: "0x0",
-      reward: null,
+      reward: [["0x0", "0x0"]],
+    });
+  }, 100000);
+
+  it("should returns fee history without reward", async () => {
+    const testType = await page.$(goto.pageIds.testTypeId);
+    await testType.type("2");
+    await page.click("#btn");
+
+    await page.waitForFunction(
+      () => document.getElementById("ret").innerText !== "",
+    );
+
+    const result = page.$eval("#ret", (e) => e.innerText);
+
+    await expect(result).resolves.not.toThrow();
+    expect(JSON.parse(await result)).toMatchObject({
+      baseFeePerGas: ["0x539", "0x539"],
+      gasUsedRatio: [0],
+      oldestBlock: "0x0",
+    });
+  }, 100000);
+
+  it("should returns zero fee history", async () => {
+    const testType = await page.$(goto.pageIds.testTypeId);
+    await testType.type("3");
+
+    await page.waitForFunction(
+      () => document.getElementById("ret").innerText !== "",
+    );
+
+    const result = page.$eval("#ret", (e) => e.innerText);
+
+    await expect(result).resolves.not.toThrow();
+    expect(JSON.parse(await result)).toMatchObject({
+      gasUsedRatio: [0],
+      oldestBlock: "0x0",
+    });
+  }, 100000);
+
+  it("should returns second block fee history", async () => {
+    const testType = await page.$(goto.pageIds.testTypeId);
+    await testType.type("4");
+
+    await page.waitForFunction(
+      () => document.getElementById("ret").innerText !== "",
+    );
+
+    const result = page.$eval("#ret", (e) => e.innerText);
+
+    await expect(result).resolves.not.toThrow();
+    expect(JSON.parse(await result)).toMatchObject({
+      baseFeePerGas: ["0x539", "0x539"],
+      gasUsedRatio: [0],
+      oldestBlock: "0x0",
+      reward: [["0x0", "0x0"]],
     });
   }, 100000);
 });

--- a/tests/e2e/src/eth_getBlockByNumber.test.js
+++ b/tests/e2e/src/eth_getBlockByNumber.test.js
@@ -44,9 +44,9 @@ describe("eth_getBlockByNumber", () => {
     const testType = await page.$(goto.pageIds.testTypeId);
     const param1 = await page.$(goto.pageIds.param1Id);
     const param2 = await page.$(goto.pageIds.param2Id);
+    await testType.type("1"); // 0: none params 1: common params to request 2: more params 3: less params
     await param1.type("0xfffffff");
     await param2.type("true");
-    await testType.type("1"); // 0: none params 1: common params to request 2: more params 3: less params
     await goto.check(page, "null");
   });
 
@@ -81,9 +81,9 @@ describe("eth_getBlockByNumber", () => {
     const testType = await page.$(goto.pageIds.testTypeId);
     const param1 = await page.$(goto.pageIds.param1Id);
     const param2 = await page.$(goto.pageIds.param2Id);
+    await testType.type("2"); // 0: none params 1: common params to request 2: more params 3: less params
     await param1.type(testDataInfo.hexBlockNumber);
     await param2.type("true");
-    await testType.type("2"); // 0: none params 1: common params to request 2: more params 3: less params
     await goto.check(page, "-32602");
   });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR update the RPC implement of `eth_feeHistory`.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/axonweb3/axon/issues/1106

**Which docs this PR relation**:

Ref # 
https://docs.infura.io/infura/networks/ethereum/json-rpc-methods/eth_feehistory 

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
