### PR TITLE
fix(API): add latest parameter for BlockId type

### DIFF
--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -29,11 +29,7 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
                     .get_block_by_number(Context::new(), Some(num.as_u64()))
                     .await
             }
-            BlockId::Latest => {
-                self.adapter
-                    .get_block_by_number(Context::new(), None)
-                    .await
-            }
+            BlockId::Latest => self.adapter.get_block_by_number(Context::new(), None).await,
             _ => return Err(Error::InvalidRequestId),
         }
         .map_err(|e| Error::Custom(e.to_string()))?;

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -29,6 +29,11 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
                     .get_block_by_number(Context::new(), Some(num.as_u64()))
                     .await
             }
+            BlockId::Latest => {
+                self.adapter
+                    .get_block_by_number(Context::new(), None)
+                    .await
+            }
             _ => return Err(Error::InvalidRequestId),
         }
         .map_err(|e| Error::Custom(e.to_string()))?;


### PR DESCRIPTION
add parameter `latest` so that function `get_block_by_id` could get the latest header

<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
