### PR TITLE
feat: add get proposal by number rpc method

### DIFF
--- a/core/api/src/jsonrpc/mod.rs
+++ b/core/api/src/jsonrpc/mod.rs
@@ -11,7 +11,9 @@ use jsonrpsee::{core::Error, proc_macros::rpc};
 
 use common_config_parser::types::Config;
 use protocol::traits::APIAdapter;
-use protocol::types::{Block, CkbRelatedInfo, Hash, Hex, Metadata, Proof, H160, H256, U256};
+use protocol::types::{
+    Block, CkbRelatedInfo, Hash, Hex, Metadata, Proof, Proposal, H160, H256, U256,
+};
 use protocol::ProtocolResult;
 
 use crate::jsonrpc::web3_types::{
@@ -214,6 +216,9 @@ pub trait AxonRpc {
 
     #[method(name = "axon_getMetadataByNumber")]
     async fn get_metadata_by_number(&self, block_number: U256) -> RpcResult<Metadata>;
+
+    #[method(name = "axon_getProposalByNumber")]
+    async fn get_proposal_by_number(&self, block_number: U256) -> RpcResult<Proposal>;
 
     #[method(name = "axon_getCurrentMetadata")]
     async fn get_current_metadata(&self) -> RpcResult<Metadata>;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR add `get_proposal_by_number` rpc method.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
