### PR TITLE
Optimize Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,33 @@
-FROM rust:latest as builder
+FROM rust:1.68.2 as builder
 
 WORKDIR /build
 COPY . .
 
-RUN apt-get update
-RUN apt-get install cmake clang llvm gcc -y
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        cmake \
+        clang \
+        llvm \
+        gcc; \
+    rm -rf /var/lib/apt/lists/*
+
 RUN cd /build && cargo build --release
 
 FROM debian:bookworm-20211011-slim
 WORKDIR /app
 
-RUN rm /var/lib/apt/lists/* -fv
-RUN apt-get update
-RUN apt install -y libssl-dev
-RUN apt install -y libc6-dev
-RUN apt-get -y install ca-certificates
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libssl-dev \
+        libc6-dev \
+        ca-certificates; \
+     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/target/release/axon /app/axon
 COPY --from=builder /build/devtools /app/devtools
 
-CMD ./axon -c=/app/devtools/chain/config.toml -g=/app/devtools/chain/genesis.json
+CMD ./axon -c=/app/devtools/chain/config.toml -g=/app/devtools/chain/genesis_single_node.json
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.68.2 as builder
+FROM rust:1.69 as builder
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR decrease axon image volume size, 255MB → 178MB
axon            0526-2            78c750a998aa   49 minutes ago      178MB
axon            0526              12a4e6bb9d1c   About an hour ago   255MB

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
