### PR TITLE
fix: writing version atomically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,6 +1649,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -6377,15 +6378,16 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -9,6 +9,7 @@ clap = "4.2"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tempfile = "3.6"
 
 common-config-parser = { path = "../../common/config-parser" }
 common-logger = { path = "../../common/logger" }

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -114,8 +114,12 @@ fn atomic_write(p: &Path, content: &[u8]) -> std::io::Result<()> {
 
     let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
     tmp.as_file_mut().write_all(content)?;
-    let f = tmp.persist(p)?;
-    f.sync_all()?;
+    // https://stackoverflow.com/questions/7433057/is-rename-without-fsync-safe
+    tmp.as_file_mut().sync_all()?;
+    tmp.persist(p)?;
+    let parent = std::fs::OpenOptions::new().read(true).open(parent)?;
+    parent.sync_all()?;
+
     Ok(())
 }
 

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -1,5 +1,4 @@
-use std::fs::File;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{self, Write};
 use std::path::Path;
 
 use clap::builder::{IntoResettable, Str};
@@ -73,34 +72,51 @@ impl AxonCli {
             std::fs::create_dir_all(&config.data_path).unwrap();
         }
 
-        let f_path = config.data_path_for_version();
-        let mut f = File::options()
-            .create(true)
-            .read(true)
-            .write(true)
-            .open(f_path)
-            .unwrap();
-
-        let mut ver_str = String::new();
-        f.read_to_string(&mut ver_str).unwrap();
-
-        if ver_str.is_empty() {
-            return f.write_all(self.version.to_string().as_bytes()).unwrap();
-        }
-
-        let prev_version = Version::parse(&ver_str).unwrap();
-        if prev_version < latest_compatible_version() {
-            println!(
-                "The previous version {:?} is not compatible with the current version {:?}",
-                prev_version, self.version
-            );
-            std::process::exit(0);
-        }
-
-        f.seek(SeekFrom::Start(0)).unwrap();
-        f.write_all(self.version.to_string().as_bytes()).unwrap();
-        f.sync_all().unwrap();
+        check_version(
+            &config.data_path_for_version(),
+            &self.version,
+            &latest_compatible_version(),
+        );
     }
+}
+
+fn check_version(p: &Path, current: &Version, least_compatible: &Version) {
+    let ver_str = match std::fs::read_to_string(p) {
+        Ok(x) => x,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => "".into(),
+        Err(e) => panic!("failed to read version: {e}"),
+    };
+
+    if ver_str.is_empty() {
+        return atomic_write(p, current.to_string().as_bytes()).unwrap();
+    }
+
+    let prev_version = Version::parse(&ver_str).unwrap();
+    if prev_version < *least_compatible {
+        panic!(
+            "The previous version {} is not compatible with the current version {}",
+            prev_version, current
+        );
+    }
+    atomic_write(p, current.to_string().as_bytes()).unwrap();
+}
+
+/// Write content to p atomically. Create the parent directory if it doesn't
+/// already exist.
+///
+/// # Panics
+///
+/// if p.parent() is None.
+fn atomic_write(p: &Path, content: &[u8]) -> std::io::Result<()> {
+    let parent = p.parent().unwrap();
+
+    std::fs::create_dir_all(parent)?;
+
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    tmp.as_file_mut().write_all(content)?;
+    let f = tmp.persist(p)?;
+    f.sync_all()?;
+    Ok(())
 }
 
 fn latest_compatible_version() -> Version {
@@ -118,4 +134,37 @@ fn register_log(config: &Config) {
         config.logger.file_size_limit,
         config.logger.modules_level.clone(),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[test]
+    fn test_check_version() {
+        let tmp = NamedTempFile::new().unwrap();
+        let p = tmp.path();
+        // We just want NamedTempFile to delete the file on drop. We want to
+        // start with the file not exist.
+        std::fs::remove_file(p).unwrap();
+
+        let least_compatible = "0.1.0-alpha.9".parse().unwrap();
+
+        check_version(p, &"0.1.15".parse().unwrap(), &least_compatible);
+        assert_eq!(std::fs::read_to_string(p).unwrap(), "0.1.15");
+
+        check_version(p, &"0.2.0".parse().unwrap(), &least_compatible);
+        assert_eq!(std::fs::read_to_string(p).unwrap(), "0.2.0");
+    }
+
+    #[should_panic = "The previous version"]
+    #[test]
+    fn test_check_version_failure() {
+        let tmp = NamedTempFile::new().unwrap();
+        let p = tmp.path();
+        check_version(p, &"0.1.0".parse().unwrap(), &"0.1.0".parse().unwrap());
+        check_version(p, &"0.2.0".parse().unwrap(), &"0.2.0".parse().unwrap());
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

To avoid partial writes. This also fixes the problem that the file isn't truncated when writing the current version, so part of the previous version might be left in the file.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
