### PR TITLE
fix: prometheus could not be disabled

### DIFF
--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -774,13 +774,12 @@ impl Axon {
     }
 
     fn run_prometheus_server(config: Option<ConfigPrometheus>) {
-        let prometheus_listening_address = match config {
-            Some(prometheus_config) => prometheus_config.listening_address.unwrap(),
-            None => std::net::SocketAddr::from(([0, 0, 0, 0], 8100)),
+        if let Some(prometheus_config) = config {
+            if let Some(prometheus_listening_address) = prometheus_config.listening_address {
+                tokio::spawn(run_prometheus_server(prometheus_listening_address));
+                log::info!("prometheus started");
+            }
         };
-        tokio::spawn(run_prometheus_server(prometheus_listening_address));
-
-        log::info!("prometheus started");
     }
 
     fn run_overlord_consensus<M, N, S, DB>(


### PR DESCRIPTION
## What this PR does / why we need it?

This PR fixes:
- The server of prometheus could not be disabled.
- High security risk since the default address of prometheus is unspecified address.
- Should not use `unwrap()` since the address could be not provided.
- Cause errors for CI checks of multi-nodes. (ref: [an example](https://github.com/axonweb3/axon/actions/runs/5936555089/job/16098042089#step:4:36)).
  - The configuration files for the multi-nodes test in CI haven't set `prometheus` section.
    So, all nodes use the default address. Then an error is caused: "Address already in use (os error 98)".

### What is the impact of this PR?

No Breaking Change

<!--
**Special notes for your reviewer**:
NIL

**PR relation**:
- Ref #

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

- Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
  see [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) or [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
-->
</details>