### PR TITLE
refactor(executor): thread local instead of global variable

### DIFF
--- a/core/api/src/adapter.rs
+++ b/core/api/src/adapter.rs
@@ -3,11 +3,14 @@ use std::sync::Arc;
 use core_executor::{
     system_contract::metadata::MetadataHandle, AxonExecutor, AxonExecutorAdapter, MPTTrie,
 };
+use core_executor::{
+    HEADER_CELL_ROOT_KEY, IMAGE_CELL_CONTRACT_ADDRESS, METADATA_CONTRACT_ADDRESS, METADATA_ROOT_KEY,
+};
 use protocol::traits::{APIAdapter, Context, Executor, ExecutorAdapter, MemPool, Network, Storage};
 use protocol::types::{
     Account, BigEndianHash, Block, BlockNumber, Bytes, CkbRelatedInfo, ExecutorContext, Hash,
-    Header, Metadata, Proposal, Receipt, SignedTransaction, TxResp, H160, MAX_BLOCK_GAS_LIMIT,
-    NIL_DATA, RLP_NULL, U256,
+    Header, Metadata, Proposal, Receipt, SignedTransaction, TxResp, H160, H256,
+    MAX_BLOCK_GAS_LIMIT, NIL_DATA, RLP_NULL, U256,
 };
 use protocol::{async_trait, codec::ProtocolCodec, trie, ProtocolResult};
 
@@ -237,14 +240,51 @@ where
         block_number: Option<u64>,
     ) -> ProtocolResult<Metadata> {
         if let Some(num) = block_number {
-            return MetadataHandle::default().get_metadata_by_block_number(num);
+            return MetadataHandle::new(self.get_metadata_root(ctx).await?)
+                .get_metadata_by_block_number(num);
         }
 
-        let num = self.storage.get_latest_block_header(ctx).await?.number;
-        MetadataHandle::default().get_metadata_by_block_number(num)
+        let num = self
+            .storage
+            .get_latest_block_header(ctx.clone())
+            .await?
+            .number;
+        MetadataHandle::new(self.get_metadata_root(ctx).await?).get_metadata_by_block_number(num)
     }
 
-    async fn get_ckb_related_info(&self, _ctx: Context) -> ProtocolResult<CkbRelatedInfo> {
-        MetadataHandle::default().get_ckb_related_info()
+    async fn get_ckb_related_info(&self, ctx: Context) -> ProtocolResult<CkbRelatedInfo> {
+        MetadataHandle::new(self.get_metadata_root(ctx).await?).get_ckb_related_info()
+    }
+
+    async fn get_image_cell_root(&self, ctx: Context) -> ProtocolResult<H256> {
+        let state_root = self.storage.get_latest_block(ctx).await?.header.state_root;
+        let state_mpt_tree = MPTTrie::from_root(state_root, Arc::clone(&self.trie_db))?;
+        let raw_account = state_mpt_tree
+            .get(IMAGE_CELL_CONTRACT_ADDRESS.as_bytes())?
+            .ok_or_else(|| APIError::Adapter("Can't find this address".to_string()))?;
+
+        let account = Account::decode(raw_account).unwrap();
+        let storage_mpt_tree = MPTTrie::from_root(account.storage_root, Arc::clone(&self.trie_db))?;
+
+        Ok(storage_mpt_tree
+            .get(HEADER_CELL_ROOT_KEY.as_bytes())?
+            .map(|r| H256::from_slice(&r))
+            .unwrap_or_default())
+    }
+
+    async fn get_metadata_root(&self, ctx: Context) -> ProtocolResult<H256> {
+        let state_root = self.storage.get_latest_block(ctx).await?.header.state_root;
+        let state_mpt_tree = MPTTrie::from_root(state_root, Arc::clone(&self.trie_db))?;
+        let raw_account = state_mpt_tree
+            .get(METADATA_CONTRACT_ADDRESS.as_bytes())?
+            .ok_or_else(|| APIError::Adapter("Can't find this address".to_string()))?;
+
+        let account = Account::decode(raw_account).unwrap();
+        let storage_mpt_tree = MPTTrie::from_root(account.storage_root, Arc::clone(&self.trie_db))?;
+
+        Ok(storage_mpt_tree
+            .get(METADATA_ROOT_KEY.as_bytes())?
+            .map(|r| H256::from_slice(&r))
+            .unwrap_or_default())
     }
 }

--- a/core/api/src/jsonrpc/impl/ckb_light_client.rs
+++ b/core/api/src/jsonrpc/impl/ckb_light_client.rs
@@ -1,24 +1,31 @@
+use std::sync::Arc;
+
 use ckb_jsonrpc_types::{CellData, CellInfo, HeaderView as CkbHeaderView, JsonBytes, OutPoint};
 use ckb_traits::HeaderProvider;
 use ckb_types::core::cell::{CellProvider, CellStatus};
 use ckb_types::{packed, prelude::Pack};
 
-use core_executor::system_contract::DataProvider;
-
+use core_executor::DataProvider;
+use jsonrpsee::core::Error;
+use protocol::traits::{APIAdapter, Context};
 use protocol::{async_trait, ckb_blake2b_256, types::H256};
 
 use crate::jsonrpc::{CkbLightClientRpcServer, RpcResult};
 
