### PR TITLE
chore(CI): add `Start Single Axon Node` test

### DIFF
--- a/.github/workflows/single-node.yml
+++ b/.github/workflows/single-node.yml
@@ -1,0 +1,81 @@
+# TODO: deprecate axon-start-with-short-genesis.yml
+name: Start Single Axon Node
+
+on:
+  push:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  build-and-run:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04] # TODO: test on [ubuntu-22.04, windows-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache of Axon binary
+        id: axon-bin-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            target/debug/axon
+          key: ${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+
+      - name: Cargo Cache
+        if: steps.axon-bin-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cargo-
+
+      - name: Cache Axon target directory
+        if: steps.axon-bin-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@v3
+        with:
+          path: |
+            target
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-target-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cargo-target
+      
+      - name: Install Rust components
+        if: steps.axon-bin-cache.outputs.cache-hit != 'true'
+        run: rustup component add rustfmt && rustup component add clippy
+
+      - name: Build Axon
+        if: steps.axon-bin-cache.outputs.cache-hit != 'true'
+        run: cargo build
+
+      - name: Start a single Axon node
+        run: |
+          target/debug/axon --version
+          target/debug/axon run \
+            -c devtools/chain/config.toml \
+            -g devtools/chain/genesis_single_node.json \
+            > /tmp/single-axon-node.log &
+         
+          sleep 700
+          set +e
+          result=$(tail -n 100 /tmp/single-axon-node.log | grep 'state goto new height 200')
+
+          if [[ "$result" != ""]]
+          then
+              echo "axon chain works well"
+          else
+              echo "axon chain has some issues, please have a check"
+              exit 1
+          fi
+
+      # TODO
+      # - name: archive log

--- a/.github/workflows/start_single_node.yml
+++ b/.github/workflows/start_single_node.yml
@@ -11,20 +11,23 @@ jobs:
   build-and-run:
     strategy:
       matrix:
-        os: [ubuntu-20.04] # TODO: test on [ubuntu-22.04, windows-latest, macos-latest]
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-20.04, ubuntu-22.04] # TODO: test on [windows-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache of Axon binary
+      - name: Cache of the axon binary
         id: axon-bin-cache
         uses: actions/cache@v3
         with:
           path: |
             target/debug/axon
-          key: ${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+            target/release/axon
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
 
       - name: Cargo Cache
         if: steps.axon-bin-cache.outputs.cache-hit != 'true'
@@ -35,9 +38,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ github.sha }}
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-cargo-
+            ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-
 
       - name: Cache Axon target directory
         if: steps.axon-bin-cache.outputs.cache-hit != 'true'
@@ -45,9 +48,9 @@ jobs:
         with:
           path: |
             target
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-target-${{ hashFiles('Cargo.lock') }}
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-target-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-cargo-target
+            ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-target
       
       - name: Install Rust components
         if: steps.axon-bin-cache.outputs.cache-hit != 'true'
@@ -65,11 +68,11 @@ jobs:
             -g devtools/chain/genesis_single_node.json \
             > /tmp/single-axon-node.log &
          
-          sleep 700
+          sleep 300
           set +e
-          result=$(tail -n 100 /tmp/single-axon-node.log | grep 'state goto new height 200')
+          result=$(tail -n 100 /tmp/single-axon-node.log | grep 'state goto new height 100')
 
-          if [[ "$result" != ""]]
+          if [[ "$result" != "" ]]
           then
               echo "axon chain works well"
           else

--- a/.github/workflows/start_single_node.yml
+++ b/.github/workflows/start_single_node.yml
@@ -80,5 +80,10 @@ jobs:
               exit 1
           fi
 
-      # TODO
-      # - name: archive log
+      - name: Archive logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: axon-single-node-logs
+          path: |
+            /tmp/single-axon-node.log


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
<!--  Have I run `make ci`? -->

**What this PR does / why we need it**:

- This PR attempts to analyze and resolve issse https://github.com/axonweb3/axon/issues/1324


**Which toolchain this PR adaption**:

No Breaking Change

**Special notes for your reviewer**:

The new workflow `name: Start Single Axon Node` is going to replace `deprecate axon-start-with-short-genesis.yml` later,
- see https://github.com/axonweb3/axon/issues/1322

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests
