### PR TITLE
refactor(consensus): change save proof moment

### DIFF
--- a/common/config-parser/src/types.rs
+++ b/common/config-parser/src/types.rs
@@ -178,11 +178,6 @@ impl Default for ConfigRocksDB {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct ConfigIbc {
-    pub uri: String,
-}
-
-#[derive(Clone, Debug, Deserialize)]
 pub struct ConfigLogger {
     pub filter:                     String,
     pub log_to_console:             bool,

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -239,9 +239,6 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<Proposal> for ConsensusEngine<A
             signature:  commit.proof.signature.signature.clone(),
             bitmap:     commit.proof.signature.address_bitmap.clone(),
         };
-        common_apm::metrics::consensus::ENGINE_ROUND_GAUGE.set(commit.proof.round as i64);
-
-        self.adapter.save_proof(ctx.clone(), proof.clone()).await?;
 
         // Get full transactions from mempool. If is error, try get from wal.
         let signed_txs = match self
@@ -596,6 +593,10 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
             &txs,
             &resp,
         );
+
+        common_apm::metrics::consensus::ENGINE_ROUND_GAUGE.set(proof.round as i64);
+
+        self.adapter.save_proof(ctx.clone(), proof.clone()).await?;
 
         // Save signed transactions
         self.adapter


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR changes the moment of save proof to DB from before execute to after execute.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