-#[derive(Default, Clone, Debug)]
-pub struct CkbLightClientRpcImpl {
-    data_provider: DataProvider,
+#[derive(Clone, Debug)]
+pub struct CkbLightClientRpcImpl<Adapter: APIAdapter> {
+    adapter: Arc<Adapter>,
 }
 
 #[async_trait]
-impl CkbLightClientRpcServer for CkbLightClientRpcImpl {
+impl<Adapter: APIAdapter + 'static> CkbLightClientRpcServer for CkbLightClientRpcImpl<Adapter> {
     async fn get_block_header_by_hash(&self, hash: H256) -> RpcResult<Option<CkbHeaderView>> {
-        Ok(self
-            .data_provider
+        let root = self
+            .adapter
+            .get_image_cell_root(Context::new())
+            .await
+            .map_err(|e| Error::Custom(e.to_string()))?;
+        Ok(DataProvider::new(root)
             .get_header(&(hash.0.pack()))
             .map(Into::into))
     }
@@ -29,8 +36,13 @@ impl CkbLightClientRpcServer for CkbLightClientRpcImpl {
         with_data: bool,
     ) -> RpcResult<Option<CellInfo>> {
         let out_point: packed::OutPoint = out_point.into();
+        let root = self
+            .adapter
+            .get_image_cell_root(Context::new())
+            .await
+            .map_err(|e| Error::Custom(e.to_string()))?;
 
-        match self.data_provider.cell(&out_point, false) {
+        match DataProvider::new(root).cell(&out_point, false) {
             CellStatus::Live(c) => {
                 let data = with_data.then_some(c.mem_cell_data).flatten();
                 Ok(Some(CellInfo {
@@ -43,5 +55,11 @@ impl CkbLightClientRpcServer for CkbLightClientRpcImpl {
             }
             _ => Ok(None),
         }
+    }
+}
+
+impl<Adapter: APIAdapter> CkbLightClientRpcImpl<Adapter> {
+    pub fn new(adapter: Arc<Adapter>) -> Self {
+        Self { adapter }
     }
 }

--- a/core/api/src/jsonrpc/mod.rs
+++ b/core/api/src/jsonrpc/mod.rs
@@ -259,7 +259,7 @@ pub async fn run_jsonrpc_server<Adapter: APIAdapter + 'static>(
     let filter =
         r#impl::filter_module(Arc::clone(&adapter), config.web3.log_filter_max_block_range)
             .into_rpc();
-    let ckb_light_client_rpc = r#impl::CkbLightClientRpcImpl::default().into_rpc();
+    let ckb_light_client_rpc = r#impl::CkbLightClientRpcImpl::new(Arc::clone(&adapter)).into_rpc();
 
     rpc.merge(node_rpc).unwrap();
     rpc.merge(axon_rpc).unwrap();

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -8,11 +8,13 @@ use parking_lot::RwLock;
 use common_apm::Instant;
 use common_apm_derive::trace_span;
 use core_executor::system_contract::metadata::MetadataHandle;
-use core_executor::{AxonExecutor, AxonExecutorAdapter};
+use core_executor::{
+    AxonExecutor, AxonExecutorAdapter, METADATA_CONTRACT_ADDRESS, METADATA_ROOT_KEY,
+};
 use core_network::{PeerId, PeerIdExt};
 use protocol::traits::{
-    CommonConsensusAdapter, ConsensusAdapter, Context, Executor, Gossip, MemPool, MessageTarget,
-    Network, PeerTrust, Priority, Rpc, Storage, SynchronizationAdapter,
+    Backend, CommonConsensusAdapter, ConsensusAdapter, Context, Executor, Gossip, MemPool,
+    MessageTarget, Network, PeerTrust, Priority, Rpc, Storage, SynchronizationAdapter,
 };
 use protocol::types::{
     BatchSignedTxs, Block, BlockNumber, Bytes, ExecResp, Hash, Header, Hex, MerkleRoot, Metadata,
@@ -41,7 +43,6 @@ pub struct OverlordConsensusAdapter<
 
     storage:          Arc<S>,
     trie_db:          Arc<DB>,
-    metadata:         Arc<MetadataHandle>,
     overlord_handler: RwLock<Option<OverlordHandler<Proposal>>>,
     crypto:           Arc<OverlordCrypto>,
 }
@@ -339,9 +340,10 @@ where
             Arc::clone(&self.storage),
             proposal.clone().into(),
         )?;
+        let root = backend.storage(METADATA_CONTRACT_ADDRESS, *METADATA_ROOT_KEY);
+        let metadata_handle = MetadataHandle::new(root);
 
-        let verifier_list = self
-            .metadata
+        let verifier_list = metadata_handle
             .get_metadata_by_block_number(proposal.number)?
             .verifier_list;
 
@@ -357,15 +359,21 @@ where
     }
 
     async fn is_last_block_in_current_epoch(&self, block_number: u64) -> ProtocolResult<bool> {
-        self.metadata.is_last_block_in_current_epoch(block_number)
+        self.get_metadata_handle(Context::new())
+            .await?
+            .is_last_block_in_current_epoch(block_number)
     }
 
     async fn get_metadata_by_block_number(&self, block_number: u64) -> ProtocolResult<Metadata> {
-        self.metadata.get_metadata_by_block_number(block_number)
+        self.get_metadata_handle(Context::new())
+            .await?
+            .get_metadata_by_block_number(block_number)
     }
 
     async fn get_metadata_by_epoch(&self, epoch: u64) -> ProtocolResult<Metadata> {
-        self.metadata.get_metadata_by_epoch(epoch)
+        self.get_metadata_handle(Context::new())
+            .await?
+            .get_metadata_by_epoch(epoch)
     }
 
     #[trace_span(kind = "consensus.adapter")]
@@ -460,7 +468,8 @@ where
 
         // the auth_list for the target should comes from previous number
         let metadata = self
-            .metadata
+            .get_metadata_handle(ctx.clone())
+            .await?
             .get_metadata_by_block_number(block.header.number)?;
 
         if !metadata.version.contains(block.header.number) {
@@ -620,14 +629,12 @@ where
         mempool: Arc<M>,
         storage: Arc<S>,
         trie_db: Arc<DB>,
-        metadata: Arc<MetadataHandle>,
         crypto: Arc<OverlordCrypto>,
     ) -> ProtocolResult<Self> {
         Ok(OverlordConsensusAdapter {
             network,
             mempool,
             storage,
-            metadata,
             trie_db,
             overlord_handler: RwLock::new(None),
             crypto,
@@ -636,5 +643,17 @@ where
 
     pub fn set_overlord_handler(&self, handler: OverlordHandler<Proposal>) {
         *self.overlord_handler.write() = Some(handler)
+    }
+
+    async fn get_metadata_handle(&self, ctx: Context) -> ProtocolResult<MetadataHandle> {
+        let current_state_root = self.storage.get_latest_block_header(ctx).await?.state_root;
+        let backend = AxonExecutorAdapter::from_root(
+            current_state_root,
+            Arc::clone(&self.trie_db),
+            Arc::clone(&self.storage),
+            Default::default(),
+        )?;
+        let root = backend.storage(METADATA_CONTRACT_ADDRESS, *METADATA_ROOT_KEY);
+        Ok(MetadataHandle::new(root))
     }
 }

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -21,10 +21,7 @@ use protocol::types::{
     Block, Bytes, ExecResp, Hash, Hasher, Hex, Log, MerkleRoot, Metadata, Proof, Proposal, Receipt,
     SignedTransaction, ValidatorExtend, BASE_FEE_PER_GAS, MAX_BLOCK_GAS_LIMIT, RLP_NULL, U256,
 };
-use protocol::{
-    async_trait, lazy::CURRENT_STATE_ROOT, tokio::sync::Mutex as AsyncMutex, ProtocolError,
-    ProtocolResult,
-};
+use protocol::{async_trait, tokio::sync::Mutex as AsyncMutex, ProtocolError, ProtocolResult};
 
 use core_executor::logs_bloom;
 
@@ -639,7 +636,6 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
             proof:           proof.clone(),
         };
 
-        CURRENT_STATE_ROOT.swap(Arc::new(resp.state_root));
         self.status.swap(new_status);
 
         // update timeout_gap of mempool

--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -8,7 +8,7 @@ use common_apm_derive::trace_span;
 use protocol::tokio::{sync::Mutex, time::sleep};
 use protocol::traits::{Context, Synchronization, SynchronizationAdapter};
 use protocol::types::{Block, Proof, Proposal, Receipt, SignedTransaction, U256};
-use protocol::{async_trait, lazy::CURRENT_STATE_ROOT, ProtocolResult};
+use protocol::{async_trait, ProtocolResult};
 
 use crate::status::{CurrentStatus, StatusAgent};
 use crate::util::digest_signed_transactions;
@@ -375,7 +375,6 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
         )
         .await?;
 
-        CURRENT_STATE_ROOT.swap(Arc::new(resp.state_root));
         status_agent.swap(new_status);
 
         // If there are transactions in the transaction pool that have been on chain

--- a/core/executor/src/adapter/mod.rs
+++ b/core/executor/src/adapter/mod.rs
@@ -14,6 +14,10 @@ use protocol::types::{
 };
 use protocol::{codec::ProtocolCodec, trie, ProtocolResult};
 
+use crate::system_contract::{
+    HEADER_CELL_ROOT_KEY, IMAGE_CELL_CONTRACT_ADDRESS, METADATA_CONTRACT_ADDRESS, METADATA_ROOT_KEY,
+};
+
 const GET_BLOCK_HASH_NUMBER_RANGE: u64 = 256;
 
 macro_rules! blocking_async {
@@ -278,6 +282,14 @@ where
             storage,
             exec_ctx,
         })
+    }
+
+    pub fn get_metadata_root(&self) -> H256 {
+        self.storage(METADATA_CONTRACT_ADDRESS, *METADATA_ROOT_KEY)
+    }
+
+    pub fn get_image_cell_root(&self) -> H256 {
+        self.storage(IMAGE_CELL_CONTRACT_ADDRESS, *HEADER_CELL_ROOT_KEY)
     }
 
     fn apply<I: IntoIterator<Item = (H256, H256)>>(

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -10,10 +10,7 @@ mod tests;
 mod utils;
 
 pub use crate::adapter::{AxonExecutorAdapter, MPTTrie, RocksTrieDB};
-pub use crate::system_contract::{
-    metadata::MetadataHandle, DataProvider, HEADER_CELL_ROOT_KEY, IMAGE_CELL_CONTRACT_ADDRESS,
-    METADATA_CONTRACT_ADDRESS, METADATA_ROOT_KEY,
-};
+pub use crate::system_contract::{metadata::MetadataHandle, DataProvider};
 pub use crate::utils::{
     code_address, decode_revert_msg, logs_bloom, DefaultFeeAllocator, FeeInlet,
 };
@@ -39,6 +36,8 @@ use crate::precompiles::build_precompile_set;
 use crate::system_contract::{
     after_block_hook, before_block_hook, system_contract_dispatch, CkbLightClientContract,
     ImageCellContract, MetadataContract, NativeTokenContract, SystemContract,
+    CKB_LIGHT_CLIENT_CONTRACT_ADDRESS, HEADER_CELL_ROOT_KEY, METADATA_CONTRACT_ADDRESS,
+    METADATA_ROOT_KEY,
 };
 
 lazy_static::lazy_static! {
@@ -314,24 +313,13 @@ impl AxonExecutor {
     fn init_local_system_contract_roots<Adapter: ExecutorAdapter>(&self, adapter: &mut Adapter) {
         CURRENT_HEADER_CELL_ROOT.with(|root| {
             *root.borrow_mut() =
-                adapter.storage(CkbLightClientContract::ADDRESS, *HEADER_CELL_ROOT_KEY);
+                adapter.storage(CKB_LIGHT_CLIENT_CONTRACT_ADDRESS, *HEADER_CELL_ROOT_KEY);
         });
 
         CURRENT_METADATA_ROOT.with(|root| {
-            *root.borrow_mut() = adapter.storage(MetadataContract::ADDRESS, *METADATA_ROOT_KEY);
+            *root.borrow_mut() = adapter.storage(METADATA_CONTRACT_ADDRESS, *METADATA_ROOT_KEY);
         });
     }
-
-    // /// The system contract roots are updated at the end of execute transactions
-    // /// of a block.
-    // fn update_system_contract_roots_for_external_module(&self) {
-    //     BLOCK_PERIOD_UPDATED_HEADER_CELL_ROOT.store(Arc::new(
-    //         CURRENT_HEADER_CELL_ROOT.with(|root| *root.borrow()),
-    //     ));
-
-    //     BLOCK_PERIOD_METADATA_ROOT
-    //         .store(Arc::new(CURRENT_METADATA_ROOT.with(|root| *root.borrow())));
-    // }
 
     #[cfg(test)]
     fn test_exec<Adapter: ExecutorAdapter>(

--- a/core/executor/src/precompiles/call_ckb_vm.rs
+++ b/core/executor/src/precompiles/call_ckb_vm.rs
@@ -8,6 +8,7 @@ use protocol::types::{CellDep, H160, H256};
 use core_interoperation::{cycle_to_gas, gas_to_cycle, InteroperationImpl};
 
 use crate::precompiles::{axon_precompile_address, PrecompileContract};
+use crate::CURRENT_HEADER_CELL_ROOT;
 use crate::{err, system_contract::DataProvider};
 
 macro_rules! try_rlp {
@@ -33,7 +34,7 @@ impl PrecompileContract for CkbVM {
             let rlp = Rlp::new(input);
             let res = <InteroperationImpl as Interoperation>::call_ckb_vm(
                 Default::default(),
-                &DataProvider::default(),
+                &DataProvider::new(CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow())),
                 get_cell_dep(&rlp)?,
                 &try_rlp!(rlp, list_at, 3),
                 gas_to_cycle(gas),

--- a/core/executor/src/precompiles/get_cell.rs
+++ b/core/executor/src/precompiles/get_cell.rs
@@ -9,7 +9,7 @@ use protocol::types::{H160, H256};
 
 use crate::precompiles::{axon_precompile_address, PrecompileContract};
 use crate::system_contract::image_cell::{image_cell_abi, CellKey};
-use crate::{err, system_contract::image_cell::ImageCellContract};
+use crate::{err, system_contract::image_cell::ImageCellContract, CURRENT_HEADER_CELL_ROOT};
 
 #[derive(Default, Clone)]
 pub struct GetCell;
@@ -33,8 +33,9 @@ impl PrecompileContract for GetCell {
 
         let (tx_hash, index) = parse_input(input)?;
 
+        let root = CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow());
         let cell = ImageCellContract::default()
-            .get_cell(&CellKey { tx_hash, index })
+            .get_cell(root, &CellKey { tx_hash, index })
             .map_err(|_| err!(_, "get cell"))?
             .map(|c| Cell {
                 cell_output:     packed::CellOutput::new_unchecked(c.cell_output).into(),

--- a/core/executor/src/precompiles/get_header.rs
+++ b/core/executor/src/precompiles/get_header.rs
@@ -5,7 +5,7 @@ use evm::{Context, ExitError, ExitSucceed};
 use protocol::types::{H160, H256};
 
 use crate::precompiles::{axon_precompile_address, PrecompileContract};
-use crate::{err, system_contract::CkbLightClientContract};
+use crate::{err, system_contract::CkbLightClientContract, CURRENT_HEADER_CELL_ROOT};
 
 #[derive(Default, Clone)]
 pub struct GetHeader;
@@ -30,8 +30,9 @@ impl PrecompileContract for GetHeader {
         let block_hash =
             H256(<[u8; 32] as AbiDecode>::decode(input).map_err(|_| err!(_, "decode input"))?);
 
+        let root = CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow());
         let raw = CkbLightClientContract::default()
-            .get_raw(&block_hash.0)
+            .get_raw(root, &block_hash.0)
             .map_err(|_| err!(_, "get header"))?;
 
         Ok((

--- a/core/executor/src/precompiles/metadata.rs
+++ b/core/executor/src/precompiles/metadata.rs
@@ -4,7 +4,7 @@ use evm::{Context, ExitError, ExitSucceed};
 use protocol::types::H160;
 
 use crate::precompiles::{axon_precompile_address, PrecompileContract};
-use crate::{err, system_contract::metadata::MetadataHandle};
+use crate::{err, system_contract::metadata::MetadataHandle, CURRENT_METADATA_ROOT};
 
 const INPUT_LEN: usize = 1 + 8;
 
@@ -34,12 +34,13 @@ impl PrecompileContract for Metadata {
             }
 
             let (ty, number) = parse_input(input)?;
+            let root = CURRENT_METADATA_ROOT.with(|r| *r.borrow());
 
             let metadata = match ty {
-                0u8 => MetadataHandle::default()
+                0u8 => MetadataHandle::new(root)
                     .get_metadata_by_block_number(number)
                     .map_err(|e| err!(_, e.to_string()))?,
-                1u8 => MetadataHandle::default()
+                1u8 => MetadataHandle::new(root)
                     .get_metadata_by_epoch(number)
                     .map_err(|e| err!(_, e.to_string()))?,
                 _ => return err!("Invalid call type"),

--- a/core/executor/src/precompiles/verify_by_ckb_vm.rs
+++ b/core/executor/src/precompiles/verify_by_ckb_vm.rs
@@ -8,6 +8,7 @@ use protocol::types::{CellDep, OutPoint, SignatureR, SignatureS, Witness, H160, 
 use core_interoperation::{cycle_to_gas, gas_to_cycle, InteroperationImpl};
 
 use crate::precompiles::{axon_precompile_address, PrecompileContract};
+use crate::CURRENT_HEADER_CELL_ROOT;
 use crate::{err, system_contract::DataProvider};
 
 macro_rules! try_rlp {
@@ -38,7 +39,7 @@ impl PrecompileContract for CkbVM {
         if let Some(gas) = gas_limit {
             let res = InteroperationImpl::verify_by_ckb_vm(
                 Default::default(),
-                &DataProvider::default(),
+                &DataProvider::new(CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow())),
                 &InteroperationImpl::dummy_transaction(
                     SignatureR::new_by_ref(cell_deps, header_deps, inputs, Default::default()),
                     SignatureS::new(witnesses),

--- a/core/executor/src/system_contract/ckb_light_client/mod.rs
+++ b/core/executor/src/system_contract/ckb_light_client/mod.rs
@@ -10,10 +10,10 @@ use ethers::abi::AbiDecode;
 use protocol::types::{SignedTransaction, TxResp, H160, H256};
 use protocol::{traits::ExecutorAdapter, ProtocolResult};
 
-use crate::exec_try;
 use crate::system_contract::ckb_light_client::store::CkbLightClientStore;
 use crate::system_contract::utils::{succeed_resp, update_states};
-use crate::system_contract::{system_contract_address, SystemContract, CURRENT_HEADER_CELL_ROOT};
+use crate::system_contract::{system_contract_address, SystemContract};
+use crate::{exec_try, CURRENT_HEADER_CELL_ROOT};
 
 static ALLOW_READ: AtomicBool = AtomicBool::new(false);
 
@@ -72,7 +72,7 @@ impl SystemContract for CkbLightClientContract {
 
 impl CkbLightClientContract {
     pub fn get_root(&self) -> H256 {
-        **CURRENT_HEADER_CELL_ROOT.load()
+        CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow())
     }
 
     pub fn get_header_by_block_hash(

--- a/core/executor/src/system_contract/ckb_light_client/store.rs
+++ b/core/executor/src/system_contract/ckb_light_client/store.rs
@@ -14,13 +14,11 @@ pub struct CkbLightClientStore {
 }
 
 impl CkbLightClientStore {
-    pub fn new() -> ProtocolResult<Self> {
+    pub fn new(root: H256) -> ProtocolResult<Self> {
         let trie_db = match HEADER_CELL_DB.get() {
             Some(db) => db,
             None => return Err(SystemScriptError::TrieDbNotInit.into()),
         };
-
-        let root = CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow());
 
         let trie = if root == H256::default() {
             MPTTrie::new(Arc::clone(trie_db))

--- a/core/executor/src/system_contract/ckb_light_client/store.rs
+++ b/core/executor/src/system_contract/ckb_light_client/store.rs
@@ -5,10 +5,9 @@ use ethers::abi::{AbiDecode, AbiEncode};
 use protocol::{types::H256, ProtocolResult};
 
 use crate::system_contract::{
-    ckb_light_client::ckb_light_client_abi, error::SystemScriptError, CURRENT_HEADER_CELL_ROOT,
-    HEADER_CELL_DB,
+    ckb_light_client::ckb_light_client_abi, error::SystemScriptError, HEADER_CELL_DB,
 };
-use crate::{adapter::RocksTrieDB, MPTTrie};
+use crate::{adapter::RocksTrieDB, MPTTrie, CURRENT_HEADER_CELL_ROOT};
 
 pub struct CkbLightClientStore {
     pub trie: MPTTrie<RocksTrieDB>,
@@ -21,7 +20,7 @@ impl CkbLightClientStore {
             None => return Err(SystemScriptError::TrieDbNotInit.into()),
         };
 
-        let root = **CURRENT_HEADER_CELL_ROOT.load();
+        let root = CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow());
 
         let trie = if root == H256::default() {
             MPTTrie::new(Arc::clone(trie_db))
@@ -84,7 +83,7 @@ impl CkbLightClientStore {
     pub fn commit(&mut self) -> ProtocolResult<()> {
         match self.trie.commit() {
             Ok(new_root) => {
-                CURRENT_HEADER_CELL_ROOT.swap(Arc::new(new_root));
+                CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow_mut() = new_root);
                 Ok(())
             }
             Err(e) => Err(SystemScriptError::CommitError(e.to_string()).into()),

--- a/core/executor/src/system_contract/image_cell/mod.rs
+++ b/core/executor/src/system_contract/image_cell/mod.rs
@@ -15,8 +15,8 @@ use protocol::ProtocolResult;
 
 use crate::system_contract::image_cell::store::ImageCellStore;
 use crate::system_contract::utils::{succeed_resp, update_states};
-use crate::system_contract::{system_contract_address, SystemContract, CURRENT_HEADER_CELL_ROOT};
-use crate::{exec_try, MPTTrie};
+use crate::system_contract::{system_contract_address, SystemContract};
+use crate::{exec_try, MPTTrie, CURRENT_HEADER_CELL_ROOT};
 
 static ALLOW_READ: AtomicBool = AtomicBool::new(false);
 
@@ -71,7 +71,7 @@ impl SystemContract for ImageCellContract {
 
 impl ImageCellContract {
     pub fn get_root(&self) -> H256 {
-        **CURRENT_HEADER_CELL_ROOT.load()
+        CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow())
     }
 
     pub fn get_cell(&self, key: &CellKey) -> ProtocolResult<Option<CellInfo>> {

--- a/core/executor/src/system_contract/image_cell/store.rs
+++ b/core/executor/src/system_contract/image_cell/store.rs
@@ -24,13 +24,11 @@ pub struct ImageCellStore {
 }
 
 impl ImageCellStore {
-    pub fn new() -> ProtocolResult<Self> {
+    pub fn new(root: H256) -> ProtocolResult<Self> {
         let trie_db = match HEADER_CELL_DB.get() {
             Some(db) => db,
             None => return Err(SystemScriptError::TrieDbNotInit.into()),
         };
-
-        let root = CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow());
 
         let trie = if root == H256::default() {
             MPTTrie::new(Arc::clone(trie_db))

--- a/core/executor/src/system_contract/image_cell/store.rs
+++ b/core/executor/src/system_contract/image_cell/store.rs
@@ -25,15 +25,18 @@ pub struct ImageCellStore {
 
 impl ImageCellStore {
     pub fn new(root: H256) -> ProtocolResult<Self> {
-        let trie_db = match HEADER_CELL_DB.get() {
-            Some(db) => db,
-            None => return Err(SystemScriptError::TrieDbNotInit.into()),
+        let trie_db = {
+            let lock = HEADER_CELL_DB.read();
+            match lock.clone() {
+                Some(db) => db,
+                None => return Err(SystemScriptError::TrieDbNotInit.into()),
+            }
         };
 
         let trie = if root == H256::default() {
-            MPTTrie::new(Arc::clone(trie_db))
+            MPTTrie::new(Arc::clone(&trie_db))
         } else {
-            match MPTTrie::from_root(root, Arc::clone(trie_db)) {
+            match MPTTrie::from_root(root, Arc::clone(&trie_db)) {
                 Ok(m) => m,
                 Err(e) => return Err(SystemScriptError::RestoreMpt(e.to_string()).into()),
             }

--- a/core/executor/src/system_contract/metadata/handle.rs
+++ b/core/executor/src/system_contract/metadata/handle.rs
@@ -1,23 +1,22 @@
-use arc_swap::ArcSwap;
-
 use protocol::types::{CkbRelatedInfo, Metadata, H160, H256};
 use protocol::ProtocolResult;
 
 use crate::system_contract::metadata::MetadataStore;
 
-lazy_static::lazy_static! {
-    pub(crate) static ref BLOCK_PERIOD_METADATA_ROOT: ArcSwap<H256>
-        = ArcSwap::from_pointee(H256::default());
-}
-
 /// The MetadataHandle is used to expose apis that can be accessed from outside
 /// of the system contract.
-#[derive(Default)]
-pub struct MetadataHandle;
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MetadataHandle {
+    root: H256,
+}
 
 impl MetadataHandle {
+    pub fn new(root: H256) -> Self {
+        MetadataHandle { root }
+    }
+
     pub fn get_metadata_by_block_number(&self, block_number: u64) -> ProtocolResult<Metadata> {
-        let store = MetadataStore::new(self.get_metadata_root())?;
+        let store = MetadataStore::new(self.root)?;
 
         // Should retrieve the first metadata for the genesis block
         if block_number == 0 {
@@ -30,11 +29,11 @@ impl MetadataHandle {
     }
 
     pub fn get_metadata_by_epoch(&self, epoch: u64) -> ProtocolResult<Metadata> {
-        MetadataStore::new(self.get_metadata_root())?.get_metadata(epoch)
+        MetadataStore::new(self.root)?.get_metadata(epoch)
     }
 
     pub fn is_last_block_in_current_epoch(&self, block_number: u64) -> ProtocolResult<bool> {
-        let store = MetadataStore::new(self.get_metadata_root())?;
+        let store = MetadataStore::new(self.root)?;
         let segment = store.get_epoch_segment()?;
         let is_last_block = segment.is_last_block_in_epoch(block_number);
         Ok(is_last_block)
@@ -46,11 +45,6 @@ impl MetadataHandle {
     }
 
     pub fn get_ckb_related_info(&self) -> ProtocolResult<CkbRelatedInfo> {
-        MetadataStore::new(self.get_metadata_root())?.get_ckb_related_info()
-    }
-
-    // Get the metadata root from block period update variable.
-    fn get_metadata_root(&self) -> H256 {
-        **BLOCK_PERIOD_METADATA_ROOT.load()
+        MetadataStore::new(self.root)?.get_ckb_related_info()
     }
 }

--- a/core/executor/src/system_contract/metadata/mod.rs
+++ b/core/executor/src/system_contract/metadata/mod.rs
@@ -20,7 +20,7 @@ use crate::exec_try;
 use crate::system_contract::utils::{
     generate_mpt_root_changes, revert_resp, succeed_resp, update_states,
 };
-use crate::system_contract::{system_contract_address, SystemContract, CURRENT_METADATA_ROOT};
+use crate::system_contract::{system_contract_address, SystemContract};
 
 type Epoch = u64;
 

--- a/core/executor/src/system_contract/metadata/mod.rs
+++ b/core/executor/src/system_contract/metadata/mod.rs
@@ -24,6 +24,7 @@ use crate::{exec_try, CURRENT_METADATA_ROOT};
 
 type Epoch = u64;
 
+pub const METADATA_CONTRACT_ADDRESS: H160 = system_contract_address(0x1);
 const METADATA_CACHE_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
 
 lazy_static::lazy_static! {
@@ -36,7 +37,7 @@ lazy_static::lazy_static! {
 pub struct MetadataContract;
 
 impl SystemContract for MetadataContract {
-    const ADDRESS: H160 = system_contract_address(0x1);
+    const ADDRESS: H160 = METADATA_CONTRACT_ADDRESS;
 
     fn exec_<Adapter: ExecutorAdapter>(
         &self,
@@ -57,7 +58,7 @@ impl SystemContract for MetadataContract {
         );
 
         if block_number != 0 {
-            let handle = MetadataHandle::default();
+            let handle = MetadataHandle::new(CURRENT_METADATA_ROOT.with(|r| *r.borrow()));
 
             if !exec_try!(
                 handle.is_validator(block_number, sender),
@@ -124,6 +125,6 @@ impl SystemContract for MetadataContract {
     }
 }
 
-pub fn check_ckb_related_info_exist() -> bool {
-    MetadataHandle::default().get_ckb_related_info().is_ok()
+pub fn check_ckb_related_info_exist(root: H256) -> bool {
+    MetadataHandle::new(root).get_ckb_related_info().is_ok()
 }

--- a/core/executor/src/system_contract/metadata/store.rs
+++ b/core/executor/src/system_contract/metadata/store.rs
@@ -15,13 +15,11 @@ pub struct MetadataStore {
 }
 
 impl MetadataStore {
-    pub fn new() -> ProtocolResult<Self> {
+    pub fn new(root: H256) -> ProtocolResult<Self> {
         let trie_db = match METADATA_DB.get() {
             Some(db) => db,
             None => return Err(SystemScriptError::TrieDbNotInit.into()),
         };
-
-        let root = CURRENT_METADATA_ROOT.with(|r| *r.borrow());
 
         let trie = if root == H256::default() {
             let mut m = MPTTrie::new(Arc::clone(trie_db));

--- a/core/executor/src/system_contract/native_token.rs
+++ b/core/executor/src/system_contract/native_token.rs
@@ -4,11 +4,13 @@ use protocol::types::{Apply, Basic, SignedTransaction, TxResp, H160, U256};
 use crate::system_contract::utils::{revert_resp, succeed_resp};
 use crate::system_contract::{system_contract_address, SystemContract};
 
+pub const NATIVE_TOKEN_CONTRACT_ADDRESS: H160 = system_contract_address(0x0);
+
 #[derive(Default)]
 pub struct NativeTokenContract;
 
 impl SystemContract for NativeTokenContract {
-    const ADDRESS: H160 = system_contract_address(0x0);
+    const ADDRESS: H160 = NATIVE_TOKEN_CONTRACT_ADDRESS;
 
     fn exec_<B: Backend + ApplyBackend>(&self, backend: &mut B, tx: &SignedTransaction) -> TxResp {
         let tx = &tx.transaction.unsigned;

--- a/core/executor/src/tests/system_script/ckb_light_client.rs
+++ b/core/executor/src/tests/system_script/ckb_light_client.rs
@@ -60,11 +60,11 @@ fn test_update_first(backend: &mut MemoryBackend, executor: &CkbLightClientContr
     let r = exec(backend, executor, data.encode());
     assert!(r.exit_reason.is_succeed());
 
-    check_root(backend, executor);
     check_nonce(backend, 1);
 
+    let root = backend.storage(CkbLightClientContract::ADDRESS, *HEADER_CELL_ROOT_KEY);
     let queried_header = executor
-        .get_header_by_block_hash(&H256::default())
+        .get_header_by_block_hash(root, &H256::default())
         .unwrap()
         .unwrap();
 
@@ -80,11 +80,11 @@ fn test_update_second(backend: &mut MemoryBackend, executor: &CkbLightClientCont
     let r = exec(backend, executor, data.encode());
     assert!(r.exit_reason.is_succeed());
 
-    check_root(backend, executor);
     check_nonce(backend, 2);
 
+    let root = backend.storage(CkbLightClientContract::ADDRESS, *HEADER_CELL_ROOT_KEY);
     let queried_header = executor
-        .get_header_by_block_hash(&H256::from_slice(&header.block_hash))
+        .get_header_by_block_hash(root, &H256::from_slice(&header.block_hash))
         .unwrap()
         .unwrap();
 
@@ -99,10 +99,9 @@ fn test_roll_back_first(backend: &mut MemoryBackend, executor: &CkbLightClientCo
     let r = exec(backend, executor, data.encode());
     assert!(r.exit_reason.is_succeed());
 
-    check_root(backend, executor);
-
+    let root = backend.storage(CkbLightClientContract::ADDRESS, *HEADER_CELL_ROOT_KEY);
     let queried_header = executor
-        .get_header_by_block_hash(&H256::default())
+        .get_header_by_block_hash(root, &H256::default())
         .unwrap()
         .unwrap();
 
@@ -117,9 +116,10 @@ fn test_roll_back_second(backend: &mut MemoryBackend, executor: &CkbLightClientC
     let r = exec(backend, executor, data.encode());
     assert!(r.exit_reason.is_succeed());
 
-    check_root(backend, executor);
-
-    let queried_header = executor.get_header_by_block_hash(&H256::default()).unwrap();
+    let root = backend.storage(CkbLightClientContract::ADDRESS, *HEADER_CELL_ROOT_KEY);
+    let queried_header = executor
+        .get_header_by_block_hash(root, &H256::default())
+        .unwrap();
     assert!(queried_header.is_none());
 }
 
@@ -138,17 +138,6 @@ fn exec(backend: &mut MemoryBackend, executor: &CkbLightClientContract, data: Ve
     let addr = H160::from_str("0xf000000000000000000000000000000000000000").unwrap();
     let tx = gen_tx(addr, CkbLightClientContract::ADDRESS, 1000, data);
     executor.exec_(backend, &tx)
-}
-
-fn check_root(backend: &MemoryBackend, executor: &CkbLightClientContract) {
-    let account = backend
-        .state()
-        .get(&CkbLightClientContract::ADDRESS)
-        .unwrap();
-    assert_eq!(
-        &executor.get_root(),
-        account.storage.get(&HEADER_CELL_ROOT_KEY).unwrap(),
-    );
 }
 
 fn check_nonce(backend: &mut MemoryBackend, nonce: u64) {

--- a/core/executor/src/tests/system_script/image_cell.rs
+++ b/core/executor/src/tests/system_script/image_cell.rs
@@ -10,6 +10,7 @@ use protocol::types::{Backend, MemoryBackend, TxResp, H160, U256};
 use crate::system_contract::image_cell::{image_cell_abi, CellInfo, CellKey, ImageCellContract};
 use crate::system_contract::{init, CkbLightClientContract, SystemContract, HEADER_CELL_ROOT_KEY};
 use crate::tests::{gen_tx, gen_vicinity};
+use crate::{CURRENT_HEADER_CELL_ROOT, CURRENT_METADATA_ROOT};
 
 static ROCKSDB_PATH: &str = "./free-space/system-contract/image-cell";
 
@@ -18,7 +19,10 @@ pub fn test_write_functions() {
     let mut backend = MemoryBackend::new(&vicinity, BTreeMap::new());
 
     let executor = ImageCellContract::default();
-    init(ROCKSDB_PATH, ConfigRocksDB::default(), &mut backend);
+    let (m_root, h_root) = init(ROCKSDB_PATH, ConfigRocksDB::default(), &mut backend);
+
+    CURRENT_METADATA_ROOT.with(|r| *r.borrow_mut() = m_root);
+    CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow_mut() = h_root);
 
     test_update_first(&mut backend, &executor);
     test_update_second(&mut backend, &executor);

--- a/core/executor/src/tests/system_script/image_cell.rs
+++ b/core/executor/src/tests/system_script/image_cell.rs
@@ -41,11 +41,11 @@ fn test_update_first(backend: &mut MemoryBackend, executor: &ImageCellContract) 
     let r = exec(backend, executor, data.encode());
     assert!(r.exit_reason.is_succeed());
 
-    check_root(backend, executor);
     check_nonce(backend, 1);
 
+    let root = backend.storage(CkbLightClientContract::ADDRESS, *HEADER_CELL_ROOT_KEY);
     let cell_key = CellKey::new([7u8; 32], 0x0);
-    let get_cell = executor.get_cell(&cell_key).unwrap().unwrap();
+    let get_cell = executor.get_cell(root, &cell_key).unwrap().unwrap();
     check_cell(&get_cell, 0x1, None);
 }
 
@@ -64,11 +64,11 @@ fn test_update_second(backend: &mut MemoryBackend, executor: &ImageCellContract)
     let r = exec(backend, executor, data.encode());
     assert!(r.exit_reason.is_succeed());
 
-    check_root(backend, executor);
     check_nonce(backend, 2);
 
+    let root = backend.storage(CkbLightClientContract::ADDRESS, *HEADER_CELL_ROOT_KEY);
     let cell_key = CellKey::new([7u8; 32], 0x0);
-    let get_cell = executor.get_cell(&cell_key).unwrap().unwrap();
+    let get_cell = executor.get_cell(root, &cell_key).unwrap().unwrap();
     check_cell(&get_cell, 0x1, Some(0x2));
 }
 
@@ -86,10 +86,9 @@ fn test_rollback_first(backend: &mut MemoryBackend, executor: &ImageCellContract
     let r = exec(backend, executor, data.encode());
     assert!(r.exit_reason.is_succeed());
 
-    check_root(backend, executor);
-
+    let root = backend.storage(CkbLightClientContract::ADDRESS, *HEADER_CELL_ROOT_KEY);
     let cell_key = CellKey::new([7u8; 32], 0x0);
-    let get_cell = executor.get_cell(&cell_key).unwrap().unwrap();
+    let get_cell = executor.get_cell(root, &cell_key).unwrap().unwrap();
     check_cell(&get_cell, 0x1, None);
 }
 
@@ -107,10 +106,9 @@ fn test_rollback_second(backend: &mut MemoryBackend, executor: &ImageCellContrac
     let r = exec(backend, executor, data.encode());
     assert!(r.exit_reason.is_succeed());
 
-    check_root(backend, executor);
-
+    let root = backend.storage(CkbLightClientContract::ADDRESS, *HEADER_CELL_ROOT_KEY);
     let cell_key = CellKey::new([7u8; 32], 0x0);
-    let get_cell = executor.get_cell(&cell_key).unwrap();
+    let get_cell = executor.get_cell(root, &cell_key).unwrap();
     assert!(get_cell.is_none());
 }
 
@@ -129,14 +127,6 @@ fn exec(backend: &mut MemoryBackend, executor: &ImageCellContract, data: Vec<u8>
     let addr = H160::from_str("0xf000000000000000000000000000000000000000").unwrap();
     let tx = gen_tx(addr, ImageCellContract::ADDRESS, 1000, data);
     executor.exec_(backend, &tx)
-}
-
-fn check_root(backend: &MemoryBackend, executor: &ImageCellContract) {
-    let account = backend.state().get(&ImageCellContract::ADDRESS).unwrap();
-    assert_eq!(
-        &executor.get_root(),
-        account.storage.get(&HEADER_CELL_ROOT_KEY).unwrap(),
-    );
 }
 
 fn check_cell(get_cell: &CellInfo, created_number: u64, consumed_number: Option<u64>) {

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -26,10 +26,7 @@ use protocol::{
 
 use common_apm_derive::trace_span;
 use common_crypto::{Crypto, Secp256k1Recoverable};
-use core_executor::{
-    is_call_system_script, AxonExecutorAdapter, DataProvider, MetadataHandle, HEADER_CELL_ROOT_KEY,
-    IMAGE_CELL_CONTRACT_ADDRESS, METADATA_CONTRACT_ADDRESS, METADATA_ROOT_KEY,
-};
+use core_executor::{is_call_system_script, AxonExecutorAdapter, DataProvider, MetadataHandle};
 use core_interoperation::InteroperationImpl;
 
 use crate::adapter::message::{MsgPullTxs, END_GOSSIP_NEW_TXS, RPC_PULL_TXS};
@@ -187,8 +184,7 @@ where
     ) -> ProtocolResult<U256> {
         let addr = &stx.sender;
         let block = self.storage.get_latest_block(ctx.clone()).await?;
-        let backend = self.executor_backend(ctx).await?;
-        let root = backend.storage(METADATA_CONTRACT_ADDRESS, *METADATA_ROOT_KEY);
+        let root = self.executor_backend(ctx).await?.get_metadata_root();
 
         if MetadataHandle::new(root).is_validator(block.header.number + 1, *addr)? {
             return Ok(U256::zero());
@@ -289,8 +285,7 @@ where
             return Ok(());
         }
 
-        let backend = self.executor_backend(ctx).await?;
-        let root = backend.storage(IMAGE_CELL_CONTRACT_ADDRESS, *HEADER_CELL_ROOT_KEY);
+        let root = self.executor_backend(ctx).await?.get_image_cell_root();
 
         // Verify interoperation signature
         match signature.r[0] {

--- a/protocol/src/lazy.rs
+++ b/protocol/src/lazy.rs
@@ -2,11 +2,9 @@ use arc_swap::ArcSwap;
 use ckb_always_success_script::ALWAYS_SUCCESS;
 use ckb_types::{core::ScriptHashType, packed, prelude::*};
 
-use crate::ckb_blake2b_256;
-use crate::types::{Hex, MerkleRoot};
+use crate::{ckb_blake2b_256, types::Hex};
 
 lazy_static::lazy_static! {
-    pub static ref CURRENT_STATE_ROOT: ArcSwap<MerkleRoot> = ArcSwap::from_pointee(Default::default());
     pub static ref CHAIN_ID: ArcSwap<u64> = ArcSwap::from_pointee(Default::default());
     pub static ref PROTOCOL_VERSION: ArcSwap<Hex> = ArcSwap::from_pointee(Default::default());
 

--- a/protocol/src/traits/api.rs
+++ b/protocol/src/traits/api.rs
@@ -1,6 +1,6 @@
 use crate::types::{
     Account, Block, BlockNumber, Bytes, CkbRelatedInfo, Hash, Header, Metadata, Proposal, Receipt,
-    SignedTransaction, TxResp, H160, U256,
+    SignedTransaction, TxResp, H160, H256, U256,
 };
 use crate::{async_trait, traits::Context, ProtocolResult};
 
@@ -99,4 +99,8 @@ pub trait APIAdapter: Send + Sync {
     ) -> ProtocolResult<Metadata>;
 
     async fn get_ckb_related_info(&self, ctx: Context) -> ProtocolResult<CkbRelatedInfo>;
+
+    async fn get_image_cell_root(&self, ctx: Context) -> ProtocolResult<H256>;
+
+    async fn get_metadata_root(&self, ctx: Context) -> ProtocolResult<H256>;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR：
Divide the global variable of system contract roots (header cell root and metadata root) into two parts:
1. Two thread local storage that use in the `exec()` function. The local keys are loaded at the start of execution, and the life cycle is the exec() function. It is use for transactions execution. It is use for transactions executions.
2. Other using the system contract roots places change to get them from the DB as following:
```rust
let state_root = self.storage.get_latest_block_header(ctx).await?.state_root;
let backend = AxonExecutorAdapter::from_root(
    state_root,
    Arc::clone(&self.trie_db),
    Arc::clone(&self.storage),
    Default::default(),
)?;
let root = backend.get_metadata_root();
let metadata_handle = MetadataHandle::new(root);
...
```
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #1278

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
