### PR TITLE
fix(consensus): correct receipts root

### DIFF
--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -158,7 +158,10 @@ impl Executor for AxonExecutor {
             gas += r.gas_used;
             fee = fee.checked_add(r.fee_cost).unwrap_or(U256::max_value());
 
-            hashes.push(Hasher::digest(&r.ret));
+            let logs_bloom = logs_bloom(r.logs.iter());
+            let receipt = tx.encode_receipt(&r, logs_bloom);
+
+            hashes.push(Hasher::digest(&receipt));
             res.push(r);
         }
 
@@ -354,7 +357,10 @@ impl AxonExecutor {
             gas += r.gas_used;
             fee = fee.checked_add(r.fee_cost).unwrap_or(U256::max_value());
 
-            hashes.push(Hasher::digest(&r.ret));
+            let logs_bloom = logs_bloom(r.logs.iter());
+            let receipt = tx.encode_receipt(&r, logs_bloom);
+
+            hashes.push(Hasher::digest(&receipt));
             res.push(r);
         }
 

--- a/core/run/src/tests.rs
+++ b/core/run/src/tests.rs
@@ -27,7 +27,7 @@ const GENESIS_HASH: &str = "0x69eca8420bb4b072d732db96260a656f0e10201c6841b215a8
 const GENESIS_STATE_ROOT: &str =
     "0x65f57a6a666e656de33ed68957e04b35b3fe1b35a90f6eafb6f283c907dc3d77";
 const GENESIS_RECEIPTS_ROOT: &str =
-    "0x0abcdb8fd7acc8c71f28a16c3095fdafca0171f371076650152b1c356a1bccad";
+    "0x8544b530238201f1620b139861a6841040b37f78f8bdae8736ef5cec474e979b";
 
 #[test]
 fn decode_genesis() {

--- a/protocol/src/types/transaction.rs
+++ b/protocol/src/types/transaction.rs
@@ -7,7 +7,10 @@ use serde::{Deserialize, Serialize};
 
 use common_crypto::secp256k1_recover;
 
-use crate::types::{Bytes, BytesMut, Hash, Hasher, Public, TypesError, H160, H256, H520, U256};
+use crate::types::{
+    Bloom, Bytes, BytesMut, ExitReason, Hash, Hasher, Public, TxResp, TypesError, H160, H256, H520,
+    U256,
+};
 use crate::ProtocolResult;
 
 pub const GAS_PER_ZERO_BYTE: u64 = 4;
@@ -467,6 +470,49 @@ impl SignedTransaction {
 
     pub fn get_to(&self) -> Option<H160> {
         self.transaction.unsigned.to()
+    }
+
+    /// Encode a transaction receipt into bytes.
+    ///
+    /// According to [`EIP-2718`]:
+    /// - `Receipt` is either `TransactionType || ReceiptPayload` or
+    ///   `LegacyReceipt`.
+    /// - `LegacyReceipt` is kept to be RLP encoded bytes; it is `rlp([status,
+    ///   cumulativeGasUsed, logsBloom, logs])`.
+    /// - `ReceiptPayload` is an opaque byte array whose interpretation is
+    ///   dependent on the `TransactionType` and defined in future EIPs.
+    ///   - As [`EIP-2930`] defined: if `TransactionType` is `1`,
+    ///     `ReceiptPayload` is `rlp([status, cumulativeGasUsed, logsBloom,
+    ///     logs])`.
+    ///   - As [`EIP-1559`] defined: if `TransactionType` is `2`,
+    ///     `ReceiptPayload` is `rlp([status, cumulative_transaction_gas_used,
+    ///     logs_bloom, logs])`.
+    ///
+    /// [`EIP-2718`]: https://eips.ethereum.org/EIPS/eip-2718#receipts
+    /// [`EIP-2930`]: https://eips.ethereum.org/EIPS/eip-2930#parameters
+    /// [`EIP-1559`]: https://eips.ethereum.org/EIPS/eip-1559#specification
+    pub fn encode_receipt(&self, r: &TxResp, logs_bloom: Bloom) -> Bytes {
+        // Status: either 1 (success) or 0 (failure).
+        // Only present after activation of [EIP-658](https://eips.ethereum.org/EIPS/eip-658)
+        let status: u64 = if matches!(r.exit_reason, ExitReason::Succeed(_)) {
+            1
+        } else {
+            0
+        };
+        let used_gas = U256::from(r.gas_used);
+        let legacy_receipt = {
+            let mut rlp = RlpStream::new();
+            rlp.begin_list(4);
+            rlp.append(&status);
+            rlp.append(&used_gas);
+            rlp.append(&logs_bloom);
+            rlp.append_list(&r.logs);
+            rlp.out().freeze()
+        };
+        match self.type_() {
+            x if x == 0x01 || x == 0x02 => [&x.to_be_bytes()[7..], &legacy_receipt].concat().into(),
+            _ => legacy_receipt, // legacy (0x00) or undefined type
+        }
     }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will fix the incorrect receipts root.

**Which issue(s) this PR fixes**:

- Fixes #1258 
- Fixes #1260

**Which toolchain this PR adaption**:

Breaking Change:
- Receipts root for all blocks are changed.

**Special notes for your reviewer**:

This PR should be released with the `migrate` sub-command together, which will push request later.

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
