### PR TITLE
perf: reduce load peer store cost

### DIFF
--- a/core/network/src/peer_manager/peer_store/peer_store_db.rs
+++ b/core/network/src/peer_manager/peer_store/peer_store_db.rs
@@ -79,7 +79,7 @@ impl PeerStore {
                 )
             })
             .and_then(|file| {
-                Manager::load(file).map_err(|err| {
+                Manager::load(std::io::BufReader::new(file)).map_err(|err| {
                     error!(
                         "Failed to load AddrManager db, file: {:?}, error: {:?}",
                         addr_manager_path, err
@@ -96,7 +96,7 @@ impl PeerStore {
                 )
             })
             .and_then(|file| {
-                BanList::load(file).map_err(|err| {
+                BanList::load(std::io::BufReader::new(file)).map_err(|err| {
                     error!(
                         "Failed to load BanList db, file: {:?}, error: {:?}",
                         ban_list_path, err


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR uses readbuf to reduce io cost

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
