### PR TITLE
fix: struct CellOutput in solidiy example

### DIFF
--- a/examples/solidity/Types.sol
+++ b/examples/solidity/Types.sol
@@ -31,9 +31,9 @@ struct Cell {
 }
 
 struct CellOutput {
-    uint64 capacity;
-    Script lock;
-    Script type_;
+    uint64   capacity;
+    Script   lock;
+    Script[] type_;
 }
 
 struct Script {


### PR DESCRIPTION
Fix struct CellOutput in solidiy example.