### PR TITLE
feat: improve cli error handling and add git commit info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 name = "axon"
 version = "0.1.0-beta.1"
 dependencies = [
+ "anyhow",
  "axon-protocol",
  "clap 4.2.7",
  "core-api",
@@ -1641,6 +1642,7 @@ dependencies = [
 name = "core-cli"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axon-protocol",
  "clap 4.2.7",
  "common-config-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,6 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 name = "axon"
 version = "0.1.0-beta.1"
 dependencies = [
- "anyhow",
  "axon-protocol",
  "clap 4.2.7",
  "core-api",
@@ -1642,7 +1641,6 @@ dependencies = [
 name = "core-cli"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "axon-protocol",
  "clap 4.2.7",
  "common-config-parser",
@@ -1652,6 +1650,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 repository = "https://github.com/axonweb3/axon"
 
 [dependencies]
+anyhow = "1.0"
 clap = { version = "4.2", features = ["cargo"] }
 
 # byzantine = { path = "./byzantine" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 repository = "https://github.com/axonweb3/axon"
 
 [dependencies]
-anyhow = "1.0"
 clap = { version = "4.2", features = ["cargo"] }
 
 # byzantine = { path = "./byzantine" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let desc = std::process::Command::new("git")
+        .args(["describe", "--always", "--dirty", "--exclude", "*"])
+        .output()
+        .ok()
+        .and_then(|r| String::from_utf8(r.stdout).ok())
+        .map(|d| format!(" {d}"))
+        .unwrap_or_default();
+    println!("cargo:rustc-env=AXON_GIT_DESCRIPTION={desc}");
+}

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"
 clap = "4.2"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
 clap = "4.2"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.6"
+thiserror = "1.0"
 
 common-config-parser = { path = "../../common/config-parser" }
 common-logger = { path = "../../common/logger" }

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -2,7 +2,6 @@ use std::io::{self, Write};
 use std::path::Path;
 
 use anyhow::{anyhow, bail, Context as _, Result};
-use clap::builder::{IntoResettable, Str};
 use clap::{Arg, ArgMatches, Command};
 use semver::Version;
 
@@ -16,9 +15,9 @@ pub struct AxonCli {
 }
 
 impl AxonCli {
-    pub fn init(ver: impl IntoResettable<Str>) -> Self {
+    pub fn init(axon_version: Version, cli_version: &'static str) -> Self {
         let matches = Command::new("axon")
-            .version(ver)
+            .version(cli_version)
             .arg(
                 Arg::new("config_path")
                     .short('c')
@@ -38,7 +37,7 @@ impl AxonCli {
             .subcommand(Command::new("run").about("Run axon process"));
 
         AxonCli {
-            version: Version::parse(matches.get_version().unwrap()).unwrap(),
+            version: axon_version,
             matches: matches.get_matches(),
         }
     }

--- a/examples/custom_chain.rs
+++ b/examples/custom_chain.rs
@@ -49,5 +49,5 @@ impl KeyProvider for CustomKey {
 }
 
 fn main() -> anyhow::Result<()> {
-    axon::run(CustomFeeAllocator::default(), CustomKey::default())
+    axon::run(CustomFeeAllocator::default(), CustomKey::default(), "0.1.0")
 }

--- a/examples/custom_chain.rs
+++ b/examples/custom_chain.rs
@@ -48,6 +48,10 @@ impl KeyProvider for CustomKey {
     }
 }
 
-fn main() -> anyhow::Result<()> {
-    axon::run(CustomFeeAllocator::default(), CustomKey::default(), "0.1.0")
+fn main() {
+    let result = axon::run(CustomFeeAllocator::default(), CustomKey::default(), "0.1.0");
+    if let Err(e) = result {
+        eprintln!("Error {e}");
+        std::process::exit(1);
+    }
 }

--- a/examples/custom_chain.rs
+++ b/examples/custom_chain.rs
@@ -48,6 +48,6 @@ impl KeyProvider for CustomKey {
     }
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     axon::run(CustomFeeAllocator::default(), CustomKey::default())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,9 @@ use core_executor::FEE_ALLOCATOR;
 pub fn run(
     fee_allocator: impl FeeAllocate + 'static,
     key_provider: impl KeyProvider,
+    cli_version: &'static str,
 ) -> anyhow::Result<()> {
     FEE_ALLOCATOR.swap(Arc::new(Box::new(fee_allocator)));
-    AxonCli::init(clap::crate_version!()).start_with_custom_key_provider(Some(key_provider))
+    AxonCli::init(clap::crate_version!().parse().unwrap(), cli_version)
+        .start_with_custom_key_provider(Some(key_provider))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,10 @@ use std::sync::Arc;
 use core_cli::AxonCli;
 use core_executor::FEE_ALLOCATOR;
 
-pub fn run(fee_allocator: impl FeeAllocate + 'static, key_provider: impl KeyProvider) {
+pub fn run(
+    fee_allocator: impl FeeAllocate + 'static,
+    key_provider: impl KeyProvider,
+) -> anyhow::Result<()> {
     FEE_ALLOCATOR.swap(Arc::new(Box::new(fee_allocator)));
-    AxonCli::init(clap::crate_version!()).start_with_custom_key_provider(Some(key_provider));
+    AxonCli::init(clap::crate_version!()).start_with_custom_key_provider(Some(key_provider))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,14 @@ pub use protocol::{
 
 use std::sync::Arc;
 
-use core_cli::AxonCli;
+use core_cli::{AxonCli, Result};
 use core_executor::FEE_ALLOCATOR;
 
 pub fn run(
     fee_allocator: impl FeeAllocate + 'static,
     key_provider: impl KeyProvider,
     cli_version: &'static str,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     FEE_ALLOCATOR.swap(Arc::new(Box::new(fee_allocator)));
     AxonCli::init(clap::crate_version!().parse().unwrap(), cli_version)
         .start_with_custom_key_provider(Some(key_provider))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use core_cli::AxonCli;
 
-fn main() {
-    AxonCli::init(clap::crate_version!()).start();
+fn main() -> anyhow::Result<()> {
+    AxonCli::init(clap::crate_version!()).start()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,13 @@
 use core_cli::AxonCli;
 
-fn main() -> anyhow::Result<()> {
-    AxonCli::init(
+fn main() {
+    let result = AxonCli::init(
         clap::crate_version!().parse().unwrap(),
         concat!(clap::crate_version!(), env!("AXON_GIT_DESCRIPTION")),
     )
-    .start()
+    .start();
+    if let Err(e) = result {
+        eprintln!("Error {e}");
+        std::process::exit(1);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,9 @@
 use core_cli::AxonCli;
 
 fn main() -> anyhow::Result<()> {
-    AxonCli::init(clap::crate_version!()).start()
+    AxonCli::init(
+        clap::crate_version!().parse().unwrap(),
+        concat!(clap::crate_version!(), env!("AXON_GIT_DESCRIPTION")),
+    )
+    .start()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

* It's hard to read errors displayed with `unwrap` and `Debug`:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Deserialize(Error { inner: Error { inner: TomlError { message: "invalid type: map, expected a string", original: Some("# crypto\nis_force_read_only = true\n\nprivkey = \"0x37aa0f893d05914a4def0460c0a984d3611546cfb26924d7a7ca6e0db9950a2d\"\n\n# db config\ndata_path = \"./devtools/chain/data\"\n\ncrosschain_contract_address = \"0xb9dc8bde1db42410d304b5e78c2ff843134e15e0\"\nwckb_contract_address = \"0xa13763691970d9373d4fab7cc323d7ba06fa9986\"\n\n[[accounts]]\naddress = \"0xa0ee7a142d267c1f36714e4a8f75612f20a79720\"\nbalance = \"04ee2d6d415b85acef8100000000\"\n\n[[accounts]]\naddress = \"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266\"\nbalance = \"04ee2d6d415b85acef8100000000\"\n\n[[accounts]]\naddress = \"0x70997970C51812dc3A010C7d01b50e0d17dc79C8\"\nbalance = \"04ee2d6d415b85acef8100000000\"\n\n[[accounts]]\naddress = \"0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC\"\nbalance = \"04ee2d6d415b85acef8100000000\"\n\n[[accounts]]\naddress = \"0x90F79bf6EB2c4f870365E785982E1f101E93b906\"\nbalance = \"04ee2d6d415b85acef8100000000\"\n\n[[accounts]]\naddress = \"0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65\"\nbalance = \"04ee2d6d415b85acef8100000000\"\n\n[[accounts]]\naddress = \"0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc\"\nbalance = \"04ee2d6d415b85acef8100000000\"\n\n[[accounts]]\naddress = \"0x976EA74026E726554dB657fA54763abd0C3a0aa9\"\nbalance = \"04ee2d6d415b85acef8100000000\"\n\n[[accounts]]\naddress = \"0x14dC79964da2C08b23698B3D3cc7Ca32193d9955\"\nbalance = \"04ee2d6d415b85acef8100000000\"\n\n[[accounts]]\naddress = \"0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f\"\nbalance = \"04ee2d6d415b85acef8100000000\"\n\n[rpc]\nhttp_listening_address = \"0.0.0.0:8000\"\nws_listening_address = \"0.0.0.0:8010\"\nmaxconn = 25000\nmax_payload_size = 10485760\nclient_version = \"0.1.0\"\ngas_cap = 50_000_000\n\n[network]\nlistening_address = \"/ip4/0.0.0.0/tcp/8001\"\nrpc_timeout = 10\n\n[consensus]\nsync_txs_chunk_size = 5000\n\n[[network.bootstraps]]\nmulti_address = \"/ip4/13.41.118.235/tcp/8001/p2p/QmNk6bBwkLPuqnsrtxpp819XLZY3ymgjs3p1nKtxBVgqxj\"\n\n[mempool]\ntimeout_gap = 20\npool_size = 50000\nbroadcast_txs_size = 200\nbroadcast_txs_interval = 200\n\n[executor]\nlight = false\ntriedb_cache_size = 2000\n\n[logger]\nfilter = \"info\"\nlog_to_console = true\nconsole_show_file_and_line = false\nlog_path = \"logs/\"\nlog_to_file = true\nfile_size_limit = 1073741824 # 1 GiB\nmetrics = true\n# you can specify log level for modules with config below\n# modules_level = { \"overlord::state::process\" = \"debug\", core_consensus = \"error\" }\n\n[rocksdb]\nmax_open_files = 64\ncache_size = 1000\n# Provide an options file to tune RocksDB for your workload and your system configuration.\n# More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).\noptions_file = \"default.db-options\"\n\n[jaeger]\nservice_name = \"axon\"\ntracing_address = \"127.0.0.1:6831\"\ntracing_batch_size = 50\n\n[prometheus]\nlistening_address = \"0.0.0.0:8100\"\n\nis_force_read_only = true\n"), keys: ["accounts"], span: Some(310..418) } } })', core/cli/src/lib.rs:42:65
```

Now it's:

```
Error: parsing config file

Caused by:
    TOML parse error at line 1, column 1
      |
    1 | # crypto
      | ^^^^^^^^
    missing field `web3`
```

* Git commit hash is added to cli version info. It's hard to know from which commit a binary is built otherwise.

```command
$ axon --version
axon 0.1.0-beta.1 4d126a2
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
