### PR TITLE
fix(cli): the sub-command is useless

### DIFF
--- a/.github/workflows/openzeppelin_test_11.yml
+++ b/.github/workflows/openzeppelin_test_11.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           cargo build
           rm -rf ./devtools/chain/data
-          ./target/debug/axon --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
+          ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
 
       - name: Run prepare
         id: runtest

--- a/.github/workflows/openzeppelin_test_16_19.yml
+++ b/.github/workflows/openzeppelin_test_16_19.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           cargo build
           rm -rf ./devtools/chain/data
-          ./target/debug/axon --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
+          ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
 
       - name: Run prepare
         id: runtest

--- a/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
+++ b/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           cargo build
           rm -rf ./devtools/chain/data
-          ./target/debug/axon --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
+          ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
 
       - name: Run prepare
         id: runtest

--- a/.github/workflows/openzeppelin_test_6_10.yml
+++ b/.github/workflows/openzeppelin_test_6_10.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           cargo build
           rm -rf ./devtools/chain/data
-          ./target/debug/axon --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
+          ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
       - name: Run prepare
         id: runtest
         run: |

--- a/.github/workflows/v3_core_test.yml
+++ b/.github/workflows/v3_core_test.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           cargo build
           rm -rf ./devtools/chain/data
-          ./target/debug/axon --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
+          ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
       - name: Install dependencies
         run: |
           cd /home/runner/work/axon/axon/v3-core

--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           cargo build
           rm -rf ./devtools/chain/data
-          ./target/debug/axon --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
+          ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
       - name: Run Test
         run: |
           cd /home/runner/work/axon/axon/axon-test
@@ -176,7 +176,7 @@ jobs:
         run: |
           cargo build
           rm -rf ./devtools/chain/data
-          ./target/debug/axon --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
+          ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
       - name: Run Test
         run: |
           cd /home/runner/work/axon/axon/axon-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,6 @@ RUN set -eux; \
 COPY --from=builder /build/target/release/axon /app/axon
 COPY --from=builder /build/devtools /app/devtools
 
-CMD ./axon -c=/app/devtools/chain/config.toml -g=/app/devtools/chain/genesis_single_node.json
+CMD ./axon run -c=/app/devtools/chain/config.toml -g=/app/devtools/chain/genesis_single_node.json
 
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ e2e-test-lint:
 e2e-test:
 	cargo build
 	rm -rf ./devtools/chain/data
-	./target/debug/axon --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
+	./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
 	cd tests/e2e && yarn
 	cd tests/e2e/src && yarn exec http-server &
 	cd tests/e2e && yarn exec wait-on -t 5000 tcp:8000 && yarn exec wait-on -t 5000 tcp:8080 && yarn test
@@ -73,7 +73,7 @@ e2e-test:
 e2e-test-ci:
 	cargo build
 	rm -rf ./devtools/chain/data
-	./target/debug/axon --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
+	./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
 	cd tests/e2e && yarn
 	cd tests/e2e/src && yarn exec http-server &
 	cd tests/e2e && yarn exec wait-on -t 5000 tcp:8000 && yarn exec wait-on -t 5000 tcp:8080 && HEADLESS=true yarn test

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Openness and mobility are the foundation of social development, so is blockchain
 
 ### Staking on Layer 1 CKB
 
-Axon supports a Proof-of-Stake (PoS) consensus mechanism and requires each Axon-based appchain to issue native Extensible User Defined Tokens (xUDTs), which are designed and customized by the app chain's development team and released on CKB. For simplicity, the xUDTs on Axon-based chains are referred to as Axon tokens (AT tokens) below. Holders of AT tokens can stake to become validators and/or delegate their tokens to other validators in exchange for rewards. Unlike other sidechains where staking takes place on Layer 2, Axon's staking is grounded on Layer 1 CKB. Validators and other participants stake their native AT tokens on CKB, which uses a Proof-of-Work (PoW) consensus mechanism. This unique staking design helps Axon-based appchains enjoy the highest degree of decentralization and security from Layer 1 while maintain their high performance and sovereignty as independent Layer 2 networks. 
+Axon supports a Proof-of-Stake (PoS) consensus mechanism and requires each Axon-based appchain to issue native Extensible User Defined Tokens (xUDTs), which are designed and customized by the app chain's development team and released on CKB. For simplicity, the xUDTs on Axon-based chains are referred to as Axon tokens (AT tokens) below. Holders of AT tokens can stake to become validators and/or delegate their tokens to other validators in exchange for rewards. Unlike other sidechains where staking takes place on Layer 2, Axon's staking is grounded on Layer 1 CKB. Validators and other participants stake their native AT tokens on CKB, which uses a Proof-of-Work (PoW) consensus mechanism. This unique staking design helps Axon-based appchains enjoy the highest degree of decentralization and security from Layer 1 while maintain their high performance and sovereignty as independent Layer 2 networks.
 
 ## Roadmap
 
@@ -52,7 +52,7 @@ Axon provides the compiled binary on the [release page](`https://github.com/axon
 # Clone from GitHub
 git clone https://github.com/axonweb3/axon.git && cd axon
 # Run release binary for single node
-cargo run --release -- -c devtools/chain/config.toml -g devtools/chain/genesis_single_node.json
+cargo run --release -- run -c devtools/chain/config.toml -g devtools/chain/genesis_single_node.json
 
 ```
 
@@ -81,7 +81,7 @@ The following ways are a great spot to ask questions about Axon:
 
 ## Socials
 
-All Axon related accounts are displayed via [linktree](https://linktr.ee/axonweb3). 
+All Axon related accounts are displayed via [linktree](https://linktr.ee/axonweb3).
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./devtools:/app/devtools
     networks:
       - axon-net
-    command: ./axon -c=/app/devtools/chain/config.toml -g=/app/devtools/chain/genesis_single_node.json
+    command: ./axon run -c=/app/devtools/chain/config.toml -g=/app/devtools/chain/genesis_single_node.json
 
 
 networks:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the useless sub-command `run`.

Currently, no matter the sub-command is provided or not, the `axon` always runs.

I fix this so that I could add more sub-commands later.

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Chaos CI
- [x] Cargo Clippy
- [x] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
