### PR TITLE
refactor: get client version from crate and git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 name = "abi-generator"
 version = "0.1.0"
 dependencies = [
- "clap 4.2.7",
+ "clap 4.3.19",
  "ethers",
 ]
 
@@ -276,7 +276,8 @@ name = "axon"
 version = "0.1.0-beta.5"
 dependencies = [
  "axon-protocol",
- "clap 4.2.7",
+ "clap 4.3.19",
+ "common-version",
  "core-api",
  "core-cli",
  "core-consensus",
@@ -1298,25 +1299,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
  "clap_builder",
- "clap_derive 4.2.0",
+ "clap_derive 4.3.12",
  "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
- "clap_lex 0.4.1",
+ "clap_lex 0.5.0",
  "once_cell",
  "strsim 0.10.0",
 ]
@@ -1336,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1357,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "clear_on_drop"
@@ -1561,6 +1561,13 @@ name = "common-pubsub"
 version = "0.2.1"
 
 [[package]]
+name = "common-version"
+version = "0.1.0"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "console"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1635,9 +1642,10 @@ name = "core-cli"
 version = "0.1.0"
 dependencies = [
  "axon-protocol",
- "clap 4.2.7",
+ "clap 4.3.19",
  "common-config-parser",
  "common-logger",
+ "common-version",
  "core-run",
  "semver",
  "serde",
@@ -1922,7 +1930,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.2.7",
+ "clap 4.3.19",
  "criterion-plot",
  "futures",
  "is-terminal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,13 @@ version = "0.1.0-beta.5"
 authors = ["Nervos Dev <dev@nervos.org>"]
 edition = "2021"
 repository = "https://github.com/axonweb3/axon"
+build = "build.rs"
 
 [dependencies]
-clap = { version = "4.2", features = ["cargo"] }
+clap = { version = "4.3", features = ["cargo"] }
 
 # byzantine = { path = "./byzantine" }
+common-version = { path = "./common/version" }
 core-api = { path = "./core/api" }
 core-cli = { path = "./core/cli" }
 core-consensus = { path = "./core/consensus" }
@@ -28,6 +30,7 @@ members = [
     "common/memory-tracker",
     "common/merkle",
     "common/pubsub",
+    "common/version",
     "core/api",
     "core/cli",
     "core/consensus",
@@ -60,6 +63,13 @@ inherits = "release"
 debug = true
 overflow-checks = true
 opt-level = 3
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "axon"
+path = "src/main.rs"
 
 [[example]]
 name = "custom_chain"

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,10 @@
 fn main() {
-    let desc = std::process::Command::new("git")
+    if let Some(commit_id) = std::process::Command::new("git")
         .args(["describe", "--always", "--dirty", "--exclude", "*"])
         .output()
         .ok()
         .and_then(|r| String::from_utf8(r.stdout).ok())
-        .map(|d| format!(" {d}"))
-        .unwrap_or_default();
-    println!("cargo:rustc-env=AXON_GIT_DESCRIPTION={desc}");
+    {
+        println!("cargo:rustc-env=AXON_COMMIT_ID={}", commit_id);
+    }
 }

--- a/common/config-parser/src/types.rs
+++ b/common/config-parser/src/types.rs
@@ -87,8 +87,6 @@ pub struct ConfigApi {
     pub maxconn:                u32,
     pub max_payload_size:       u32,
     pub enable_dump_profile:    Option<bool>,
-    #[serde(default)]
-    pub client_version:         String,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/common/version/Cargo.toml
+++ b/common/version/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
-name = "abi-generator"
+name = "common-version"
 version = "0.1.0"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.3", features = ["derive"] }
-ethers = "2.0"
+semver = "1.0"

--- a/common/version/src/lib.rs
+++ b/common/version/src/lib.rs
@@ -1,0 +1,60 @@
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+pub const DEFAULT_COMMIT_ID: &str = "unknown";
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version {
+    inner: semver::Version,
+}
+
+impl FromStr for Version {
+    type Err = semver::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        semver::Version::from_str(s).map(|inner| Version { inner })
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl Version {
+    pub fn new(ver: &str) -> Self {
+        Version::from_str(ver)
+            .unwrap_or_else(|e| panic!("Parse version error {:?}", e))
+            .set_commit_id(DEFAULT_COMMIT_ID)
+    }
+
+    pub fn new_with_commit_id(ver: &str, commit_id: &str) -> Self {
+        Version::new(ver).set_commit_id(commit_id)
+    }
+
+    pub fn commit_id(&self) -> String {
+        self.inner.build.to_ascii_lowercase()
+    }
+
+    fn set_commit_id(mut self, commit_id: &str) -> Self {
+        self.inner.build = semver::BuildMetadata::new(commit_id)
+            .unwrap_or_else(|e| panic!("Parse commit id error {:?}", e));
+
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use semver::BuildMetadata;
+    use std::str::FromStr;
+
+    use crate::DEFAULT_COMMIT_ID;
+
+    #[test]
+    fn test_parse_default_commit_id() {
+        let build = BuildMetadata::from_str(DEFAULT_COMMIT_ID);
+        assert_eq!(build.unwrap().as_str(), DEFAULT_COMMIT_ID);
+    }
+}

--- a/core/api/src/jsonrpc/impl/node.rs
+++ b/core/api/src/jsonrpc/impl/node.rs
@@ -17,10 +17,10 @@ pub struct NodeRpcImpl {
 }
 
 impl NodeRpcImpl {
-    pub fn new(version: &str, path: PathBuf) -> Self {
+    pub fn new(ver: String, path: PathBuf) -> Self {
         NodeRpcImpl {
-            version: version.to_string(),
-            pprof:   Arc::new(AtomicBool::default()),
+            version: ver,
+            pprof:   Arc::new(AtomicBool::new(false)),
             _path:   path.join("api"),
         }
     }

--- a/core/api/src/jsonrpc/mod.rs
+++ b/core/api/src/jsonrpc/mod.rs
@@ -241,6 +241,7 @@ pub trait CkbLightClientRpc {
 }
 
 pub async fn run_jsonrpc_server<Adapter: APIAdapter + 'static>(
+    version: String,
     config: Config,
     adapter: Arc<Adapter>,
 ) -> ProtocolResult<(Option<ServerHandle>, Option<ServerHandle>)> {
@@ -253,8 +254,7 @@ pub async fn run_jsonrpc_server<Adapter: APIAdapter + 'static>(
     )
     .into_rpc();
 
-    let node_rpc =
-        r#impl::NodeRpcImpl::new(&config.rpc.client_version, config.data_path).into_rpc();
+    let node_rpc = r#impl::NodeRpcImpl::new(version, config.data_path).into_rpc();
     let axon_rpc = r#impl::AxonRpcImpl::new(Arc::clone(&adapter)).into_rpc();
     let filter =
         r#impl::filter_module(Arc::clone(&adapter), config.web3.log_filter_max_block_range)

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "4.2"
+clap = { version = "4.3", features = ["cargo", "string"] }
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -14,5 +14,6 @@ thiserror = "1.0"
 
 common-config-parser = { path = "../../common/config-parser" }
 common-logger = { path = "../../common/logger" }
+common-version = { path = "../../common/version" }
 core-run = { path = "../../core/run" }
 protocol = { path = "../../protocol", package = "axon-protocol" }

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -81,6 +81,7 @@ pub static JEMALLOC: Jemalloc = Jemalloc;
 
 #[derive(Debug)]
 pub struct Axon {
+    version:    String,
     config:     Config,
     genesis:    RichBlock,
     state_root: MerkleRoot,
@@ -90,8 +91,9 @@ pub struct Axon {
 mod tests;
 
 impl Axon {
-    pub fn new(config: Config, genesis: RichBlock) -> Axon {
+    pub fn new(version: String, config: Config, genesis: RichBlock) -> Axon {
         Axon {
+            version,
             config,
             genesis,
             state_root: MerkleRoot::default(),
@@ -386,7 +388,7 @@ impl Axon {
             Arc::clone(&trie_db),
             Arc::new(network_handle),
         ));
-        let _handles = run_jsonrpc_server(self.config.clone(), api_adapter).await?;
+        let _handles = run_jsonrpc_server(self.version, self.config.clone(), api_adapter).await?;
 
         // Run sync
         tokio::spawn(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,15 @@ use core_executor::FEE_ALLOCATOR;
 pub fn run(
     fee_allocator: impl FeeAllocate + 'static,
     key_provider: impl KeyProvider,
-    cli_version: &'static str,
+    app_version: &'static str,
 ) -> Result<()> {
     FEE_ALLOCATOR.swap(Arc::new(Box::new(fee_allocator)));
-    AxonCli::init(clap::crate_version!().parse().unwrap(), cli_version)
-        .start_with_custom_key_provider(Some(key_provider))
+
+    AxonCli::init(
+        clap::crate_version!()
+            .parse()
+            .expect("Parse kernel version"),
+        app_version.parse().expect("Parse application version"),
+    )
+    .start_with_custom_key_provider(Some(key_provider))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,15 @@
+use clap::crate_version;
+
+use common_version::Version;
 use core_cli::AxonCli;
 
 fn main() {
-    let result = AxonCli::init(
-        clap::crate_version!().parse().unwrap(),
-        concat!(clap::crate_version!(), env!("AXON_GIT_DESCRIPTION")),
-    )
-    .start();
-    if let Err(e) = result {
+    let crate_version = crate_version!();
+    let kernel_version = option_env!("AXON_COMMIT_ID")
+        .map(|commit_id| Version::new_with_commit_id(crate_version, commit_id))
+        .unwrap_or_else(|| Version::new(crate_version));
+
+    if let Err(e) = AxonCli::init(kernel_version.clone(), kernel_version).start() {
         eprintln!("Error {e}");
         std::process::exit(1);
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

This PR
1. Get the client version from crate version and git such as `0.1.0-beta.5+8f3eded`
2. Remove the `client_version` field in `config.rpc`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
