### PR TITLE
chore: refactor `Build Axon` step in the workflows

### DIFF
--- a/.github/workflows/axon-start-with-short-genesis.yml
+++ b/.github/workflows/axon-start-with-short-genesis.yml
@@ -1,58 +1,103 @@
 name: Axon start test
+
 on:
   push:
-    branches:
-      - main
+  pull_request:
   merge_group:
+  workflow_dispatch:
+
 jobs:
-  build:
-    runs-on: [self-hosted,spark]
+  # Build Axon and cache the binary
+  build-axon:
+    uses: ./.github/workflows/build.yml
+
+  # Start a single Axon node
+  single-node:
+    needs: build-axon
+    strategy:
+      matrix:
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-20.04, ubuntu-22.04] # TODO: test on [windows-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      - name: Build docker image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: axonweb3/axon:start-test
-      - name: axon start test
-        run: |
-          cd ${{ github.workspace }}/../docker-deploy
-          sudo rm -rf logs*
-          sudo rm -rf devtools/chain/data*
-          sed -i 's/image:.*$/image:  axonweb3\/axon:start-test/g' docker-compose.yml
-          cp ${{ github.workspace }}/devtools/chain/geneses/genesis_multi_nodes_short_epoch_len.json devtools/chain/genesis_multi_nodes.json
-          cp ${{ github.workspace }}/devtools/chain/k8s/node_1.toml devtools/chain/node_1.toml
-          cp ${{ github.workspace }}/devtools/chain/k8s/node_2.toml devtools/chain/node_2.toml
-          cp ${{ github.workspace }}/devtools/chain/k8s/node_3.toml devtools/chain/node_3.toml
-          cp ${{ github.workspace }}/devtools/chain/k8s/node_4.toml devtools/chain/node_4.toml
-          docker-compose up -d
-          docker-compose ps -a
-          sleep 700
-          set +e
-          result_axon1=$(tail -n 100 logs1/axon.log | grep 'state goto new height 200')
-          result_axon2=$(tail -n 100 logs2/axon.log | grep 'state goto new height 200')
-          result_axon3=$(tail -n 100 logs3/axon.log | grep 'state goto new height 200')
-          result_axon4=$(tail -n 100 logs4/axon.log | grep 'state goto new height 200')
+    - uses: actions/checkout@v3
+    - name: Cache of the axon binary
+      id: axon-bin-cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          target/debug/axon
+          target/release/axon
+        key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
 
-          docker-compose down
-          if [[ "$result_axon1" != ""  ||  $result_axon2 != ""  ||  $result_axon3 != ""   ||  $result_axon4 != "" ]]
-          then
-              echo "axon chain works well"
-          else
-              echo "axon chain has some issues, please have a check"
-              exit 1
-          fi
+    - name: Start a single Axon node
+      run: |
+        target/debug/axon --version
+        target/debug/axon run \
+          -c devtools/chain/config.toml \
+          -g devtools/chain/genesis_single_node.json \
+          > ${{ runner.temp }}/${{ matrix.os }}-single-axon-node.log &
+        
+        sleep 300
+        set +e
+        result=$(tail -n 100 ${{ runner.temp }}/${{ matrix.os }}-single-axon-node.log | grep 'state goto new height 100')
 
+        if [[ "$result" != "" ]]
+        then
+            echo "axon chain works well"
+        else
+            echo "axon chain has some issues, please have a check"
+            exit 1
+        fi
 
+    - name: Archive logs
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: axon-single-node-logs
+        path: |
+          ${{ runner.temp }}/${{ matrix.os }}-single-axon-node.log
 
+  # TODO:
+  # multi-nodes:
+  #   needs: build-axon
+  #   strategy:
+  #     matrix:
+  #       # Supported GitHub-hosted runners and hardware resources
+  #       # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+  #       os: [ubuntu-20.04, ubuntu-22.04] # TODO: test on [windows-latest, macos-latest]
+  #     fail-fast: false
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #   - uses: actions/checkout@v3
 
