### PR TITLE
feat(cli): check user provided genesis if not first run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,6 +1859,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tempfile",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "toml 0.7.3",

--- a/core/run/Cargo.toml
+++ b/core/run/Cargo.toml
@@ -12,6 +12,7 @@ rlp = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+tempfile = "3.6"
 toml = "0.7"
 
 common-apm = { path = "../../common/apm" }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR add a feature that:

- Check user provided genesis if not first run (ref: #1275).

  - Also check if the genesis state is changed.

And this PR fixes a potential issue:

- If it's not the first run, the `genesis` in `Axon` struct is incorrect.

  - Because the `state_root` and `receipts_root` will be set to the correct values only when it is the first run.

    - They are set in the method `execute_transactions(..)`:

      https://github.com/axonweb3/axon/blob/1f346175f773433f69082b03e247e2fb85acd00a/core/run/src/lib.rs#L206-L207

    - But if it's not first run, `execute_transactions(..)` will not be called.
 
      https://github.com/axonweb3/axon/blob/1f346175f773433f69082b03e247e2fb85acd00a/core/run/src/lib.rs#L127-L131
      https://github.com/axonweb3/axon/blob/1f346175f773433f69082b03e247e2fb85acd00a/core/run/src/lib.rs#L149

  This is not a bug currently, because these fields are not used.

**Which issue(s) this PR fixes**:

Fixes #1275.

**Which toolchain this PR adaption**:

No Breaking Change

~**Special notes for your reviewer**~:

~Since it has to run a temporary empty chain to generate the genesis state, so it uses temporary directories to create `RocksAdapter` and `RocksTrieDB`.~

~But [`system_contract::init(..)`] sets a global environment variable, so it has to be called with the real path.~

~I am not sure whether it OK or not:~
- ~Could [`system_contract::init(..)`] be called twice?~
- ~Is [`system_contract::init(..)`] sensitive with the height?~
  ~Because the first time it is called, the height will always be `0` after this PR.~

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests


[`system_contract::init(..)`]: https://github.com/axonweb3/axon/blob/1f346175f773433f69082b03e247e2fb85acd00a/core/executor/src/system_contract/mod.rs#L80