### PR TITLE
refactor(config): remove deprecated, move `sync_txs_chunk_size` out from `consensus`

### DIFF
--- a/common/config-parser/src/types.rs
+++ b/common/config-parser/src/types.rs
@@ -29,7 +29,8 @@ pub struct Config {
     pub network:    ConfigNetwork,
     pub mempool:    ConfigMempool,
     pub executor:   ConfigExecutor,
-    pub consensus:  ConfigConsensus,
+    #[serde(rename = "synchronization")]
+    pub sync:       ConfigSynchronization,
     #[serde(default)]
     pub logger:     ConfigLogger,
     #[serde(default)]
@@ -38,8 +39,7 @@ pub struct Config {
     pub prometheus: Option<ConfigPrometheus>,
 
     #[serde(default)]
-    pub ibc_contract_address:  H160,
-    pub wckb_contract_address: H160,
+    pub ibc_contract_address: H160,
 }
 
 impl Config {
@@ -210,7 +210,7 @@ fn default_sync_txs_chunk_size() -> usize {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct ConfigConsensus {
+pub struct ConfigSynchronization {
     #[serde(default = "default_sync_txs_chunk_size")]
     pub sync_txs_chunk_size: usize,
 }
@@ -236,7 +236,6 @@ pub struct ConfigMempool {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct ConfigExecutor {
-    pub light:             bool,
     pub triedb_cache_size: usize,
 }
 

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -361,7 +361,7 @@ impl Axon {
         consensus_adapter.set_overlord_handler(overlord_consensus.get_overlord_handler());
 
         let synchronization = Arc::new(OverlordSynchronization::<_>::new(
-            self.config.consensus.sync_txs_chunk_size,
+            self.config.sync.sync_txs_chunk_size,
             consensus_adapter,
             status_agent.clone(),
             lock,

--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -4,9 +4,6 @@ privkey = "0x37aa0f893d05914a4def0460c0a984d3611546cfb26924d7a7ca6e0db9950a2d"
 # db config
 data_path = "./devtools/chain/data"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -62,7 +59,7 @@ log_filter_max_block_range = 25000
 listening_address = "/ip4/0.0.0.0/tcp/8001"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -75,7 +72,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/k8s/node_1.toml
+++ b/devtools/chain/k8s/node_1.toml
@@ -4,9 +4,6 @@ privkey = "0x37aa0f893d05914a4def0460c0a984d3611546cfb26924d7a7ca6e0db9950a2d"
 # db config
 data_path = "./devtools/chain/data1"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -62,7 +59,7 @@ log_filter_max_block_range = 25000
 listening_address = "/ip4/0.0.0.0/tcp/8001"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -84,7 +81,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/k8s/node_2.toml
+++ b/devtools/chain/k8s/node_2.toml
@@ -4,9 +4,6 @@ privkey = "0x383fcff8683b8115e31613949be24254b4204ffbe43c227408a76334a2e3fb32"
 # db config
 data_path = "./devtools/chain/data2"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -62,7 +59,7 @@ log_filter_max_block_range = 25000
 listening_address = "/ip4/0.0.0.0/tcp/8001"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -84,7 +81,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/k8s/node_3.toml
+++ b/devtools/chain/k8s/node_3.toml
@@ -4,9 +4,6 @@ privkey = "0x51ce21643b911347c5d5c85c323d9d5421810dc89f46b688720b2715f5e8e936"
 # db config
 data_path = "./devtools/chain/data3"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -62,7 +59,7 @@ log_filter_max_block_range = 25000
 listening_address = "/ip4/0.0.0.0/tcp/8001"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -84,7 +81,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/k8s/node_4.toml
+++ b/devtools/chain/k8s/node_4.toml
@@ -4,9 +4,6 @@ privkey = "0x69ff51f4c22f30615f68b88efa740f8f1b9169e88842b83d189748d06f1a948e"
 # db config
 data_path = "./devtools/chain/data4"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -62,7 +59,7 @@ log_filter_max_block_range = 25000
 listening_address = "/ip4/0.0.0.0/tcp/8001"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -84,7 +81,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/k8s/sync_nodes/node_5.toml
+++ b/devtools/chain/k8s/sync_nodes/node_5.toml
@@ -4,9 +4,6 @@ privkey = "0x0179ffa9c9d7bfdef64b29b5800bf6954caa033973a875ddc4393826b9c78db0"
 # db config
 data_path = "./devtools/chain/data5"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -58,7 +55,7 @@ client_version = "0.1.0"
 listening_address = "/ip4/0.0.0.0/tcp/8001"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -92,7 +89,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/k8s/sync_nodes/node_6.toml
+++ b/devtools/chain/k8s/sync_nodes/node_6.toml
@@ -4,9 +4,6 @@ privkey = "0x3914e28bdc5da1112f60bba7c3b3138c75fdbd334043f25fd297589143860ad5"
 # db config
 data_path = "./devtools/chain/data6"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -57,7 +54,7 @@ client_version = "0.1.0"
 listening_address = "/ip4/0.0.0.0/tcp/8001"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -91,7 +88,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/k8s/sync_nodes/node_7.toml
+++ b/devtools/chain/k8s/sync_nodes/node_7.toml
@@ -4,9 +4,6 @@ privkey = "0x69e99b40bc26bbbafe68989b3972eb1028b5c8de3eac20a1fb2b68f3a259722e"
 # db config
 data_path = "./devtools/chain/data7"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -58,7 +55,7 @@ client_version = "0.1.0"
 listening_address = "/ip4/0.0.0.0/tcp/8001"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -92,7 +89,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/k8s/sync_nodes/node_8.toml
+++ b/devtools/chain/k8s/sync_nodes/node_8.toml
@@ -4,9 +4,6 @@ privkey = "0x2df9df719f297aa88bfa2d5278743ac7c6612285716ea5db49a2fb8b6216a4a2"
 # db config
 data_path = "./devtools/chain/data8"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -58,7 +55,7 @@ client_version = "0.1.0"
 listening_address = "/ip4/0.0.0.0/tcp/8001"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -92,7 +89,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/nodes/node_1.toml
+++ b/devtools/chain/nodes/node_1.toml
@@ -4,9 +4,6 @@ privkey = "0x37aa0f893d05914a4def0460c0a984d3611546cfb26924d7a7ca6e0db9950a2d"
 # db config
 data_path = "./devtools/chain/data/node_1"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -61,7 +58,7 @@ log_filter_max_block_range = 25000
 listening_address = "/ip4/127.0.0.1/tcp/10001"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -83,7 +80,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/nodes/node_2.toml
+++ b/devtools/chain/nodes/node_2.toml
@@ -4,9 +4,6 @@ privkey = "0x383fcff8683b8115e31613949be24254b4204ffbe43c227408a76334a2e3fb32"
 # db config
 data_path = "./devtools/chain/data/node_2"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -61,7 +58,7 @@ log_filter_max_block_range = 25000
 listening_address = "/ip4/127.0.0.1/tcp/10002"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -83,7 +80,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/nodes/node_3.toml
+++ b/devtools/chain/nodes/node_3.toml
@@ -4,9 +4,6 @@ privkey = "0x51ce21643b911347c5d5c85c323d9d5421810dc89f46b688720b2715f5e8e936"
 # db config
 data_path = "./devtools/chain/data/node_3"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -61,7 +58,7 @@ log_filter_max_block_range = 25000
 listening_address = "/ip4/127.0.0.1/tcp/10003"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -83,7 +80,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]

--- a/devtools/chain/nodes/node_4.toml
+++ b/devtools/chain/nodes/node_4.toml
@@ -4,9 +4,6 @@ privkey = "0x69ff51f4c22f30615f68b88efa740f8f1b9169e88842b83d189748d06f1a948e"
 # db config
 data_path = "./devtools/chain/data/node_4"
 
-crosschain_contract_address = "0xb9dc8bde1db42410d304b5e78c2ff843134e15e0"
-wckb_contract_address = "0xa13763691970d9373d4fab7cc323d7ba06fa9986"
-
 [[accounts]]
 address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
 balance = "04ee2d6d415b85acef8100000000"
@@ -61,7 +58,7 @@ log_filter_max_block_range = 25000
 listening_address = "/ip4/127.0.0.1/tcp/10004"
 rpc_timeout = 10
 
-[consensus]
+[synchronization]
 sync_txs_chunk_size = 5000
 
 [[network.bootstraps]]
@@ -83,7 +80,6 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-light = false
 triedb_cache_size = 500
 
 [logger]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR refactor config according to https://github.com/axonweb3/axon/issues/1307#issuecomment-1681530686.

A field in `consensus` section doesn't affect the consensus.
Its readability is poor, and it's not easy to understand.

### What is the impact of this PR?

Breaking Change:
- Configurations.
  - Remove `crosschain_contract_address`, `wckb_contract_address` and `executor.light`.
  - The `consensus` section will be renamed to `synchronization`.

<!--
**Special notes for your reviewer**:
NIL

**PR relation**:
- Ref #

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

- Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
  see [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) or [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
-->
</details>