### PR TITLE
refactor: use constant values as default values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "ckb-types",
  "common-crypto",
  "common-hasher",
+ "common-merkle",
  "creep",
  "derive_more",
  "ethereum",

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -18,8 +18,8 @@ use common_logger::{json, log};
 use common_merkle::TrieMerkle;
 use protocol::traits::{ConsensusAdapter, Context, MessageTarget, NodeInfo};
 use protocol::types::{
-    Block, BlockVersion, Bytes, ExecResp, Hash, Hasher, Hex, Metadata, Proof, Proposal,
-    SignedTransaction, ValidatorExtend, BASE_FEE_PER_GAS, MAX_BLOCK_GAS_LIMIT, RLP_NULL,
+    Block, BlockVersion, Bytes, ExecResp, Hash, Hex, Metadata, Proof, Proposal, SignedTransaction,
+    ValidatorExtend, BASE_FEE_PER_GAS, MAX_BLOCK_GAS_LIMIT, RLP_NULL,
 };
 use protocol::{async_trait, tokio::sync::Mutex as AsyncMutex, ProtocolError, ProtocolResult};
 
@@ -551,7 +551,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
                 })
         };
 
-        let stxs_hash = Hasher::digest(rlp::encode_list(signed_txs));
+        let stxs_hash = digest_signed_transactions(signed_txs);
 
         if stxs_hash != proposal.signed_txs_hash {
             return Err(ConsensusError::InvalidOrderSignedTransactionsHash {

--- a/core/consensus/src/util.rs
+++ b/core/consensus/src/util.rs
@@ -11,11 +11,17 @@ use common_crypto::{
     BlsPrivateKey, BlsPublicKey, BlsSignature, BlsSignatureVerify, HashValue, PrivateKey, Signature,
 };
 use protocol::traits::Context;
-use protocol::types::{Address, Bytes, Hash, Hasher, Hex, MerkleRoot, SignedTransaction};
+use protocol::types::{
+    Address, Bytes, Hash, Hasher, Hex, MerkleRoot, SignedTransaction, RLP_EMPTY_LIST,
+};
 use protocol::{ProtocolError, ProtocolResult};
 
 pub fn digest_signed_transactions(stxs: &[SignedTransaction]) -> Hash {
-    Hasher::digest(rlp::encode_list(stxs))
+    if stxs.is_empty() {
+        RLP_EMPTY_LIST
+    } else {
+        Hasher::digest(rlp::encode_list(stxs))
+    }
 }
 
 pub fn time_now() -> u64 {

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -187,12 +187,15 @@ impl Executor for AxonExecutor {
 
         // self.update_system_contract_roots_for_external_module();
 
-        // TODO When fixes receipt_root, set to RLP_NULL when empty
-        let receipt_root = TrieMerkle::from_iter(hashes.iter().enumerate())
-            .root_hash()
-            .unwrap_or_else(|err| {
-                panic!("failed to calculate trie root hash for receipts since {err}")
-            });
+        let receipt_root = if hashes.is_empty() {
+            RLP_NULL
+        } else {
+            TrieMerkle::from_iter(hashes.iter().enumerate())
+                .root_hash()
+                .unwrap_or_else(|err| {
+                    panic!("failed to calculate trie root hash for receipts since {err}")
+                })
+        };
 
         ExecResp {
             state_root: new_state_root,
@@ -381,11 +384,15 @@ impl AxonExecutor {
         // commit changes by all txs included in this block only once
         let new_state_root = adapter.commit();
 
-        let receipt_root = TrieMerkle::from_iter(hashes.iter().enumerate())
-            .root_hash()
-            .unwrap_or_else(|err| {
-                panic!("failed to calculate trie root hash for receipts since {err}")
-            });
+        let receipt_root = if hashes.is_empty() {
+            RLP_NULL
+        } else {
+            TrieMerkle::from_iter(hashes.iter().enumerate())
+                .root_hash()
+                .unwrap_or_else(|err| {
+                    panic!("failed to calculate trie root hash for receipts since {err}")
+                })
+        };
 
         ExecResp {
             state_root: new_state_root,

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -40,6 +40,8 @@ hex = "0.4"
 serde_json = "1.0"
 toml = "0.7"
 
+common-merkle = { path = "../common/merkle" }
+
 [features]
 default = ["hex-serialize"]
 hex-serialize = []

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -30,9 +30,17 @@ pub const NIL_DATA: H256 = H256([
     0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b, 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70,
 ]);
 
+// Same value as `hash(rlp(null))`.
+// Also be same value as the `root_hash` of an empty `TrieMerkle`.
 pub const RLP_NULL: H256 = H256([
     0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6, 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e,
     0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0, 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21,
+]);
+
+// Same value as `hash(rlp([]))`.
+pub const RLP_EMPTY_LIST: H256 = H256([
+    0x1d, 0xcc, 0x4d, 0xe8, 0xde, 0xc7, 0x5d, 0x7a, 0xab, 0x85, 0xb5, 0x67, 0xb6, 0xcc, 0xd4, 0x1a,
+    0xd3, 0x12, 0x45, 0x1b, 0x94, 0x8a, 0x74, 0x13, 0xf0, 0xa1, 0x42, 0xfd, 0x40, 0xd4, 0x93, 0x47,
 ]);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -481,6 +489,8 @@ mod tests {
     use super::*;
     use std::fs;
 
+    use common_merkle::TrieMerkle;
+
     #[test]
     fn test_eip55() {
         let addr = "0x35e70c3f5a794a77efc2ec5ba964bffcc7fd2c0a";
@@ -510,10 +520,30 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_empty() {
+    fn test_default_values() {
         let bytes = Hex::empty();
         let hash = Hasher::digest(bytes.as_bytes());
         assert_eq!(hash, NIL_DATA);
+
+        let h256_default = H256::default();
+        assert!(h256_default.is_zero());
+
+        let null_data: &[u8] = &[];
+        let rlp_null_data = rlp::encode(&null_data);
+        assert_eq!(&rlp_null_data, &rlp::NULL_RLP[..]);
+
+        let empty_list: Vec<u8> = vec![];
+        let rlp_empty_list = rlp::encode_list(&empty_list);
+        assert_eq!(&rlp_empty_list, &rlp::EMPTY_LIST_RLP[..]);
+
+        let hash = Hasher::digest(rlp::NULL_RLP);
+        assert_eq!(hash, RLP_NULL);
+
+        let hash = Hasher::digest(rlp::EMPTY_LIST_RLP);
+        assert_eq!(hash, RLP_EMPTY_LIST);
+
+        let root = TrieMerkle::default().root_hash().unwrap();
+        assert_eq!(root, RLP_NULL);
     }
 
     #[test]


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this PR, some values use constant values to set the default values, and some are not.

<details><summary>Click for example.</summary>

https://github.com/axonweb3/axon/blob/4ef2f5608633d8a60bfd50ab337b4965de3b714b/core/consensus/src/engine.rs#L71-L79

In fact, the above code is the same as

```rust
let txs_root = { 
    TrieMerkle::from_iter(txs.hashes.iter().enumerate()) 
        .root_hash() 
        .unwrap_or_else(|err| { 
            panic!("failed to calculate trie root hash for transactions since {err}") 
        })
}; 
```

The only difference is avoiding some computations, so that improve a little performance.

---

</details>

In this PR:
- Unify the value assignments of those roots.
- Add documentation how these constant value come.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Which docs this PR relation**:

Ref #1318

**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

NIL

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests