### PR TITLE
fix: r/s should be quantities in json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,6 +1626,7 @@ dependencies = [
  "core-consensus",
  "core-executor",
  "core-interoperation",
+ "either",
  "json",
  "jsonrpsee",
  "log",
@@ -2288,6 +2289,9 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"

--- a/core/api/Cargo.toml
+++ b/core/api/Cargo.toml
@@ -23,7 +23,7 @@ common-config-parser = { path = "../../common/config-parser" }
 core-consensus = { path = "../../core/consensus" }
 core-executor = { path = "../../core/executor" }
 core-interoperation ={ path = "../../core/interoperation" }
-either = { version = "1.8.1", features = ["serde"] }
+either = { version = "1.8", features = ["serde"] }
 protocol = { path = "../../protocol", package = "axon-protocol" }
 
 [dev-dependencies]

--- a/core/api/Cargo.toml
+++ b/core/api/Cargo.toml
@@ -23,6 +23,7 @@ common-config-parser = { path = "../../common/config-parser" }
 core-consensus = { path = "../../core/consensus" }
 core-executor = { path = "../../core/executor" }
 core-interoperation ={ path = "../../core/interoperation" }
+either = { version = "1.8.1", features = ["serde"] }
 protocol = { path = "../../protocol", package = "axon-protocol" }
 
 [dev-dependencies]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

At least for eth sig, r/s should be quantities for spec conformance and better compatibility with various JSONRPC clients.

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
