### PR TITLE
fix(storage): genesis receipts should be saved

### DIFF
--- a/core/consensus/src/lib.rs
+++ b/core/consensus/src/lib.rs
@@ -28,7 +28,7 @@ use protocol::{Display, ProtocolError, ProtocolErrorKind};
 
 pub use crate::adapter::OverlordConsensusAdapter;
 pub use crate::consensus::OverlordConsensus;
-pub use crate::synchronization::{OverlordSynchronization, RichBlock, SyncStatus, SYNC_STATUS};
+pub use crate::synchronization::{OverlordSynchronization, SyncStatus, SYNC_STATUS};
 pub use crate::wal::{ConsensusWal, SignedTxsWAL};
 pub use overlord::{types::Node, DurationConfig};
 

--- a/core/consensus/src/tests/synchronization.rs
+++ b/core/consensus/src/tests/synchronization.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use protocol::{
     tokio::{self, sync::Mutex as AsyncMutex},
     traits::{Context, Synchronization},
-    types::{Block, Header},
+    types::{Block, Header, RichBlock},
 };
 
 use crate::{
     status::{CurrentStatus, StatusAgent},
-    synchronization::{OverlordSynchronization, RichBlock},
+    synchronization::OverlordSynchronization,
     tests::MockSyncAdapter,
     util::time_now,
 };

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -11,9 +11,7 @@ mod utils;
 
 pub use crate::adapter::{AxonExecutorAdapter, MPTTrie, RocksTrieDB};
 pub use crate::system_contract::{metadata::MetadataHandle, DataProvider};
-pub use crate::utils::{
-    code_address, decode_revert_msg, logs_bloom, DefaultFeeAllocator, FeeInlet,
-};
+pub use crate::utils::{code_address, decode_revert_msg, DefaultFeeAllocator, FeeInlet};
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -27,9 +25,9 @@ use common_merkle::TrieMerkle;
 use protocol::codec::ProtocolCodec;
 use protocol::traits::{Backend, Executor, ExecutorAdapter};
 use protocol::types::{
-    data_gas_cost, Account, Config, ExecResp, Hasher, SignedTransaction, TransactionAction, TxResp,
-    ValidatorExtend, GAS_CALL_TRANSACTION, GAS_CREATE_TRANSACTION, H160, H256, NIL_DATA, RLP_NULL,
-    U256,
+    data_gas_cost, logs_bloom, Account, Config, ExecResp, Hasher, SignedTransaction,
+    TransactionAction, TxResp, ValidatorExtend, GAS_CALL_TRANSACTION, GAS_CREATE_TRANSACTION, H160,
+    H256, NIL_DATA, RLP_NULL, U256,
 };
 
 use crate::precompiles::build_precompile_set;

--- a/core/executor/src/utils.rs
+++ b/core/executor/src/utils.rs
@@ -1,4 +1,4 @@
-use protocol::types::{Bloom, Hasher, Log, H160, H256, U256};
+use protocol::types::{Hasher, H160, H256, U256};
 
 use crate::FeeAllocate;
 
@@ -6,7 +6,6 @@ const FUNC_SELECTOR_LEN: usize = 4;
 const U256_BE_BYTES_LEN: usize = 32;
 const REVERT_MSG_LEN_OFFSET: usize = FUNC_SELECTOR_LEN + U256_BE_BYTES_LEN;
 const REVERT_EFFECT_MSG_OFFSET: usize = REVERT_MSG_LEN_OFFSET + U256_BE_BYTES_LEN;
-const BLOOM_BYTE_LENGTH: usize = 256;
 const EXEC_REVERT: &str = "execution reverted: ";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -71,29 +70,6 @@ pub fn decode_revert_msg(input: &[u8]) -> String {
     }
 
     decode_reason(&input[REVERT_EFFECT_MSG_OFFSET..end_offset])
-}
-
-pub fn logs_bloom<'a, I>(logs: I) -> Bloom
-where
-    I: Iterator<Item = &'a Log>,
-{
-    let mut bloom = Bloom::zero();
-
-    for log in logs {
-        m3_2048(&mut bloom, log.address.as_bytes());
-        for topic in log.topics.iter() {
-            m3_2048(&mut bloom, topic.as_bytes());
-        }
-    }
-    bloom
-}
-
-fn m3_2048(bloom: &mut Bloom, x: &[u8]) {
-    let hash = Hasher::digest(x).0;
-    for i in [0, 2, 4] {
-        let bit = (hash[i + 1] as usize + ((hash[i] as usize) << 8)) & 0x7FF;
-        bloom.0[BLOOM_BYTE_LENGTH - 1 - bit / 8] |= 1 << (bit % 8);
-    }
 }
 
 #[cfg(test)]

--- a/protocol/src/types/mod.rs
+++ b/protocol/src/types/mod.rs
@@ -6,7 +6,8 @@ pub use bytes::{Buf, BufMut, Bytes, BytesMut};
 pub use ckb_client::*;
 pub use evm::{backend::*, ExitError, ExitRevert, ExitSucceed};
 pub use executor::{
-    AccessList, AccessListItem, Account, Config, ExecResp, ExecutorContext, ExitReason, TxResp,
+    logs_bloom, AccessList, AccessListItem, Account, Config, ExecResp, ExecutorContext, ExitReason,
+    TxResp,
 };
 pub use interoperation::*;
 pub use primitive::*;

--- a/tests/e2e/src/eth_feeHistory.test.js
+++ b/tests/e2e/src/eth_feeHistory.test.js
@@ -24,7 +24,7 @@ describe("eth_feeHistory", () => {
       baseFeePerGas: ["0x539", "0x539"],
       gasUsedRatio: [0],
       oldestBlock: "0x0",
-      reward: [["0x0", "0x0"]],
+      reward: [["0x24f304", "0x0"]],
     });
   }, 100000);
 
@@ -79,7 +79,7 @@ describe("eth_feeHistory", () => {
       baseFeePerGas: ["0x539", "0x539"],
       gasUsedRatio: [0],
       oldestBlock: "0x0",
-      reward: [["0x0", "0x0"]],
+      reward: [["0x24f304", "0x0"]],
     });
   }, 100000);
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fix [this issue](https://github.com/axonweb3/axon/pull/1278#discussion_r1269003807).

**Which toolchain this PR adaption**:

Breaking Change:
- The storage data, which is initialized with previous versions, won't be fixed.
- Change fee.

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
