### PR TITLE
refactor(precompile): call ckb vm and verify by ckb payload

### DIFF
--- a/core/executor/src/precompiles/call_ckb_vm.rs
+++ b/core/executor/src/precompiles/call_ckb_vm.rs
@@ -9,14 +9,13 @@ use protocol::types::{Bytes, H160};
 use core_interoperation::{cycle_to_gas, gas_to_cycle, InteroperationImpl};
 
 use crate::precompiles::{axon_precompile_address, PrecompileContract};
-use crate::CURRENT_HEADER_CELL_ROOT;
-use crate::system_contract::image_cell::image_cell_abi::OutPoint;
-use crate::{err, system_contract::DataProvider};
+use crate::system_contract::{image_cell::image_cell_abi::OutPoint, DataProvider};
+use crate::{err, CURRENT_HEADER_CELL_ROOT};
 
 #[derive(Default, Clone)]
-pub struct CkbVM;
+pub struct CallCkbVM;
 
-impl PrecompileContract for CkbVM {
+impl PrecompileContract for CallCkbVM {
     const ADDRESS: H160 = axon_precompile_address(0x04);
     const MIN_GAS: u64 = 500;
 

--- a/core/executor/src/precompiles/get_cell.rs
+++ b/core/executor/src/precompiles/get_cell.rs
@@ -34,7 +34,7 @@ impl PrecompileContract for GetCell {
         let (tx_hash, index) = parse_input(input)?;
 
         let root = CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow());
-        let cell = ImageCellReader::default()
+        let cell_opt = ImageCellReader::default()
             .get_cell(root, &CellKey { tx_hash, index })
             .map_err(|_| err!(_, "get cell"))?
             .map(|c| Cell {
@@ -43,13 +43,16 @@ impl PrecompileContract for GetCell {
                 is_consumed:     c.consumed_number.is_some(),
                 created_number:  c.created_number,
                 consumed_number: c.consumed_number.unwrap_or(0),
-            })
-            .unwrap_or_default();
+            });
+
+        if cell_opt.is_none() {
+            return err!("get cell return None");
+        }
 
         Ok((
             PrecompileOutput {
                 exit_status: ExitSucceed::Returned,
-                output:      cell.encode(),
+                output:      cell_opt.unwrap().encode(),
             },
             gas,
         ))

--- a/core/executor/src/precompiles/get_header.rs
+++ b/core/executor/src/precompiles/get_header.rs
@@ -31,14 +31,18 @@ impl PrecompileContract for GetHeader {
             H256(<[u8; 32] as AbiDecode>::decode(input).map_err(|_| err!(_, "decode input"))?);
 
         let root = CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow());
-        let raw = CkbHeaderReader::default()
+        let header_opt = CkbHeaderReader::default()
             .get_raw(root, &block_hash.0)
             .map_err(|_| err!(_, "get header"))?;
+
+        if header_opt.is_none() {
+            return err!("get header return None");
+        }
 
         Ok((
             PrecompileOutput {
                 exit_status: ExitSucceed::Returned,
-                output:      raw.unwrap_or_default(),
+                output:      header_opt.unwrap(),
             },
             gas,
         ))

--- a/core/executor/src/precompiles/mod.rs
+++ b/core/executor/src/precompiles/mod.rs
@@ -28,8 +28,7 @@ use protocol::types::H160;
 
 use crate::precompiles::{
     blake2_f::Blake2F, call_ckb_vm::CallCkbVM, ec_add::EcAdd, ec_mul::EcMul, ec_pairing::EcPairing,
-    ecrecover::EcRecover, get_cell::GetCell, identity::Identity, modexp::ModExp,
-    ripemd160::Ripemd160, sha256::Sha256,
+    ecrecover::EcRecover, identity::Identity, modexp::ModExp, ripemd160::Ripemd160, sha256::Sha256,
 };
 
 #[macro_export]
@@ -95,8 +94,7 @@ const fn axon_precompile_address(addr: u8) -> H160 {
 
 pub fn build_precompile_set() -> BTreeMap<H160, PrecompileFn> {
     precompiles!(
-        EcRecover, Sha256, Ripemd160, Identity, ModExp, EcAdd, EcMul, EcPairing, Blake2F, GetCell,
-        CallCkbVM
+        EcRecover, Sha256, Ripemd160, Identity, ModExp, EcAdd, EcMul, EcPairing, Blake2F, CallCkbVM
     )
 }
 

--- a/core/executor/src/precompiles/mod.rs
+++ b/core/executor/src/precompiles/mod.rs
@@ -27,8 +27,9 @@ use evm::{Context, ExitError};
 use protocol::types::H160;
 
 use crate::precompiles::{
-    blake2_f::Blake2F, ec_add::EcAdd, ec_mul::EcMul, ec_pairing::EcPairing, ecrecover::EcRecover,
-    get_cell::GetCell, identity::Identity, modexp::ModExp, ripemd160::Ripemd160, sha256::Sha256,
+    blake2_f::Blake2F, call_ckb_vm::CallCkbVM, ec_add::EcAdd, ec_mul::EcMul, ec_pairing::EcPairing,
+    ecrecover::EcRecover, get_cell::GetCell, get_header::GetHeader, identity::Identity,
+    modexp::ModExp, ripemd160::Ripemd160, sha256::Sha256,
 };
 
 #[macro_export]
@@ -94,7 +95,8 @@ const fn axon_precompile_address(addr: u8) -> H160 {
 
 pub fn build_precompile_set() -> BTreeMap<H160, PrecompileFn> {
     precompiles!(
-        EcRecover, Sha256, Ripemd160, Identity, ModExp, EcAdd, EcMul, EcPairing, Blake2F, GetCell
+        EcRecover, Sha256, Ripemd160, Identity, ModExp, EcAdd, EcMul, EcPairing, Blake2F, GetCell,
+        GetHeader, CallCkbVM
     )
 }
 

--- a/core/executor/src/precompiles/mod.rs
+++ b/core/executor/src/precompiles/mod.rs
@@ -28,8 +28,8 @@ use protocol::types::H160;
 
 use crate::precompiles::{
     blake2_f::Blake2F, call_ckb_vm::CallCkbVM, ec_add::EcAdd, ec_mul::EcMul, ec_pairing::EcPairing,
-    ecrecover::EcRecover, get_cell::GetCell, get_header::GetHeader, identity::Identity,
-    modexp::ModExp, ripemd160::Ripemd160, sha256::Sha256,
+    ecrecover::EcRecover, get_cell::GetCell, identity::Identity, modexp::ModExp,
+    ripemd160::Ripemd160, sha256::Sha256,
 };
 
 #[macro_export]
@@ -96,7 +96,7 @@ const fn axon_precompile_address(addr: u8) -> H160 {
 pub fn build_precompile_set() -> BTreeMap<H160, PrecompileFn> {
     precompiles!(
         EcRecover, Sha256, Ripemd160, Identity, ModExp, EcAdd, EcMul, EcPairing, Blake2F, GetCell,
-        GetHeader, CallCkbVM
+        CallCkbVM
     )
 }
 

--- a/core/executor/src/precompiles/verify_by_ckb_vm.rs
+++ b/core/executor/src/precompiles/verify_by_ckb_vm.rs
@@ -88,7 +88,7 @@ impl VerifyByCkbPayload {
     }
 
     pub fn header_deps(&self) -> Vec<H256> {
-        self.header_deps.iter().map(|h| h.into()).collect()
+        self.header_deps.iter().map(Into::into).collect()
     }
 
     pub fn inputs(&self) -> Vec<protocol::types::OutPoint> {

--- a/core/executor/src/precompiles/verify_by_ckb_vm.rs
+++ b/core/executor/src/precompiles/verify_by_ckb_vm.rs
@@ -8,9 +8,9 @@ use protocol::types::{SignatureR, SignatureS, H160, H256};
 
 use core_interoperation::{cycle_to_gas, gas_to_cycle, InteroperationImpl};
 
-use crate::err;
 use crate::precompiles::{axon_precompile_address, call_ckb_vm::CellDep, PrecompileContract};
 use crate::system_contract::{image_cell::image_cell_abi::OutPoint, DataProvider};
+use crate::{err, CURRENT_HEADER_CELL_ROOT};
 
 #[derive(Default, Clone)]
 pub struct CkbVM;

--- a/core/executor/src/precompiles/verify_by_ckb_vm.rs
+++ b/core/executor/src/precompiles/verify_by_ckb_vm.rs
@@ -1,21 +1,16 @@
+use ethers::contract::{EthAbiCodec, EthAbiType};
+use ethers::{abi::AbiDecode, core::types::Bytes as EthBytes};
 use evm::executor::stack::{PrecompileFailure, PrecompileOutput};
 use evm::{Context, ExitError, ExitSucceed};
-use rlp::Rlp;
 
 use protocol::traits::Interoperation;
-use protocol::types::{CellDep, OutPoint, SignatureR, SignatureS, Witness, H160, H256};
+use protocol::types::{SignatureR, SignatureS, H160, H256};
 
 use core_interoperation::{cycle_to_gas, gas_to_cycle, InteroperationImpl};
 
-use crate::precompiles::{axon_precompile_address, PrecompileContract};
-use crate::CURRENT_HEADER_CELL_ROOT;
-use crate::{err, system_contract::DataProvider};
-
-macro_rules! try_rlp {
-    ($rlp_: expr, $func: ident, $pos: expr) => {{
-        $rlp_.$func($pos).map_err(|e| err!(_, e.to_string()))?
-    }};
-}
+use crate::err;
+use crate::precompiles::{axon_precompile_address, call_ckb_vm::CellDep, PrecompileContract};
+use crate::system_contract::{image_cell::image_cell_abi::OutPoint, DataProvider};
 
 #[derive(Default, Clone)]
 pub struct CkbVM;
@@ -30,19 +25,20 @@ impl PrecompileContract for CkbVM {
         _context: &Context,
         _is_static: bool,
     ) -> Result<(PrecompileOutput, u64), PrecompileFailure> {
-        let rlp = Rlp::new(input);
-        let cell_deps: Vec<CellDep> = try_rlp!(rlp, list_at, 0);
-        let header_deps: Vec<H256> = try_rlp!(rlp, list_at, 1);
-        let inputs: Vec<OutPoint> = try_rlp!(rlp, list_at, 2);
-        let witnesses: Vec<Witness> = try_rlp!(rlp, list_at, 3);
+        let payload = parse_input(input)?;
 
         if let Some(gas) = gas_limit {
             let res = InteroperationImpl::verify_by_ckb_vm(
                 Default::default(),
                 &DataProvider::new(CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow())),
                 &InteroperationImpl::dummy_transaction(
-                    SignatureR::new_by_ref(cell_deps, header_deps, inputs, Default::default()),
-                    SignatureS::new(witnesses),
+                    SignatureR::new_by_ref(
+                        payload.cell_deps(),
+                        payload.header_deps(),
+                        payload.inputs(),
+                        Default::default(),
+                    ),
+                    SignatureS::new(payload.witnesses()),
                     None,
                 ),
                 None,
@@ -53,7 +49,7 @@ impl PrecompileContract for CkbVM {
             return Ok((
                 PrecompileOutput {
                     exit_status: ExitSucceed::Returned,
-                    output:      0i8.to_le_bytes().to_vec(),
+                    output:      res.to_le_bytes().to_vec(),
                 },
                 cycle_to_gas(res).max(Self::MIN_GAS),
             ));
@@ -64,5 +60,81 @@ impl PrecompileContract for CkbVM {
 
     fn gas_cost(_input: &[u8]) -> u64 {
         unreachable!()
+    }
+}
+
+fn parse_input(input: &[u8]) -> Result<VerifyByCkbPayload, PrecompileFailure> {
+    <VerifyByCkbPayload as AbiDecode>::decode(input).map_err(|_| err!(_, "decode input"))
+}
+
+#[derive(EthAbiType, EthAbiCodec, Clone, Default, Debug, PartialEq, Eq)]
+pub struct VerifyByCkbPayload {
+    pub cell_deps:   Vec<CellDep>,
+    pub header_deps: Vec<[u8; 32]>,
+    pub inputs:      Vec<OutPoint>,
+    pub witnesses:   Vec<WitnessArgs>,
+}
+
+impl VerifyByCkbPayload {
+    pub fn cell_deps(&self) -> Vec<protocol::types::CellDep> {
+        self.cell_deps
+            .iter()
+            .map(|c| protocol::types::CellDep {
+                tx_hash:  c.out_point.tx_hash.into(),
+                index:    c.out_point.index,
+                dep_type: c.dep_type,
+            })
+            .collect()
+    }
+
+    pub fn header_deps(&self) -> Vec<H256> {
+        self.header_deps.iter().map(|h| h.into()).collect()
+    }
+
+    pub fn inputs(&self) -> Vec<protocol::types::OutPoint> {
+        self.inputs
+            .iter()
+            .map(|i| protocol::types::OutPoint {
+                tx_hash: i.tx_hash.into(),
+                index:   i.index,
+            })
+            .collect()
+    }
+
+    pub fn witnesses(&self) -> Vec<protocol::types::Witness> {
+        self.witnesses.clone().into_iter().map(Into::into).collect()
+    }
+}
+
+#[derive(EthAbiType, EthAbiCodec, Clone, Default, Debug, PartialEq, Eq)]
+pub struct WitnessArgs {
+    pub lock:        EthBytes,
+    pub input_type:  EthBytes,
+    pub output_type: EthBytes,
+}
+
+impl From<WitnessArgs> for protocol::types::Witness {
+    fn from(w: WitnessArgs) -> Self {
+        let lock = if w.lock.is_empty() {
+            None
+        } else {
+            Some(w.lock.0)
+        };
+        let input_type = if w.input_type.is_empty() {
+            None
+        } else {
+            Some(w.input_type.0)
+        };
+        let output_type = if w.output_type.is_empty() {
+            None
+        } else {
+            Some(w.output_type.0)
+        };
+
+        protocol::types::Witness {
+            lock,
+            input_type,
+            output_type,
+        }
     }
 }

--- a/examples/solidity/CallCkbVm.sol
+++ b/examples/solidity/CallCkbVm.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+import "./Types.sol";
+
+contract CallCkbVm {
+    event CallCkbVmEvent(int8);
+    event NotGetCellEvent();
+
+    int8 ret;
+
+    function testCallCkbVm(
+        bytes32 txHash,
+        uint32 index,
+        uint8 depType,
+        bytes[] memory input_args
+    ) public {
+        OutPoint memory outPoint = OutPoint(txHash, index);
+        (bool isSuccess, bytes memory res) = address(0x0104).staticcall(
+            abi.encode(CellDep(outPoint, depType), input_args)
+        );
+
+        if (isSuccess) {
+            ret = int8(uint8(res[0]));
+            emit CallCkbVmEvent(ret);
+        } else {
+            emit NotGetCellEvent();
+        }
+    }
+
+    function callCkbVm() public view returns (int8) {
+        return ret;
+    }
+}

--- a/examples/solidity/GetCell.sol
+++ b/examples/solidity/GetCell.sol
@@ -10,7 +10,9 @@ contract GetCell {
     Cell cell;
 
     function testGetCell(bytes32 txHash, uint32 index) public {
-        (bool isSuccess, bytes memory res) = address(0x0103).staticcall(abi.encode(OutPoint(txHash, index)));
+        (bool isSuccess, bytes memory res) = address(0x0103).staticcall(
+            abi.encode(OutPoint(txHash, index))
+        );
 
         if (isSuccess) {
             cell = abi.decode(res, (Cell));

--- a/examples/solidity/Types.sol
+++ b/examples/solidity/Types.sol
@@ -31,9 +31,9 @@ struct Cell {
 }
 
 struct CellOutput {
-    uint64 capacity;
-    Script lock;
-    Script type_;
+    uint64   capacity;
+    Script   lock;
+    Script[] type_;
 }
 
 struct Script {

--- a/examples/solidity/Types.sol
+++ b/examples/solidity/Types.sol
@@ -1,17 +1,33 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0;
 
+struct VerifyPayload {
+    CellDep[]     cellDeps;
+    HeaderDep[]   headerDeps;
+    OutPoint[]    inputs;
+    WitnessArgs[] witnesses;
+}
+
 struct OutPoint {
     bytes32 txHash;
-    uint32 index;
+    uint32  index;
+}
+
+struct CellDep {
+    OutPoint outPoint;
+    uint8    index;
+}
+
+struct HeaderDep {
+    bytes32 headerHash;
 }
 
 struct Cell {
     CellOutput cellOutput;
-    bytes cellData;
-    bool isConsumed;
-    uint64 createdNumber;
-    uint64 consumedNumber;
+    bytes      cellData;
+    bool       isConsumed;
+    uint64     createdNumber;
+    uint64     consumedNumber;
 }
 
 struct CellOutput {
@@ -22,8 +38,14 @@ struct CellOutput {
 
 struct Script {
     ScriptHashType hashType;
-    bytes32 codeHash;
-    bytes args;
+    bytes32        codeHash;
+    bytes          args;
+}
+
+struct WitnessArgs {
+    bytes lock;
+    bytes inputType;
+    bytes outputType;
 }
 
 enum ScriptHashType {
@@ -33,17 +55,17 @@ enum ScriptHashType {
 }
 
 struct Header {
-    uint32 version;
-    uint32 compactTarget;
-    uint64 timestamp;
-    uint64 number;
-    uint64 epch;
+    uint32  version;
+    uint32  compactTarget;
+    uint64  timestamp;
+    uint64  number;
+    uint64  epch;
     bytes32 parentHash;
     bytes32 transactionsRoot;
     bytes32 proposalsHash;
     bytes32 extraHash;
     bytes32 dao;
     uint128 nonce;
-    bytes extension;
+    bytes   extension;
     bytes32 blockHash;
 }

--- a/examples/solidity/VerifyByCKb.sol
+++ b/examples/solidity/VerifyByCKb.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+import "./Types.sol";
+
+contract VerifyByCkb {
+    event VerifyByCkbErent(uint64);
+    event NotGetCellEvent();
+
+    uint64 ret;
+
+    function testVerifyByCkb(
+        CellDep[] memory cellDeps,
+        HeaderDep[] memory HeaderDeps,
+        OutPoint[] memory inputs,
+        WitnessArgs[] memory witnesses
+    ) public {
+        VerifyPayload memory payload = VerifyPayload(
+            cellDeps,
+            HeaderDeps,
+            inputs,
+            witnesses
+        );
+        (bool isSuccess, bytes memory res) = address(0x0105).staticcall(
+            abi.encode(payload)
+        );
+
+        if (isSuccess) {
+            ret = bytesToUint64(res);
+            emit VerifyByCkbErent(ret);
+        } else {
+            emit NotGetCellEvent();
+        }
+    }
+
+    function callCkbVm() public view returns (uint64) {
+        return ret;
+    }
+
+    function bytesToUint64(bytes memory b) public pure returns (uint64) {
+        uint64 number;
+
+        for (uint i = 0; i < 8; i++) {
+            number = number + uint8(b[i]);
+        }
+
+        return number;
+    }
+}

--- a/examples/solidity/VerifyByCKb.sol
+++ b/examples/solidity/VerifyByCKb.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.9;
 import "./Types.sol";
 
 contract VerifyByCkb {
-    event VerifyByCkbErent(uint64);
+    event VerifyByCkbEvent(uint64);
     event NotGetCellEvent();
 
     uint64 ret;
@@ -27,7 +27,7 @@ contract VerifyByCkb {
 
         if (isSuccess) {
             ret = bytesToUint64(res);
-            emit VerifyByCkbErent(ret);
+            emit VerifyByCkbEvent(ret);
         } else {
             emit NotGetCellEvent();
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR change the payloads of call CKB vm and verify by CKB precompile contracts into `EthAbiCodec` derive. The old version is defined by `rlp`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
