### PR TITLE
feat: import addresses with EIP-55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "derive_more",
  "ethereum",
  "ethereum-types 0.14.1",
+ "ethers-core",
  "evm",
  "faster-hex 0.8.0",
  "hex",

--- a/common/config-parser/src/types/spec.rs
+++ b/common/config-parser/src/types/spec.rs
@@ -3,7 +3,10 @@ use std::{ffi::OsStr, io, path::PathBuf};
 use clap::builder::{StringValueParser, TypedValueParser, ValueParserFactory};
 use serde::Deserialize;
 
-use protocol::types::{Block, Bytes, Header, RichBlock, SignedTransaction, H160, U256};
+use protocol::{
+    codec::deserialize_address,
+    types::{Block, Bytes, Header, RichBlock, SignedTransaction, H160, U256},
+};
 
 use crate::parse_file;
 
@@ -39,6 +42,7 @@ pub struct Params {}
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct InitialAccount {
+    #[serde(deserialize_with = "deserialize_address")]
     pub address: H160,
     pub balance: U256,
 }

--- a/devtools/chain/specs/multi_nodes/chain-spec.toml
+++ b/devtools/chain/specs/multi_nodes/chain-spec.toml
@@ -1,16 +1,23 @@
+#
+# Data of the genesis block.
+#
+
 [genesis]
 timestamp = 1680249207
 extra_data = []
 base_fee_per_gas = "0x539"
 chain_id = 2022
+# A JSON file which includes all transactions in the genesis block.
 transactions = "genesis_transactions.json"
 
-[[accounts]]
-address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
-balance = "04ee2d6d415b85acef8100000000"
+#
+# Accounts since the genesis block.
+#
+# WARNING: The following accounts are publicly known, DO NOT USE them in any production environment.
+# Generated with the mnemonic "test test test test test test test test test test test junk".
 
 [[accounts]]
-address = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 balance = "04ee2d6d415b85acef8100000000"
 
 [[accounts]]
@@ -44,5 +51,13 @@ balance = "04ee2d6d415b85acef8100000000"
 [[accounts]]
 address = "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
 balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720"
+balance = "04ee2d6d415b85acef8100000000"
+
+#
+# Parameters which make the chain to be unique.
+#
 
 [params]

--- a/devtools/chain/specs/multi_nodes_short_epoch_len/chain-spec.toml
+++ b/devtools/chain/specs/multi_nodes_short_epoch_len/chain-spec.toml
@@ -1,16 +1,23 @@
+#
+# Data of the genesis block.
+#
+
 [genesis]
 timestamp = 1679656015
 extra_data = []
 base_fee_per_gas = "0x539"
 chain_id = 2022
+# A JSON file which includes all transactions in the genesis block.
 transactions = "genesis_transactions.json"
 
-[[accounts]]
-address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
-balance = "04ee2d6d415b85acef8100000000"
+#
+# Accounts since the genesis block.
+#
+# WARNING: The following accounts are publicly known, DO NOT USE them in any production environment.
+# Generated with the mnemonic "test test test test test test test test test test test junk".
 
 [[accounts]]
-address = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 balance = "04ee2d6d415b85acef8100000000"
 
 [[accounts]]
@@ -44,5 +51,13 @@ balance = "04ee2d6d415b85acef8100000000"
 [[accounts]]
 address = "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
 balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720"
+balance = "04ee2d6d415b85acef8100000000"
+
+#
+# Parameters which make the chain to be unique.
+#
 
 [params]

--- a/devtools/chain/specs/single_node/chain-spec.toml
+++ b/devtools/chain/specs/single_node/chain-spec.toml
@@ -1,6 +1,7 @@
 #
 # Data of the genesis block.
 #
+
 [genesis]
 timestamp = 1679656015
 extra_data = []
@@ -12,13 +13,11 @@ transactions = "genesis_transactions.json"
 #
 # Accounts since the genesis block.
 #
+# WARNING: The following accounts are publicly known, DO NOT USE them in any production environment.
+# Generated with the mnemonic "test test test test test test test test test test test junk".
 
 [[accounts]]
-address = "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
-balance = "04ee2d6d415b85acef8100000000"
-
-[[accounts]]
-address = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 balance = "04ee2d6d415b85acef8100000000"
 
 [[accounts]]
@@ -51,6 +50,10 @@ balance = "04ee2d6d415b85acef8100000000"
 
 [[accounts]]
 address = "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
+balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720"
 balance = "04ee2d6d415b85acef8100000000"
 
 #

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -18,6 +18,7 @@ creep = "0.2"
 derive_more = "0.99"
 ethereum = { version = "0.14", features = ["with-codec", "with-serde"] }
 ethereum-types = { version = "0.14", features = ["arbitrary", "codec", "rlp", "serialize", "std"] }
+ethers-core = "2.0"
 evm = { version = "0.37", features = ["with-serde"] }
 faster-hex = "0.8"
 lazy_static = "1.4"


### PR DESCRIPTION
## What this PR does / why we need it?

This PR:
- Implement EIP-55 for imported addresses.
- Add comments for preset addresses for dev chains.
- Sort preset addresses by their derivation path (from `/0` to `/9`).

### What is the impact of this PR?

No Breaking Change

<!--
**Special notes for your reviewer**:
NIL

**PR relation**:
- Ref #

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

- Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
  see [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) or [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
-->
</details>