### PR TITLE
ci: enhance axon start test check

### DIFF
--- a/.github/workflows/axon-start-with-short-genesis.yml
+++ b/.github/workflows/axon-start-with-short-genesis.yml
@@ -37,9 +37,13 @@ jobs:
           docker-compose ps -a
           sleep 700
           set +e
-          result=$(tail -n 100 logs1/axon.log | grep 'state goto new height 200')
+          result_axon1=$(tail -n 100 logs1/axon.log | grep 'state goto new height 200')
+          result_axon2=$(tail -n 100 logs2/axon.log | grep 'state goto new height 200')
+          result_axon3=$(tail -n 100 logs3/axon.log | grep 'state goto new height 200')
+          result_axon4=$(tail -n 100 logs4/axon.log | grep 'state goto new height 200')
+
           docker-compose down
-          if [[ "$result" != "" ]]
+          if [[ "$result_axon1" != ""  ||  $result_axon2 != ""  ||  $result_axon3 != ""   ||  $result_axon4 != "" ]]
           then
               echo "axon chain works well"
           else


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
