### PR TITLE
Fix the permission error in `/run-ci` workflow

### DIFF
--- a/.github/workflows/entry_workflow.yml
+++ b/.github/workflows/entry_workflow.yml
@@ -8,8 +8,13 @@ on:
 jobs:
   test:
     name: from-comments
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/run-ci') &&  github.repository_owner == 'axonweb3'
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/run-ci') && github.repository_owner == 'axonweb3'
     runs-on: ubuntu-20.04
+    # When the permissions key is used, all unspecified permissions are set to no access, with the exception of the metadata scope, which always gets read access.
+    # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: read
+
     steps:
       - name: Query author repository permissions
         uses: octokit/request-action@v2.x
@@ -17,7 +22,7 @@ jobs:
         with:
           route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate axon-bot token
         id: generate_axon_bot_token
         uses: wow-actions/use-app-token@v2


### PR DESCRIPTION
## **What this PR does / why we need it**:

axon-bot doesn't work => Error: Must have push access to view collaborator permission.

- This PR attempts to fix https://github.com/axonweb3/axon/pull/1278#issuecomment-1642054492
- And use a minimum permission of GITHUB_TOKEN according to a good practice.

### **Special notes for your reviewer**:

I think we may avoid using other `Personal Access Token` in this repo later.
If you are thinking _"why should I use the GITHUB_TOKEN instead of my normal PAT?", remember that a Personal Access Token is always available, so if someone is able to steal that PAT they can potentially do some harm.

The GITHUB_TOKEN instead expires just right after the job is over. So even if someone is able to steal it (which is almost impossible), they basically can't do anything wrong.

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**
- [x] Code Format
- [x] Unit Tests