+  #   - name: axon start test
+  #     run: |
+  #       cd ${{ github.workspace }}/../docker-deploy
+  #       sudo rm -rf logs*
+  #       sudo rm -rf devtools/chain/data*
+  #       sed -i 's/image:.*$/image:  axonweb3\/axon:start-test/g' docker-compose.yml
+  #       cp ${{ github.workspace }}/devtools/chain/geneses/genesis_multi_nodes_short_epoch_len.json devtools/chain/genesis_multi_nodes.json
+  #       cp ${{ github.workspace }}/devtools/chain/k8s/node_1.toml devtools/chain/node_1.toml
+  #       cp ${{ github.workspace }}/devtools/chain/k8s/node_2.toml devtools/chain/node_2.toml
+  #       cp ${{ github.workspace }}/devtools/chain/k8s/node_3.toml devtools/chain/node_3.toml
+  #       cp ${{ github.workspace }}/devtools/chain/k8s/node_4.toml devtools/chain/node_4.toml
+  #       docker-compose up -d
+  #       docker-compose ps -a
+  #       sleep 700
+  #       set +e
+  #       result_axon1=$(tail -n 100 logs1/axon.log | grep 'state goto new height 200')
+  #       result_axon2=$(tail -n 100 logs2/axon.log | grep 'state goto new height 200')
+  #       result_axon3=$(tail -n 100 logs3/axon.log | grep 'state goto new height 200')
+  #       result_axon4=$(tail -n 100 logs4/axon.log | grep 'state goto new height 200')
 
+  #       docker-compose down
+  #       if [[ "$result_axon1" != ""  ||  $result_axon2 != ""  ||  $result_axon3 != ""   ||  $result_axon4 != "" ]]
+  #       then
+  #           echo "axon chain works well"
+  #       else
+  #           echo "axon chain has some issues, please have a check"
+  #           exit 1
+  #       fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+name: Build Axon Binary
+
+on:
+  push:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+  # Rather than copying and pasting from one workflow to another, you can make workflows reusable.
+  # See https://docs.github.com/en/actions/using-workflows/reusing-workflows
+  workflow_call:
+
+jobs:
+  build-and-cache:
+    strategy:
+      matrix:
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-20.04, ubuntu-22.04] # TODO: test on [windows-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Cache of the Axon binary
+      id: axon-bin-cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          target/debug/axon
+          target/release/axon
+        key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+
+    - name: Cache of Cargo
+      uses: actions/cache@v3
+      if: steps.axon-bin-cache.outputs.cache-hit != 'true'
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Build Axon in the development profile 
+      if: steps.axon-bin-cache.outputs.cache-hit != 'true'
+      run: cargo build
+
+    # TOOD: not sure if this step is required
+    # - name: Build a release version of Axon
+    #   if: steps.axon-bin-cache.outputs.cache-hit != 'true'
+    #   run: cargo build --release

--- a/.github/workflows/openzeppelin_test_11.yml
+++ b/.github/workflows/openzeppelin_test_11.yml
@@ -12,12 +12,19 @@ on:
         required: true
 
 jobs:
+  # Build Axon and cache the binary
+  build-axon:
+    uses: ./.github/workflows/build.yml
+
   openzeppelin-contracts-1:
+    needs: build-axon
     strategy:
-      fail-fast: false
       matrix:
-        net: ["axon"]
-    runs-on: ubuntu-latest
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-22.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     outputs:
       output-sha: ${{ steps.escape_multiple_lines_test_inputs.outputs.result }}
     steps:
@@ -90,9 +97,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node_modules-
 
+      - name: Cache of the axon binary
+        uses: actions/cache@v3
+        with:
+          path: |
+            target/debug/axon
+            target/release/axon
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+
       - name: Deploy Local Network of Axon
         run: |
-          cargo build
           rm -rf ./devtools/chain/data
           ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
 
@@ -118,6 +132,7 @@ jobs:
         with:
           name: jfoa-build-reports-${{ runner.os }}
           path: openzeppelin-contracts/mochawesome-report/
