### PR TITLE
fix: no default values when unexpected errors occurred

### DIFF
--- a/core/executor/src/adapter/mod.rs
+++ b/core/executor/src/adapter/mod.rs
@@ -149,7 +149,7 @@ where
     fn exists(&self, address: H160) -> bool {
         self.trie
             .contains(&Bytes::from(address.as_bytes().to_vec()))
-            .unwrap_or_default()
+            .unwrap_or(false)
     }
 
     fn basic(&self, address: H160) -> Basic {

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -186,13 +186,18 @@ impl Executor for AxonExecutor {
 
         // self.update_system_contract_roots_for_external_module();
 
+        // TODO When fixes receipt_root, set to RLP_NULL when empty
+        let receipt_root = TrieMerkle::from_iter(hashes.iter().enumerate())
+            .root_hash()
+            .unwrap_or_else(|err| {
+                panic!("failed to calculate trie root hash for receipts since {err}")
+            });
+
         ExecResp {
-            state_root:   new_state_root,
-            receipt_root: TrieMerkle::from_iter(hashes.iter().enumerate())
-                .root_hash()
-                .unwrap_or_default(),
-            gas_used:     gas,
-            tx_resp:      res,
+            state_root: new_state_root,
+            receipt_root,
+            gas_used: gas,
+            tx_resp: res,
         }
     }
 
@@ -372,13 +377,17 @@ impl AxonExecutor {
         // commit changes by all txs included in this block only once
         let new_state_root = adapter.commit();
 
+        let receipt_root = TrieMerkle::from_iter(hashes.iter().enumerate())
+            .root_hash()
+            .unwrap_or_else(|err| {
+                panic!("failed to calculate trie root hash for receipts since {err}")
+            });
+
         ExecResp {
-            state_root:   new_state_root,
-            receipt_root: TrieMerkle::from_iter(hashes.iter().enumerate())
-                .root_hash()
-                .unwrap_or_default(),
-            gas_used:     gas,
-            tx_resp:      res,
+            state_root: new_state_root,
+            receipt_root,
+            gas_used: gas,
+            tx_resp: res,
         }
     }
 }

--- a/core/executor/src/precompiles/get_cell.rs
+++ b/core/executor/src/precompiles/get_cell.rs
@@ -42,7 +42,7 @@ impl PrecompileContract for GetCell {
                 cell_data:       c.cell_data.into(),
                 is_consumed:     c.consumed_number.is_some(),
                 created_number:  c.created_number,
-                consumed_number: c.consumed_number.unwrap_or_default(),
+                consumed_number: c.consumed_number.unwrap_or(0),
             })
             .unwrap_or_default();
 

--- a/protocol/src/types/interoperation.rs
+++ b/protocol/src/types/interoperation.rs
@@ -180,11 +180,7 @@ impl From<&CellWithData> for CellMeta {
 
 impl CellWithData {
     pub fn capacity(&self) -> u64 {
-        let capacity = self
-            .type_script
-            .as_ref()
-            .map(|s| s.len())
-            .unwrap_or_default()
+        let capacity = self.type_script.as_ref().map(|s| s.len()).unwrap_or(0)
             + self.lock_script.len()
             + self.data.len()
             + CAPACITY_BYTES_LEN;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR:
- Remove `unwrap_or_default` for unexpected errors.

- Set default value directly instead of `unwrap_or_default`.

  - `const fn for traits` is not released (today, latest toolchain is `1.71.0`), set a const value with `unwrap_or(const_value)` is better than `unwrap_or_default`, since `unwrap_or_default` will call the `Default::default(..)` function.
     p.s. `-O3`, even `-O2`, may ignore the call, set const value directly.

  - More readability, a literal value is more clearly than `Default::default(..)`.

**Which issue(s) this PR fixes**:

Fixes #1287

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
