### PR TITLE
fix: fix block id decode

### DIFF
--- a/core/api/src/jsonrpc/web3_types.rs
+++ b/core/api/src/jsonrpc/web3_types.rs
@@ -438,10 +438,16 @@ impl<'a> Visitor<'a> for BlockIdVisitor {
                     }
                     "blockHash" => {
                         let value: String = visitor.next_value()?;
-                        if value.len() != 32 {
+                        let raw_value = Hex::decode(value.clone())
+                            .map_err(|e| Error::custom(format!("Invalid hex code: {}", e)))?;
+                        if raw_value.len() != 32 {
                             return Err(Error::custom(format!("Invalid block hash: {}", value)));
+                        } else {
+                            let mut v = [0u8; 32];
+                            v.copy_from_slice(&raw_value);
+                            block_hash = Some(v.into());
+                            break;
                         }
-                        block_hash = Some(H256::from_slice(value.as_bytes()))
                     }
                     key => return Err(Error::custom(format!("Unknown key: {}", key))),
                 },


### PR DESCRIPTION


**What this PR does / why we need it**:

This PR fix H256 decode from hex.

ref: https://github.com/paritytech/parity-common/blob/master/primitive-types/impls/serde/src/lib.rs#L59-L85

**Which issue(s) this PR fixes**:

Fixes #1228 

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