+
   finally:
     name: Finally
     needs: [ openzeppelin-contracts-1 ]

--- a/.github/workflows/openzeppelin_test_16_19.yml
+++ b/.github/workflows/openzeppelin_test_16_19.yml
@@ -12,12 +12,19 @@ on:
         required: true
 
 jobs:
+  # Build Axon and cache the binary
+  build-axon:
+    uses: ./.github/workflows/build.yml
+
   openzeppelin-contracts-1:
+    needs: build-axon
     strategy:
-      fail-fast: false
       matrix:
-        net: ["axon"]
-    runs-on: ubuntu-latest
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-22.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     outputs:
       output-sha: ${{ steps.escape_multiple_lines_test_inputs.outputs.result }}
     steps:
@@ -90,9 +97,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node_modules-
 
+      - name: Cache of the axon binary
+        uses: actions/cache@v3
+        with:
+          path: |
+            target/debug/axon
+            target/release/axon
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+
       - name: Deploy Local Network of Axon
         run: |
-          cargo build
           rm -rf ./devtools/chain/data
           ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
 
@@ -133,6 +147,7 @@ jobs:
         with:
           name: jfoa-build-reports-${{ runner.os }}
           path: openzeppelin-contracts/mochawesome-report/
+
   finally:
     name: Finally
     needs: [ openzeppelin-contracts-1 ]

--- a/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
+++ b/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
@@ -12,12 +12,19 @@ on:
         required: true
 
 jobs:
+  # Build Axon and cache the binary
+  build-axon:
+    uses: ./.github/workflows/build.yml
+
   openzeppelin-contracts-1:
+    needs: build-axon
     strategy:
-      fail-fast: false
       matrix:
-        net: ["axon"]
-    runs-on: ubuntu-latest
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-22.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     outputs:
       output-sha: ${{ steps.escape_multiple_lines_test_inputs.outputs.result }}
     steps:
@@ -90,10 +97,17 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('/home/runner/work/**/package-lock.json', '/home/runner/work/**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-
+      
+      - name: Cache of the axon binary
+        uses: actions/cache@v3
+        with:
+          path: |
+            target/debug/axon
+            target/release/axon
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
 
       - name: Deploy Local Network of Axon
         run: |
-          cargo build
           rm -rf ./devtools/chain/data
           ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
 
@@ -159,6 +173,7 @@ jobs:
         with:
           name: jfoa-build-reports-${{ runner.os }}
           path: openzeppelin-contracts/mochawesome-report/
+
   finally:
     name: Finally
     needs: [ openzeppelin-contracts-1 ]

--- a/.github/workflows/openzeppelin_test_6_10.yml
+++ b/.github/workflows/openzeppelin_test_6_10.yml
@@ -12,12 +12,19 @@ on:
         required: true
 
 jobs:
+  # Build Axon and cache the binary
+  build-axon:
+    uses: ./.github/workflows/build.yml
+
   openzeppelin-contracts-1:
+    needs: build-axon
     strategy:
-      fail-fast: false
       matrix:
-        net: ["axon"]
-    runs-on: ubuntu-latest
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-22.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     outputs:
       output-sha: ${{ steps.escape_multiple_lines_test_inputs.outputs.result }}
     steps:
@@ -90,9 +97,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node_modules-
 
+      - name: Cache of the axon binary
+        uses: actions/cache@v3
+        with:
+          path: |
+            target/debug/axon
+            target/release/axon
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+      
       - name: Deploy Local Network of Axon
         run: |
-          cargo build
           rm -rf ./devtools/chain/data
           ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
       - name: Run prepare
@@ -138,6 +152,7 @@ jobs:
         with:
           name: jfoa-build-reports-${{ runner.os }}
           path: openzeppelin-contracts/mochawesome-report/
+
   finally:
     name: Finally
     needs: [ openzeppelin-contracts-1 ]

--- a/.github/workflows/v3_core_test.yml
+++ b/.github/workflows/v3_core_test.yml
@@ -12,12 +12,19 @@ on:
         required: true
 
 jobs:
+  # Build Axon and cache the binary
+  build-axon:
+    uses: ./.github/workflows/build.yml
+
   v3-core-test:
+    needs: build-axon
     strategy:
-      fail-fast: false
       matrix:
-        net: ["axon"]
-    runs-on: ubuntu-latest
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-22.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     outputs:
       output-sha: ${{ steps.escape_multiple_lines_test_inputs.outputs.result }}
     steps:
@@ -79,9 +86,16 @@ jobs:
       - id: yarn-cache
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
+      - name: Cache of the axon binary
+        uses: actions/cache@v3
+        with:
+          path: |
+            target/debug/axon
+            target/release/axon
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+
       - name: Deploy Local Network of Axon
         run: |
-          cargo build
           rm -rf ./devtools/chain/data
           ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
       - name: Install dependencies
@@ -119,6 +133,7 @@ jobs:
         with:
           name: jfoa-build-reports-${{ runner.os }}
           path: v3-core/mochawesome-report/
+
   finally:
     name: Finally
     needs: [ v3-core-test ]

--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -14,13 +14,20 @@ on:
         required: true
 
 jobs:
+  # Build Axon and cache the binary
+  build-axon:
+    uses: ./.github/workflows/build.yml
+
   dispatch-web3-compatible:
+    needs: build-axon
     strategy:
-      fail-fast: false
       matrix:
-        net: ["axon"]
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-22.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     if: contains(github.event_name, 'workflow_dispatch')
-    runs-on: ubuntu-latest
     outputs:
       output-sha: ${{ steps.escape_multiple_lines_test_inputs.outputs.result }}
     steps:
@@ -91,9 +98,15 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('/home/runner/work/**/package-lock.json', '/home/runner/work/**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-
+      - name: Cache of the axon binary
+        uses: actions/cache@v3
+        with:
+          path: |
+            target/debug/axon
+            target/release/axon
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
       - name: Deploy Local Network of Axon
         run: |
-          cargo build
           rm -rf ./devtools/chain/data
           ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
       - name: Run Test
@@ -111,6 +124,7 @@ jobs:
         with:
           name: jfoa-build-reports-${{ runner.os }}
           path: axon-test/mochawesome-report/
+
   finally:
     name: Finally
     needs: [ dispatch-web3-compatible ]
@@ -141,14 +155,17 @@ jobs:
             })
 
   web3-compatible:
+    needs: build-axon
     strategy:
-      fail-fast: false
       matrix:
-        net: ["axon"]
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-22.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
     if: |
       (contains(fromJson('["dependabot[bot]" ]'), github.actor) && github.event_name == 'pull_request') ||
       (contains(github.event_name, 'push') && github.ref == 'refs/heads/main' )
-    runs-on: ubuntu-latest
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -172,9 +189,15 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('/home/runner/work/**/package-lock.json', '/home/runner/work/**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-
+      - name: Cache of the axon binary
+        uses: actions/cache@v3
+        with:
+          path: |
+            target/debug/axon
+            target/release/axon
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
       - name: Deploy Local Network of Axon
         run: |
-          cargo build
           rm -rf ./devtools/chain/data
           ./target/debug/axon run --config devtools/chain/config.toml --genesis devtools/chain/genesis_single_node.json > /tmp/log 2>&1 &
       - name: Run Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

`cargo build` takes a lot of time
=> This PR cache the building result with commit_id in the cache-key, so we don't have to build Axon from zero in every GitHub action workflow.
=> With cargo cache, the `Build Axon` step only takes 90 seconds.
=> The workflows such as openzeppelin_tests will consume ~20 mins less.

### What is the impact of this PR?

- No Breaking Change
- improve efficiency in project building and testing，and may report bugs effectively
- Perhaps in the near future, all tests could be triggered by default, not manually.

<!--
**Special notes for your reviewer**:
NIL

**PR relation**:
- Ref #

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

- Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
  see [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) or [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
-->
</details>