### PR TITLE
chore: remove useless config

### DIFF
--- a/common/config-parser/src/types.rs
+++ b/common/config-parser/src/types.rs
@@ -94,25 +94,17 @@ pub struct ConfigApi {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct ConfigNetwork {
-    pub bootstraps:                 Option<Vec<ConfigNetworkBootstrap>>,
-    pub allowlist:                  Option<Vec<String>>,
-    pub allowlist_only:             Option<bool>,
-    pub trust_interval_duration:    Option<u64>,
-    pub trust_max_history_duration: Option<u64>,
-    pub fatal_ban_duration:         Option<u64>,
-    pub soft_ban_duration:          Option<u64>,
-    pub max_connected_peers:        Option<usize>,
-    pub same_ip_conn_limit:         Option<usize>,
-    pub inbound_conn_limit:         Option<usize>,
-    pub listening_address:          MultiAddr,
-    pub rpc_timeout:                Option<u64>,
-    pub selfcheck_interval:         Option<u64>,
-    pub send_buffer_size:           Option<usize>,
-    pub write_timeout:              Option<u64>,
-    pub recv_buffer_size:           Option<usize>,
-    pub max_frame_length:           Option<usize>,
-    pub max_wait_streams:           Option<usize>,
-    pub ping_interval:              Option<u64>,
+    pub bootstraps:          Option<Vec<ConfigNetworkBootstrap>>,
+    pub allowlist:           Option<Vec<String>>,
+    pub allowlist_only:      Option<bool>,
+    pub max_connected_peers: Option<usize>,
+    pub inbound_conn_limit:  Option<usize>,
+    pub listening_address:   MultiAddr,
+    pub rpc_timeout:         Option<u64>,
+    pub send_buffer_size:    Option<usize>,
+    pub recv_buffer_size:    Option<usize>,
+    pub max_frame_length:    Option<usize>,
+    pub ping_interval:       Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/core/network/src/config.rs
+++ b/core/network/src/config.rs
@@ -24,30 +24,14 @@ pub const DEFAULT_MAX_CONNECTIONS: usize = 40;
 pub const DEFAULT_MAX_FRAME_LENGTH: usize = 4 * 1024 * 1024; // 4 Mib
 pub const DEFAULT_BUFFER_SIZE: usize = 24 * 1024 * 1024; // same as tentacle
 
-// Default max wait streams for accept
-pub const DEFAULT_MAX_WAIT_STREAMS: usize = 256;
-// Default write timeout
-pub const DEFAULT_WRITE_TIMEOUT: u64 = 10; // seconds
-
 pub const DEFAULT_SAME_IP_CONN_LIMIT: usize = 1;
 pub const DEFAULT_INBOUND_CONN_LIMIT: usize = 20;
-
-// Default peer trust metric
-pub const DEFAULT_PEER_TRUST_INTERVAL_DURATION: Duration = Duration::from_secs(60);
-pub const DEFAULT_PEER_TRUST_MAX_HISTORY_DURATION: Duration =
-    Duration::from_secs(24 * 60 * 60 * 10); // 10 day
-const DEFAULT_PEER_FATAL_BAN_DURATION: Duration = Duration::from_secs(60 * 60); // 1 hour
-const DEFAULT_PEER_SOFT_BAN_DURATION: Duration = Duration::from_secs(60 * 10); // 10 minutes
 
 // Default peer store persistent path
 pub const DEFAULT_PEER_DAT_FILE: &str = "./";
 
 pub const DEFAULT_PING_INTERVAL: u64 = 15;
 pub const DEFAULT_PING_TIMEOUT: u64 = 30;
-pub const DEFAULT_DISCOVERY_SYNC_INTERVAL: u64 = 60 * 60; // 1 hour
-
-pub const DEFAULT_PEER_MANAGER_HEART_BEAT_INTERVAL: u64 = 30;
-pub const DEFAULT_SELF_HEART_BEAT_INTERVAL: u64 = 35;
 
 pub const DEFAULT_RPC_TIMEOUT: u64 = 10;
 
@@ -59,33 +43,21 @@ pub struct NetworkConfig {
     pub max_frame_length: usize,
     pub send_buffer_size: usize,
     pub recv_buffer_size: usize,
-    pub max_wait_streams: usize,
-    pub write_timeout:    u64,
 
     // peer manager
-    pub bootstraps:             Vec<Multiaddr>,
-    pub allowlist:              Vec<PeerId>,
-    pub allowlist_only:         bool,
-    pub enable_save_restore:    bool,
-    pub peer_store_path:        PathBuf,
-    pub peer_trust_interval:    Duration,
-    pub peer_trust_max_history: Duration,
-    pub peer_fatal_ban:         Duration,
-    pub peer_soft_ban:          Duration,
-    pub same_ip_conn_limit:     usize,
-    pub inbound_conn_limit:     usize,
+    pub bootstraps:          Vec<Multiaddr>,
+    pub allowlist:           Vec<PeerId>,
+    pub allowlist_only:      bool,
+    pub enable_save_restore: bool,
+    pub peer_store_path:     PathBuf,
+    pub inbound_conn_limit:  usize,
 
     // identity and encryption
     pub secio_keypair: SecioKeyPair,
 
     // protocol
-    pub ping_interval:           Duration,
-    pub ping_timeout:            Duration,
-    pub discovery_sync_interval: Duration,
-
-    // routine
-    pub peer_manager_heart_beat_interval: Duration,
-    pub heart_beat_interval:              Duration,
+    pub ping_interval: Duration,
+    pub ping_timeout:  Duration,
 
     // rpc
     pub rpc_timeout: Duration,
@@ -96,38 +68,24 @@ impl NetworkConfig {
         let mut listen_addr = Multiaddr::from(DEFAULT_LISTEN_IP_ADDR);
         listen_addr.push(Protocol::Tcp(DEFAULT_LISTEN_PORT));
 
-        let peer_manager_hb_interval =
-            Duration::from_secs(DEFAULT_PEER_MANAGER_HEART_BEAT_INTERVAL);
-
         NetworkConfig {
             default_listen:   listen_addr,
             max_connections:  DEFAULT_MAX_CONNECTIONS,
             max_frame_length: DEFAULT_MAX_FRAME_LENGTH,
             send_buffer_size: DEFAULT_BUFFER_SIZE,
             recv_buffer_size: DEFAULT_BUFFER_SIZE,
-            max_wait_streams: DEFAULT_MAX_WAIT_STREAMS,
-            write_timeout:    DEFAULT_WRITE_TIMEOUT,
 
-            bootstraps:             Default::default(),
-            allowlist:              Default::default(),
-            allowlist_only:         false,
-            enable_save_restore:    false,
-            peer_store_path:        PathBuf::from(DEFAULT_PEER_DAT_FILE.to_owned()),
-            peer_trust_interval:    DEFAULT_PEER_TRUST_INTERVAL_DURATION,
-            peer_trust_max_history: DEFAULT_PEER_TRUST_MAX_HISTORY_DURATION,
-            peer_fatal_ban:         DEFAULT_PEER_FATAL_BAN_DURATION,
-            peer_soft_ban:          DEFAULT_PEER_SOFT_BAN_DURATION,
-            same_ip_conn_limit:     DEFAULT_SAME_IP_CONN_LIMIT,
-            inbound_conn_limit:     DEFAULT_INBOUND_CONN_LIMIT,
+            bootstraps:          Default::default(),
+            allowlist:           Default::default(),
+            allowlist_only:      false,
+            enable_save_restore: false,
+            peer_store_path:     PathBuf::from(DEFAULT_PEER_DAT_FILE.to_owned()),
+            inbound_conn_limit:  DEFAULT_INBOUND_CONN_LIMIT,
 
             secio_keypair: SecioKeyPair::secp256k1_generated(),
 
-            ping_interval:           Duration::from_secs(DEFAULT_PING_INTERVAL),
-            ping_timeout:            Duration::from_secs(DEFAULT_PING_TIMEOUT),
-            discovery_sync_interval: Duration::from_secs(DEFAULT_DISCOVERY_SYNC_INTERVAL),
-
-            peer_manager_heart_beat_interval: peer_manager_hb_interval,
-            heart_beat_interval:              Duration::from_secs(DEFAULT_SELF_HEART_BEAT_INTERVAL),
+            ping_interval: Duration::from_secs(DEFAULT_PING_INTERVAL),
+            ping_timeout:  Duration::from_secs(DEFAULT_PING_TIMEOUT),
 
             rpc_timeout: Duration::from_secs(DEFAULT_RPC_TIMEOUT),
         }
@@ -214,12 +172,6 @@ impl NetworkConfig {
 
     pub fn ping_timeout(mut self, timeout: u64) -> Self {
         self.ping_timeout = Duration::from_secs(timeout);
-
-        self
-    }
-
-    pub fn discovery_sync_interval(mut self, interval: u64) -> Self {
-        self.discovery_sync_interval = Duration::from_secs(interval);
 
         self
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR remove useless config in network config

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [x] v3 Core Tests
