### PR TITLE
ci: add merge_group to enable GitHub merge queue

### DIFF
--- a/.github/workflows/axon-start-with-short-genesis.yml
+++ b/.github/workflows/axon-start-with-short-genesis.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
 jobs:
   build:
     runs-on: [self-hosted,spark]

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -5,6 +5,7 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize, reopened ]
+  merge_group:
   workflow_dispatch:
     inputs:
       dispatch:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -5,6 +5,7 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize, reopened ]
+  merge_group:
   workflow_dispatch:
     inputs:
       dispatch:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  merge_group:
   workflow_dispatch:
     inputs:
       dispatch:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -5,6 +5,7 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize, reopened ]
+  merge_group:
   workflow_dispatch:
     inputs:
       dispatch:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds merge_group to enable GitHub merge queue.

Without `merge_group` in workflows, the merge queue is fancy but not totally useless.

[GitHub Docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) has written:
> You must use the `merge_group` event to trigger your GitHub Actions workflow when a pull request is added to a merge queue.

I only add the 5 basic checks as required checks for merging a PR.

**Which issue(s) this PR fixes**:

Fixes #1312.

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests
