### PR TITLE
[WIP] feat(cli): add a sub-command to migrate the database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,6 +1591,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "unicode-width",
  "windows-sys 0.42.0",
 ]
 
@@ -1845,6 +1846,7 @@ dependencies = [
  "common-crypto",
  "common-logger",
  "common-memory-tracker",
+ "console 0.15.5",
  "core-api",
  "core-consensus",
  "core-executor",
@@ -1854,6 +1856,7 @@ dependencies = [
  "core-rpc-client",
  "core-storage",
  "futures",
+ "indicatif",
  "log",
  "rlp",
  "serde",

--- a/core/run/Cargo.toml
+++ b/core/run/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 
 [dependencies]
 backtrace = "0.3"
+console = "0.15"
 futures = "0.3"
+indicatif = "0.16"
 log = "0.4"
 rlp = "0.5"
 serde = "1.0"

--- a/core/run/src/migrate.rs
+++ b/core/run/src/migrate.rs
@@ -1,0 +1,74 @@
+use std::cmp::Ordering;
+use std::sync::Arc;
+
+use common_config_parser::types::Config;
+use core_storage::{
+    adapter::rocks::{ReadOnlyRocksAdapter, RocksAdapter},
+    ImplStorage,
+};
+use protocol::{traits::VersionedStorage, types::RichBlock};
+
+use crate::{migrations, MainError};
+
+const INIT_DB_VERSION: &str = "20230706050403";
+
+/// A helper struct for migrations.
+pub struct Migrate {
+    migrations: migrations::Migrations,
+}
+
+impl Migrate {
+    /// Constructs a new struct.
+    pub fn new() -> Self {
+        let mut migrations = migrations::Migrations::new();
+        migrations.push(Box::new(migrations::DefaultMigration::new(INIT_DB_VERSION)));
+        Self { migrations }
+    }
+
+    /// Check if database's version is matched with the executable binary
+    /// version.
+    pub fn check(&self, adapter: &ReadOnlyRocksAdapter) -> Result<Ordering, MainError> {
+        self.migrations
+            .check(adapter)
+            .map_err(|err| MainError::Other(err.to_string()))
+    }
+
+    /// Whether there is any migration requires confirmation from users.
+    pub fn require_confirm(&self, adapter: &ReadOnlyRocksAdapter) -> Result<bool, MainError> {
+        self.migrations
+            .require_confirm(adapter)
+            .map_err(|err| MainError::Other(err.to_string()))
+    }
+
+    /// Displays a note to warning users about the risks before they confirm the
+    /// migration.
+    pub fn notes(&self, adapter: &ReadOnlyRocksAdapter) -> Result<Vec<(&str, &str)>, MainError> {
+        adapter
+            .version()
+            .map_err(|err| MainError::Other(err.to_string()))
+            .map(|ver_opt| self.migrations.notes(ver_opt.as_ref()))
+    }
+
+    /// Initializes version for a database.
+    pub fn initialize_version(
+        &self,
+        adapter: &Arc<ImplStorage<RocksAdapter>>,
+    ) -> Result<(), MainError> {
+        self.migrations
+            .initialize_version(adapter)
+            .map_err(|err| MainError::Other(err.to_string()))
+    }
+
+    /// Migrates the input database.
+    pub async fn migrate(
+        &self,
+        adapter: &Arc<ImplStorage<RocksAdapter>>,
+        config: &Config,
+        genesis: &RichBlock,
+    ) -> Result<(), MainError> {
+        self.migrations
+            .migrate(adapter, config, genesis)
+            .await
+            .map_err(|err| MainError::Other(err.to_string()))
+    }
+}

--- a/core/run/src/migrations/mod.rs
+++ b/core/run/src/migrations/mod.rs
@@ -1,0 +1,242 @@
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use console::Term;
+use core_storage::{
+    adapter::rocks::{ReadOnlyRocksAdapter, RocksAdapter, RocksAdapterError},
+    ImplStorage,
+};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget};
+
+use common_config_parser::types::Config;
+use protocol::{async_trait, traits::VersionedStorage as _, types::RichBlock, ProtocolError};
+
+const NO_VERSION: &str = "00000000000000";
+
+/// A single migration.
+#[async_trait]
+pub trait Migration {
+    /// Applies the current migration.
+    async fn migrate(
+        &self,
+        _storage: &Arc<ImplStorage<RocksAdapter>>,
+        _config: &Config,
+        _genesis: &RichBlock,
+        _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
+    ) -> Result<(), ProtocolError>;
+
+    /// Returns migration version, use `%Y%m%d%H%M%S` format.
+    fn version(&self) -> &str;
+
+    /// Whether current migration will cost a lot of time to perform.
+    fn is_expensive(&self) -> bool;
+
+    /// If there is anything important and users should know it before do
+    /// migration, the put the note here.
+    ///
+    /// For example, if the current migration could corrupt the database
+    /// potentially, this method should return a note to let users know
+    /// that.
+    fn note(&self) -> Option<&str>;
+}
+
+/// A list of migrations that should be performed in order.
+#[derive(Default)]
+pub struct Migrations {
+    migrations: BTreeMap<String, Box<dyn Migration>>,
+}
+
+impl Migrations {
+    /// Creates an empty list of migrations.
+    pub fn new() -> Self {
+        Migrations {
+            migrations: BTreeMap::new(),
+        }
+    }
+
+    /// Adds a migration at the last of current migrations list.
+    pub fn push(&mut self, migration: Box<dyn Migration>) {
+        self.migrations
+            .insert(migration.version().to_string(), migration);
+    }
+
+    /// Check if database's version is matched with the executable binary
+    /// version.
+    ///
+    /// Returns
+    /// - Less: The database version is less than the matched version of the
+    ///   executable binary. Requires migration.
+    /// - Equal: The database version is matched with the executable binary
+    ///   version.
+    /// - Greater: The database version is greater than the matched version of
+    ///   the executable binary. Requires upgrade the executable binary.
+    pub fn check(&self, storage: &ReadOnlyRocksAdapter) -> Result<Ordering, RocksAdapterError> {
+        let status = if let Some(version) = storage.version()? {
+            if let Some(m) = self.migrations.values().last() {
+                version.as_str().cmp(m.version())
+            } else {
+                Ordering::Equal
+            }
+        } else {
+            Ordering::Less
+        };
+        Ok(status)
+    }
+
+    /// Whether there is any migration requires confirmation from users.
+    pub fn require_confirm(
+        &self,
+        storage: &ReadOnlyRocksAdapter,
+    ) -> Result<bool, RocksAdapterError> {
+        let require_confirm = if let Some(version) = storage.version()? {
+            self.migrations
+                .values()
+                .skip_while(|m| m.version() <= version.as_str())
+                .any(|m| m.is_expensive() || m.note().is_some())
+        } else {
+            self.migrations
+                .values()
+                .any(|m| m.is_expensive() || m.note().is_some())
+        };
+        Ok(require_confirm)
+    }
+
+    /// A list of important notes that users should know them before perform
+    /// migrations.
+    pub fn notes(&self, version_opt: Option<&String>) -> Vec<(&str, &str)> {
+        if let Some(version) = version_opt {
+            self.migrations
+                .values()
+                .skip_while(|m| m.version() <= version.as_str())
+                .filter_map(|m| m.note().map(|note| (m.version(), note)))
+                .collect()
+        } else {
+            self.migrations
+                .values()
+                .filter_map(|m| m.note().map(|note| (m.version(), note)))
+                .collect()
+        }
+    }
+
+    async fn run(
+        &self,
+        storage: &Arc<ImplStorage<RocksAdapter>>,
+        current_version: &str,
+        config: &Config,
+        genesis: &RichBlock,
+    ) -> Result<(), ProtocolError> {
+        let mpb = Arc::new(MultiProgress::new());
+        let migrations: Vec<_> = self
+            .migrations
+            .iter()
+            .filter_map(|(v, m)| {
+                if v.as_str() > current_version {
+                    Some(m)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let migrations_count = migrations.len();
+        for (idx, m) in migrations.iter().enumerate() {
+            let mpbc = Arc::clone(&mpb);
+            let pb = move |count: u64| -> ProgressBar {
+                let pb = mpbc.add(ProgressBar::new(count));
+                pb.set_draw_target(ProgressDrawTarget::term(Term::stdout(), None));
+                pb.set_prefix(format!("[{}/{}]", idx + 1, migrations_count));
+                pb
+            };
+            m.migrate(storage, config, genesis, Arc::new(pb)).await?;
+            storage.set_version(m.version())?;
+        }
+        mpb.join_and_clear().map_err(|_| {
+            let errmsg = "failed to let MultiProgress join then clear".to_string();
+            RocksAdapterError::Other(errmsg)
+        })?;
+        Ok(())
+    }
+
+    /// Initializes version for a database.
+    pub fn initialize_version(
+        &self,
+        storage: &Arc<ImplStorage<RocksAdapter>>,
+    ) -> Result<(), RocksAdapterError> {
+        if storage.version()?.is_none() {
+            if let Some(m) = self.migrations.values().last() {
+                storage.set_version(m.version())?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Migrates the input database.
+    pub async fn migrate(
+        &self,
+        storage: &Arc<ImplStorage<RocksAdapter>>,
+        config: &Config,
+        genesis: &RichBlock,
+    ) -> Result<(), ProtocolError> {
+        match storage.version()? {
+            Some(ref v) => {
+                if let Some(m) = self.migrations.values().last() {
+                    if m.version() < v.as_str() {
+                        log::error!(
+                            "Database downgrade detected. \
+                            The database schema version is newer than \
+                            the schema version which the executable file uses,\
+                            please upgrade the executable file to a newer version"
+                        );
+                        let err = RocksAdapterError::other("database downgrade is not supported");
+                        return Err(err.into());
+                    }
+                }
+
+                self.run(storage, v.as_str(), config, genesis).await?;
+                Ok(())
+            }
+            None => {
+                self.run(storage, NO_VERSION, config, genesis).await?;
+                Ok(())
+            }
+        }
+    }
+}
+
+/// A migration which do nothing.
+pub struct DefaultMigration {
+    version: String,
+}
+
+impl DefaultMigration {
+    pub fn new(version: &str) -> Self {
+        Self {
+            version: version.to_owned(),
+        }
+    }
+}
+
+#[async_trait]
+impl Migration for DefaultMigration {
+    async fn migrate(
+        &self,
+        _storage: &Arc<ImplStorage<RocksAdapter>>,
+        _config: &Config,
+        _genesis: &RichBlock,
+        _pb: Arc<dyn Fn(u64) -> ProgressBar + Send + Sync>,
+    ) -> Result<(), ProtocolError> {
+        Ok(())
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+
+    fn is_expensive(&self) -> bool {
+        false
+    }
+
+    fn note(&self) -> Option<&str> {
+        None
+    }
+}

--- a/protocol/src/traits/mod.rs
+++ b/protocol/src/traits/mod.rs
@@ -22,5 +22,5 @@ pub use network::{
 };
 pub use storage::{
     CommonStorage, IntoIteratorByRef, Storage, StorageAdapter, StorageBatchModify, StorageCategory,
-    StorageIterator, StorageSchema,
+    StorageIterator, StorageSchema, VersionedStorage,
 };

--- a/protocol/src/traits/storage.rs
+++ b/protocol/src/traits/storage.rs
@@ -24,6 +24,14 @@ pub trait StorageSchema {
     fn category() -> StorageCategory;
 }
 
+pub trait VersionedStorage {
+    type Error;
+    /// Fetches the version of current storage.
+    fn version(&self) -> Result<Option<String>, Self::Error>;
+    /// Sets the version of current storage.
+    fn set_version(&self, version: &str) -> Result<(), Self::Error>;
+}
+
 pub trait IntoIteratorByRef<S: StorageSchema> {
     fn ref_to_iter<'a, 'b: 'a>(&'b self) -> StorageIterator<'a, S>;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR add a sub-command `migrate` to do migrations on database.

- [An example to show how to add migration.](https://github.com/axonweb3/axon/pull/1302)

- `axon run`
  
  <details><summary>Click HERE to see the flowchart.</summary><br/>
  
  ```mermaid
  flowchart TD
      start[User] --> |axon run| open_ro_db{Open\nReadonly\nStorage}
  
      open_ro_db --> |Failed| init_db[Init Storage with Migration Version]
      init_db --> load_genesis
      open_ro_db --> |Passed| check_db[Check\nStorage\nVersion]
  
      check_db --> |Equal| load_genesis{Load Genesis Block\nfrom Storage}
      check_db --> |Less| old_bin[Executable is Old]
      check_db --> |Greater| new_bin[Executable is New]
  
      old_bin --> exit[Exit with Error]
      new_bin --> check_migrations{Has Break Changes\nor Migrations will be Slow}
  
      check_migrations --> |Yes| require_migration[Ask to Do Migrations]
      require_migration --> exit
      check_migrations --> |No| fast_migrate[Process Fast Migrations]
  
      fast_migrate -->  |Can| load_genesis
      fast_migrate -->  |Can Not| exit
  
      load_genesis --> |Found| check_genesis{Check Genesis}
      load_genesis --> |Not Found| create_genesis[Create Genesis]
  
      check_genesis --> |Failed| different_genesis[User Provide Genesis is\nNot Same as the Storage Version]
      different_genesis --> exit
      check_genesis --> |Passed| run[Run Axon Services]
      create_genesis --> run
  ```
  
  </details>

- `axon migrate` 

  <details><summary>Click HERE to see the flowchart.</summary><br/>

  ```mermaid
  flowchart TD
  
      start[User] --> |axon migrate| open_ro_db{Open\nReadonly\nStorage}
  
      open_ro_db --> |Failed| no_db[Storage Not Found]
      no_db --> exit[Exit]
      open_ro_db --> |Passed| check_db[Check\nStorage\nVersion]
  
      check_db --> |Equal| version_eq[No migrations are required]
      check_db --> |Less| bin_is_old[Executable is Old]
      check_db --> |Greater| bin_is_new[Executable is New]
  
      version_eq --> exit
      bin_is_old --> exit
  
      bin_is_new --> is_force{If User Input --force}
  
      is_force --> |Not| check_migrations{Has Break Changes\nor Migrations will be Slow}
      is_force --> |Yes| do_migrate[Process Migrations] 
  
      check_migrations --> |Yes| require_confirm[Require User Confirmation]
      check_migrations --> |No| do_migrate[Process Migrations]
  
      require_confirm --> try_prompt{Create Interactive Prompt}
  
      try_prompt --> |Passed| display_notes[Display Notes of Current Migration]
      try_prompt --> |Failed| exit
  
      display_notes --> accept_notes{Ask User Accept or Not}
  
      accept_notes --> |Accept| is_more_migrations{Has Next Migration}
      accept_notes --> |Reject| exit
  
      is_more_migrations --> |Yes| display_notes
      is_more_migrations --> |No| last_warning{Told Users\nThe Migrations\nare Slow and\nCannot Restore}
  
      last_warning --> |Reject| exit
      last_warning --> |Accept| do_migrate
      do_migrate --> exit
  ```

  </details>

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests