### PR TITLE
refactor: use derive apis to parse command line arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,6 +1488,7 @@ name = "common-config-parser"
 version = "0.2.1"
 dependencies = [
  "axon-protocol",
+ "clap 4.3.19",
  "reqwest",
  "serde",
  "serde_json",

--- a/common/config-parser/Cargo.toml
+++ b/common/config-parser/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = "4.3"
 reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.3", features = ["cargo", "string"] }
+clap = { version = "4.3", features = ["cargo", "string", "derive"] }
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/core/cli/src/args/mod.rs
+++ b/core/cli/src/args/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod run;

--- a/core/cli/src/args/run.rs
+++ b/core/cli/src/args/run.rs
@@ -1,0 +1,59 @@
+use std::ffi::OsStr;
+
+use clap::{builder::TypedValueParser, Parser};
+
+use common_config_parser::types::{Config, JsonValueParser};
+use common_version::Version;
+use core_run::{Axon, KeyProvider};
+use protocol::types::RichBlock;
+
+use crate::{
+    error::{Error, Result},
+    utils,
+};
+
+#[derive(Parser, Debug)]
+#[command(about = "Run axon process")]
+pub struct RunArgs {
+    #[arg(short = 'c', long = "config", help = "Axon config path")]
+    pub config:  Config,
+    #[arg(short = 'g', long = "genesis", help = "Axon genesis path")]
+    #[arg(value_parser=RichBlockValueParser)]
+    pub genesis: RichBlock,
+}
+
+#[derive(Clone, Debug)]
+struct RichBlockValueParser;
+
+impl TypedValueParser for RichBlockValueParser {
+    type Value = RichBlock;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        JsonValueParser::<RichBlock>::default().parse_ref(cmd, arg, value)
+    }
+}
+
+impl RunArgs {
+    pub(crate) fn execute<K: KeyProvider>(
+        self,
+        application_version: Version,
+        kernel_version: Version,
+        key_provider: Option<K>,
+    ) -> Result<()> {
+        let Self { config, genesis } = self;
+        utils::check_version(
+            &config.data_path_for_version(),
+            &kernel_version,
+            utils::latest_compatible_version(),
+        )?;
+        utils::register_log(&config);
+        Axon::new(application_version.to_string(), config, genesis)
+            .run(key_provider)
+            .map_err(Error::Running)
+    }
+}

--- a/core/cli/src/error.rs
+++ b/core/cli/src/error.rs
@@ -1,0 +1,33 @@
+use std::io;
+
+use common_version::Version;
+use thiserror::Error;
+
+use protocol::ProtocolError;
+
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum Error {
+    // Boxing so the error type isn't too large (clippy::result-large-err).
+    #[error(transparent)]
+    CheckingVersion(Box<CheckingVersionError>),
+    #[error("reading data version: {0}")]
+    ReadingVersion(#[source] io::Error),
+    #[error("writing data version: {0}")]
+    WritingVersion(#[source] io::Error),
+
+    #[error(transparent)]
+    Running(ProtocolError),
+}
+
+#[non_exhaustive]
+#[derive(Error, Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[error("data version({data}) is not compatible with the current axon version({current}), version >= {least_compatible} is supported")]
+pub struct CheckingVersionError {
+    pub current:          Version,
+    pub data:             Version,
+    pub least_compatible: Version,
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -1,55 +1,31 @@
-use std::io::{self, Write};
-use std::path::Path;
+use clap::{CommandFactory as _, FromArgMatches as _, Parser, Subcommand};
 
-use clap::{Arg, ArgMatches, Command};
-use protocol::ProtocolError;
-use thiserror::Error;
-
-use common_config_parser::{parse_file, types::Config, ParseError};
 use common_version::Version;
-use core_run::{Axon, KeyProvider, SecioKeyPair};
-use protocol::types::RichBlock;
+use core_run::{KeyProvider, SecioKeyPair};
 
-#[non_exhaustive]
-#[derive(Error, Debug)]
-pub enum Error {
-    // Boxing so the error type isn't too large (clippy::result-large-err).
-    #[error(transparent)]
-    CheckingVersion(Box<CheckingVersionError>),
-    #[error("reading data version: {0}")]
-    ReadingVersion(#[source] io::Error),
-    #[error("writing data version: {0}")]
-    WritingVersion(#[source] io::Error),
+mod args;
+mod error;
+pub(crate) mod utils;
 
-    #[error("parsing config: {0}")]
-    ParsingConfig(#[source] ParseError),
-    #[error("getting parent directory of config file")]
-    GettingParent,
-    #[error("parsing genesis: {0}")]
-    ParsingGenesis(#[source] ParseError),
-    #[error("unknown subcommand: {0}")]
-    UnknownSubcommand(String),
+pub use args::run::RunArgs;
+pub use error::{CheckingVersionError, Error, Result};
 
-    #[error(transparent)]
-    Running(ProtocolError),
+#[derive(Parser, Debug)]
+#[command(name = "axon")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
 }
 
-#[non_exhaustive]
-#[derive(Error, Debug)]
-#[cfg_attr(test, derive(PartialEq, Eq))]
-#[error("data version({data}) is not compatible with the current axon version({current}), version >= {least_compatible} is supported")]
-pub struct CheckingVersionError {
-    pub current:          Version,
-    pub data:             Version,
-    pub least_compatible: Version,
+#[derive(Subcommand, Debug)]
+enum Commands {
+    Run(RunArgs),
 }
-
-pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub struct AxonCli {
-    kernel_version:      Version,
     application_version: Version,
-    matches:             ArgMatches,
+    kernel_version:      Version,
+    inner:               Cli,
 }
 
 impl AxonCli {
@@ -58,194 +34,30 @@ impl AxonCli {
             "{}-with-axon-kernel-{}",
             application_version, kernel_version
         );
-
-        let matches = Command::new("axon")
-            .version(mix_version)
-            .subcommand_required(true)
-            .subcommand(
-                Command::new("run")
-                    .about("Run axon process")
-                    .arg(
-                        Arg::new("config_path")
-                            .short('c')
-                            .long("config")
-                            .help("Axon config path")
-                            .required(true)
-                            .num_args(1),
-                    )
-                    .arg(
-                        Arg::new("genesis_path")
-                            .short('g')
-                            .long("genesis")
-                            .help("Axon genesis path")
-                            .required(true)
-                            .num_args(1),
-                    ),
-            );
-
+        let cmd = Cli::command().version(mix_version);
+        let cli = Cli::from_arg_matches(&cmd.get_matches()).unwrap_or_else(|_| unreachable!());
         AxonCli {
             kernel_version,
             application_version,
-            matches: matches.get_matches(),
+            inner: cli,
         }
     }
 
-    pub fn start(&self) -> Result<()> {
+    pub fn start(self) -> Result<()> {
         self.start_with_custom_key_provider::<SecioKeyPair>(None)
     }
 
     pub fn start_with_custom_key_provider<K: KeyProvider>(
-        &self,
+        self,
         key_provider: Option<K>,
     ) -> Result<()> {
-        if let Some((cmd, matches)) = self.matches.subcommand() {
-            match cmd {
-                "run" => {
-                    let config_path = matches.get_one::<String>("config_path").unwrap();
-                    let path = Path::new(&config_path)
-                        .parent()
-                        .ok_or(Error::GettingParent)?;
-                    let mut config: Config =
-                        parse_file(config_path, false).map_err(Error::ParsingConfig)?;
-
-                    if let Some(ref mut f) = config.rocksdb.options_file {
-                        *f = path.join(&f)
-                    }
-                    let genesis: RichBlock =
-                        parse_file(matches.get_one::<String>("genesis_path").unwrap(), true)
-                            .map_err(Error::ParsingGenesis)?;
-
-                    self.check_version(&config)?;
-
-                    register_log(&config);
-
-                    Axon::new(self.application_version.to_string(), config, genesis)
-                        .run(key_provider)
-                        .map_err(Error::Running)
-                }
-                _ => Err(Error::UnknownSubcommand(cmd.to_owned())),
-            }
-        } else {
-            // Since `clap.subcommand_required(true)`.
-            unreachable!();
-        }
-    }
-
-    fn check_version(&self, config: &Config) -> Result<()> {
-        // Won't panic because parent of data_path_for_version() is data_path.
-        check_version(
-            &config.data_path_for_version(),
-            &self.kernel_version,
-            latest_compatible_version(),
-        )
-    }
-}
-
-/// # Panics
-///
-/// If p.parent() is None.
-fn check_version(p: &Path, current: &Version, least_compatible: Version) -> Result<()> {
-    let ver_str = match std::fs::read_to_string(p) {
-        Ok(x) => x,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => "".into(),
-        Err(e) => return Err(Error::ReadingVersion(e)),
-    };
-
-    if ver_str.is_empty() {
-        atomic_write(p, current.to_string().as_bytes()).map_err(Error::WritingVersion)?;
-        return Ok(());
-    }
-
-    let prev_version = Version::new(&ver_str);
-    if prev_version < least_compatible {
-        return Err(Error::CheckingVersion(Box::new(CheckingVersionError {
-            least_compatible,
-            data: prev_version,
-            current: current.clone(),
-        })));
-    }
-    atomic_write(p, current.to_string().as_bytes()).map_err(Error::WritingVersion)?;
-    Ok(())
-}
-
-/// Write content to p atomically. Create the parent directory if it doesn't
-/// already exist.
-///
-/// # Panics
-///
-/// if p.parent() is None.
-fn atomic_write(p: &Path, content: &[u8]) -> io::Result<()> {
-    let parent = p.parent().unwrap();
-
-    std::fs::create_dir_all(parent)?;
-
-    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
-    tmp.as_file_mut().write_all(content)?;
-    // https://stackoverflow.com/questions/7433057/is-rename-without-fsync-safe
-    tmp.as_file_mut().sync_all()?;
-    tmp.persist(p)?;
-    let parent = std::fs::OpenOptions::new().read(true).open(parent)?;
-    parent.sync_all()?;
-
-    Ok(())
-}
-
-fn latest_compatible_version() -> Version {
-    Version::new("0.1.0-beta.1")
-}
-
-fn register_log(config: &Config) {
-    common_logger::init(
-        config.logger.filter.clone(),
-        config.logger.log_to_console,
-        config.logger.console_show_file_and_line,
-        config.logger.log_to_file,
-        config.logger.metrics,
-        config.logger.log_path.clone(),
-        config.logger.file_size_limit,
-        config.logger.modules_level.clone(),
-    );
-}
-
-#[cfg(test)]
-mod tests {
-    use tempfile::NamedTempFile;
-
-    use super::*;
-
-    #[test]
-    fn test_check_version() -> Result<()> {
-        let tmp = NamedTempFile::new().unwrap();
-        let p = tmp.path();
-        // We just want NamedTempFile to delete the file on drop. We want to
-        // start with the file not exist.
-        std::fs::remove_file(p).unwrap();
-
-        let latest_compatible: Version = "0.1.0-alpha.9".parse().unwrap();
-
-        check_version(p, &"0.1.15".parse().unwrap(), latest_compatible.clone())?;
-        assert_eq!(std::fs::read_to_string(p).unwrap(), "0.1.15");
-
-        check_version(p, &"0.2.0".parse().unwrap(), latest_compatible)?;
-        assert_eq!(std::fs::read_to_string(p).unwrap(), "0.2.0");
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_check_version_failure() {
-        let tmp = NamedTempFile::new().unwrap();
-        let p = tmp.path();
-        check_version(p, &"0.1.0".parse().unwrap(), "0.1.0".parse().unwrap()).unwrap();
-        let err =
-            check_version(p, &"0.2.2".parse().unwrap(), "0.2.0".parse().unwrap()).unwrap_err();
-        match err {
-            Error::CheckingVersion(e) => assert_eq!(*e, CheckingVersionError {
-                current:          "0.2.2".parse().unwrap(),
-                least_compatible: "0.2.0".parse().unwrap(),
-                data:             "0.1.0+unknown".parse().unwrap(),
-            }),
-            e => panic!("unexpected error {e}"),
+        let AxonCli {
+            application_version,
+            kernel_version,
+            inner: cli,
+        } = self;
+        match cli.command {
+            Commands::Run(args) => args.execute(application_version, kernel_version, key_provider),
         }
     }
 }

--- a/core/cli/src/utils.rs
+++ b/core/cli/src/utils.rs
@@ -1,0 +1,119 @@
+use std::{
+    io::{self, Write},
+    path::Path,
+};
+
+use common_version::Version;
+
+use common_config_parser::types::Config;
+
+use crate::{CheckingVersionError, Error, Result};
+
+/// # Panics
+///
+/// If p.parent() is None.
+pub(crate) fn check_version(p: &Path, current: &Version, least_compatible: Version) -> Result<()> {
+    let ver_str = match std::fs::read_to_string(p) {
+        Ok(x) => x,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => "".into(),
+        Err(e) => return Err(Error::ReadingVersion(e)),
+    };
+
+    if ver_str.is_empty() {
+        atomic_write(p, current.to_string().as_bytes()).map_err(Error::WritingVersion)?;
+        return Ok(());
+    }
+
+    let prev_version = Version::new(&ver_str);
+    if prev_version < least_compatible {
+        return Err(Error::CheckingVersion(Box::new(CheckingVersionError {
+            least_compatible,
+            data: prev_version,
+            current: current.clone(),
+        })));
+    }
+    atomic_write(p, current.to_string().as_bytes()).map_err(Error::WritingVersion)?;
+    Ok(())
+}
+
+/// Write content to p atomically. Create the parent directory if it doesn't
+/// already exist.
+///
+/// # Panics
+///
+/// if p.parent() is None.
+fn atomic_write(p: &Path, content: &[u8]) -> io::Result<()> {
+    let parent = p.parent().unwrap();
+
+    std::fs::create_dir_all(parent)?;
+
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    tmp.as_file_mut().write_all(content)?;
+    // https://stackoverflow.com/questions/7433057/is-rename-without-fsync-safe
+    tmp.as_file_mut().sync_all()?;
+    tmp.persist(p)?;
+    let parent = std::fs::OpenOptions::new().read(true).open(parent)?;
+    parent.sync_all()?;
+
+    Ok(())
+}
+
+pub(crate) fn latest_compatible_version() -> Version {
+    Version::new("0.1.0-beta.1")
+}
+
+pub(crate) fn register_log(config: &Config) {
+    common_logger::init(
+        config.logger.filter.clone(),
+        config.logger.log_to_console,
+        config.logger.console_show_file_and_line,
+        config.logger.log_to_file,
+        config.logger.metrics,
+        config.logger.log_path.clone(),
+        config.logger.file_size_limit,
+        config.logger.modules_level.clone(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[test]
+    fn test_check_version() -> Result<()> {
+        let tmp = NamedTempFile::new().unwrap();
+        let p = tmp.path();
+        // We just want NamedTempFile to delete the file on drop. We want to
+        // start with the file not exist.
+        std::fs::remove_file(p).unwrap();
+
+        let latest_compatible: Version = "0.1.0-alpha.9".parse().unwrap();
+
+        check_version(p, &"0.1.15".parse().unwrap(), latest_compatible.clone())?;
+        assert_eq!(std::fs::read_to_string(p).unwrap(), "0.1.15");
+
+        check_version(p, &"0.2.0".parse().unwrap(), latest_compatible)?;
+        assert_eq!(std::fs::read_to_string(p).unwrap(), "0.2.0");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_check_version_failure() {
+        let tmp = NamedTempFile::new().unwrap();
+        let p = tmp.path();
+        check_version(p, &"0.1.0".parse().unwrap(), "0.1.0".parse().unwrap()).unwrap();
+        let err =
+            check_version(p, &"0.2.2".parse().unwrap(), "0.2.0".parse().unwrap()).unwrap_err();
+        match err {
+            Error::CheckingVersion(e) => assert_eq!(*e, CheckingVersionError {
+                current:          "0.2.2".parse().unwrap(),
+                least_compatible: "0.2.0".parse().unwrap(),
+                data:             "0.1.0+unknown".parse().unwrap(),
+            }),
+            e => panic!("unexpected error {e}"),
+        }
+    }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR:
- Use derive APIs to parse command line arguments.
- Split the code so that the code of different sub-commands won't interfere with each other.

**Which issue(s) this PR fixes**:

[Original issue](https://github.com/axonweb3/axon/pull/1269/files#r1261952704) was:

> ... I think it's a good time to switch to derived commands to reduce boilerplate and to make getting arguments less error-prone.

**Which toolchain this PR adaption**:

No Breaking Change

<details><summary>CI Settings</summary><br/>

**CI Description**

| CI Name                                   | Description                                                     |
| ----------------------------------------- | --------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition    |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`      |
| *Coverage Test*                           | Get the unit test coverage report                             |
| *E2E Test*                                | Run end-to-end test to check interfaces                         |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`     |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                               |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3             |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin           |

**CI Usage**

> Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Chaos CI
- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

</details>