### PR TITLE
refactor: the all-in-one file of `core-run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "ethers-core",
  "evm",
  "faster-hex 0.8.0",
+ "hasher",
  "hex",
  "lazy_static",
  "ophelia",

--- a/common/memory-tracker/src/lib.rs
+++ b/common/memory-tracker/src/lib.rs
@@ -4,7 +4,7 @@ use std::{sync::Arc, time::Duration};
 
 use jemalloc_ctl::{epoch, stats};
 use log::error;
-use rocksdb::ops::{GetColumnFamilys, GetProperty, GetPropertyCF};
+pub use rocksdb::ops::{GetColumnFamilys, GetProperty, GetPropertyCF};
 
 use protocol::tokio;
 

--- a/core/run/src/components/extensions.rs
+++ b/core/run/src/components/extensions.rs
@@ -1,0 +1,68 @@
+//! Optional extensions.
+
+use common_apm::{server::run_prometheus_server, tracing::global_tracer_register};
+use common_config_parser::types::{ConfigJaeger, ConfigPrometheus};
+use protocol::{tokio, ProtocolResult};
+
+pub(crate) trait ExtensionConfig {
+    const NAME: &'static str;
+
+    /// Try to start and return the result.
+    fn try_to_start(&self) -> ProtocolResult<bool>;
+
+    /// Try to start and ignore the result.
+    fn start_if_possible(&self) {
+        match self.try_to_start() {
+            Ok(started) => {
+                if started {
+                    log::info!("{} is started", Self::NAME);
+                } else {
+                    log::info!("{} is disabled", Self::NAME);
+                }
+            }
+            Err(err) => {
+                log::error!("failed to start {} since {err}", Self::NAME);
+            }
+        }
+    }
+}
+
+impl ExtensionConfig for Option<ConfigJaeger> {
+    const NAME: &'static str = "Jaeger";
+
+    fn try_to_start(&self) -> ProtocolResult<bool> {
+        if let Some(ref config) = self {
+            if let Some(ref addr) = config.tracing_address {
+                let service_name = config
+                    .service_name
+                    .as_ref()
+                    .map(ToOwned::to_owned)
+                    .unwrap_or("axon".to_owned());
+                let tracing_batch_size = config.tracing_batch_size.unwrap_or(50);
+                global_tracer_register(&service_name, addr.to_owned(), tracing_batch_size);
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl ExtensionConfig for Option<ConfigPrometheus> {
+    const NAME: &'static str = "Prometheus";
+
+    fn try_to_start(&self) -> ProtocolResult<bool> {
+        if let Some(ref config) = self {
+            if let Some(ref addr) = config.listening_address {
+                tokio::spawn(run_prometheus_server(addr.to_owned()));
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/core/run/src/components/mod.rs
+++ b/core/run/src/components/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod system;
+
 #[cfg(all(
     not(target_env = "msvc"),
     not(target_os = "macos"),

--- a/core/run/src/components/mod.rs
+++ b/core/run/src/components/mod.rs
@@ -1,0 +1,28 @@
+#[cfg(all(
+    not(target_env = "msvc"),
+    not(target_os = "macos"),
+    feature = "jemalloc"
+))]
+pub(crate) mod profiling;
+
+#[cfg(not(all(
+    not(target_env = "msvc"),
+    not(target_os = "macos"),
+    feature = "jemalloc"
+)))]
+pub(crate) mod profiling {
+    use std::sync::Arc;
+
+    pub(crate) fn start() {
+        log::warn!("profiling is not supported, so it doesn't start");
+    }
+    pub(crate) fn stop() {
+        log::warn!("profiling is not supported, so it doesn't require stopping");
+    }
+    pub(crate) fn track_current_process() {
+        log::warn!("profiling is not supported, so it doesn't track current process");
+    }
+    pub(crate) fn track_db_process<DB>(typ: &str, _db: &Arc<DB>) {
+        log::warn!("profiling is not supported, so it doesn't track db process for [{typ}]");
+    }
+}

--- a/core/run/src/components/mod.rs
+++ b/core/run/src/components/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod extensions;
 pub(crate) mod system;
 
 #[cfg(all(

--- a/core/run/src/components/mod.rs
+++ b/core/run/src/components/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod extensions;
 pub(crate) mod network;
+pub(crate) mod storage;
 pub(crate) mod system;
 
 #[cfg(all(

--- a/core/run/src/components/mod.rs
+++ b/core/run/src/components/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod extensions;
+pub(crate) mod network;
 pub(crate) mod system;
 
 #[cfg(all(

--- a/core/run/src/components/network.rs
+++ b/core/run/src/components/network.rs
@@ -1,0 +1,147 @@
+//! Configure the network service.
+
+use std::sync::Arc;
+
+use core_consensus::message::{
+    ChokeMessageHandler, ProposalMessageHandler, PullBlockRpcHandler, PullProofRpcHandler,
+    PullTxsRpcHandler, QCMessageHandler, RemoteHeightMessageHandler, VoteMessageHandler,
+    BROADCAST_HEIGHT, END_GOSSIP_AGGREGATED_VOTE, END_GOSSIP_SIGNED_CHOKE,
+    END_GOSSIP_SIGNED_PROPOSAL, END_GOSSIP_SIGNED_VOTE, RPC_RESP_SYNC_PULL_BLOCK,
+    RPC_RESP_SYNC_PULL_PROOF, RPC_RESP_SYNC_PULL_TXS, RPC_SYNC_PULL_BLOCK, RPC_SYNC_PULL_PROOF,
+    RPC_SYNC_PULL_TXS,
+};
+use core_consensus::OverlordSynchronization;
+use core_db::RocksAdapter;
+use core_mempool::{
+    NewTxsHandler, PullTxsHandler, END_GOSSIP_NEW_TXS, RPC_PULL_TXS, RPC_RESP_PULL_TXS,
+    RPC_RESP_PULL_TXS_SYNC,
+};
+use core_network::{KeyProvider, NetworkService, PeerId, PeerIdExt};
+use core_storage::ImplStorage;
+use protocol::{
+    traits::{Consensus, Context, MemPool, Network, SynchronizationAdapter},
+    types::ValidatorExtend,
+    ProtocolResult,
+};
+
+pub(crate) trait NetworkServiceExt {
+    fn tag_consensus(&self, validators: &[ValidatorExtend]) -> ProtocolResult<()>;
+
+    fn register_mempool_endpoint(
+        &mut self,
+        mempool: &Arc<impl MemPool + 'static>,
+    ) -> ProtocolResult<()>;
+
+    fn register_consensus_endpoint(
+        &mut self,
+        overlord_consensus: &Arc<impl Consensus + 'static>,
+    ) -> ProtocolResult<()>;
+
+    fn register_synchronization_endpoint(
+        &mut self,
+        synchronization: &Arc<OverlordSynchronization<impl SynchronizationAdapter + 'static>>,
+    ) -> ProtocolResult<()>;
+
+    fn register_storage_endpoint(
+        &mut self,
+        storage: &Arc<ImplStorage<RocksAdapter>>,
+    ) -> ProtocolResult<()>;
+
+    fn register_rpc(&mut self) -> ProtocolResult<()>;
+}
+
+impl<K> NetworkServiceExt for NetworkService<K>
+where
+    K: KeyProvider,
+{
+    fn tag_consensus(&self, validators: &[ValidatorExtend]) -> ProtocolResult<()> {
+        let peer_ids = validators
+            .iter()
+            .map(|v| PeerId::from_pubkey_bytes(v.pub_key.as_bytes()).map(PeerIdExt::into_bytes_ext))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        self.handle().tag_consensus(Context::new(), peer_ids)
+    }
+
+    fn register_mempool_endpoint(
+        &mut self,
+        mempool: &Arc<impl MemPool + 'static>,
+    ) -> ProtocolResult<()> {
+        // register broadcast new transaction
+        self.register_endpoint_handler(
+            END_GOSSIP_NEW_TXS,
+            NewTxsHandler::new(Arc::clone(mempool)),
+        )?;
+        // register pull txs from other node
+        self.register_endpoint_handler(
+            RPC_PULL_TXS,
+            PullTxsHandler::new(Arc::new(self.handle()), Arc::clone(mempool)),
+        )?;
+        Ok(())
+    }
+
+    fn register_consensus_endpoint(
+        &mut self,
+        overlord_consensus: &Arc<impl Consensus + 'static>,
+    ) -> ProtocolResult<()> {
+        // register consensus
+        self.register_endpoint_handler(
+            END_GOSSIP_SIGNED_PROPOSAL,
+            ProposalMessageHandler::new(Arc::clone(overlord_consensus)),
+        )?;
+        self.register_endpoint_handler(
+            END_GOSSIP_AGGREGATED_VOTE,
+            QCMessageHandler::new(Arc::clone(overlord_consensus)),
+        )?;
+        self.register_endpoint_handler(
+            END_GOSSIP_SIGNED_VOTE,
+            VoteMessageHandler::new(Arc::clone(overlord_consensus)),
+        )?;
+        self.register_endpoint_handler(
+            END_GOSSIP_SIGNED_CHOKE,
+            ChokeMessageHandler::new(Arc::clone(overlord_consensus)),
+        )?;
+        Ok(())
+    }
+
+    fn register_synchronization_endpoint(
+        &mut self,
+        synchronization: &Arc<OverlordSynchronization<impl SynchronizationAdapter + 'static>>,
+    ) -> ProtocolResult<()> {
+        self.register_endpoint_handler(
+            BROADCAST_HEIGHT,
+            RemoteHeightMessageHandler::new(Arc::clone(synchronization)),
+        )?;
+        Ok(())
+    }
+
+    fn register_storage_endpoint(
+        &mut self,
+        storage: &Arc<ImplStorage<RocksAdapter>>,
+    ) -> ProtocolResult<()> {
+        let handle = Arc::new(self.handle());
+        // register storage
+        self.register_endpoint_handler(
+            RPC_SYNC_PULL_BLOCK,
+            PullBlockRpcHandler::new(Arc::clone(&handle), Arc::clone(storage)),
+        )?;
+        self.register_endpoint_handler(
+            RPC_SYNC_PULL_PROOF,
+            PullProofRpcHandler::new(Arc::clone(&handle), Arc::clone(storage)),
+        )?;
+        self.register_endpoint_handler(
+            RPC_SYNC_PULL_TXS,
+            PullTxsRpcHandler::new(Arc::clone(&handle), Arc::clone(storage)),
+        )?;
+        Ok(())
+    }
+
+    fn register_rpc(&mut self) -> ProtocolResult<()> {
+        self.register_rpc_response(RPC_RESP_PULL_TXS)?;
+        self.register_rpc_response(RPC_RESP_PULL_TXS_SYNC)?;
+        self.register_rpc_response(RPC_RESP_SYNC_PULL_BLOCK)?;
+        self.register_rpc_response(RPC_RESP_SYNC_PULL_PROOF)?;
+        self.register_rpc_response(RPC_RESP_SYNC_PULL_TXS)?;
+        Ok(())
+    }
+}

--- a/core/run/src/components/profiling.rs
+++ b/core/run/src/components/profiling.rs
@@ -1,0 +1,47 @@
+//! Control the profiling related features.
+
+use std::sync::Arc;
+
+use common_memory_tracker::{GetColumnFamilys, GetProperty, GetPropertyCF};
+use jemalloc_ctl::{Access, AsName};
+use jemallocator::Jemalloc;
+use protocol::tokio;
+
+#[global_allocator]
+pub static JEMALLOC: Jemalloc = Jemalloc;
+
+pub(crate) fn start() {
+    set_profile(true);
+}
+
+pub(crate) fn stop() {
+    set_profile(false);
+    dump_profile();
+}
+
+pub(crate) fn track_current_process() {
+    tokio::spawn(common_memory_tracker::track_current_process());
+}
+
+pub(crate) fn track_db_process<DB>(typ: &'static str, db_ref: &Arc<DB>)
+where
+    DB: GetColumnFamilys + GetProperty + GetPropertyCF + Send + Sync + 'static,
+{
+    let db = Arc::clone(db_ref);
+    tokio::spawn(common_memory_tracker::track_db_process::<DB>(typ, db));
+}
+
+fn set_profile(is_active: bool) {
+    let _ = b"prof.active\0"
+        .name()
+        .write(is_active)
+        .map_err(|e| panic!("Set jemalloc profile error {:?}", e));
+}
+
+fn dump_profile() {
+    let name = b"profile.out\0".as_ref();
+    b"prof.dump\0"
+        .name()
+        .write(name)
+        .expect("Should succeed to dump profile")
+}

--- a/core/run/src/components/storage.rs
+++ b/core/run/src/components/storage.rs
@@ -1,0 +1,80 @@
+use std::{path::Path, sync::Arc};
+
+use common_config_parser::types::{spec::InitialAccount, ConfigRocksDB};
+use core_db::{RocksAdapter, RocksDB};
+use core_executor::{MPTTrie, RocksTrieDB};
+use core_storage::ImplStorage;
+use protocol::{
+    async_trait,
+    codec::ProtocolCodec,
+    traits::{Context, Storage},
+    trie::{self, Trie},
+    types::{Account, Block, ExecResp, HasherKeccak, RichBlock, NIL_DATA, RLP_NULL},
+    ProtocolResult,
+};
+
+pub(crate) fn init_storage<P: AsRef<Path>>(
+    config: &ConfigRocksDB,
+    rocksdb_path: P,
+    triedb_cache_size: usize,
+) -> ProtocolResult<(
+    Arc<ImplStorage<RocksAdapter>>,
+    Arc<RocksTrieDB>,
+    Arc<RocksDB>,
+)> {
+    let adapter = Arc::new(RocksAdapter::new(rocksdb_path, config.clone())?);
+    let inner_db = adapter.inner_db();
+    let trie_db = Arc::new(RocksTrieDB::new_evm(adapter.inner_db(), triedb_cache_size));
+    let storage = Arc::new(ImplStorage::new(adapter, config.cache_size));
+    Ok((storage, trie_db, inner_db))
+}
+
+#[async_trait]
+pub(crate) trait StorageExt: Storage {
+    async fn try_load_genesis(&self) -> ProtocolResult<Option<Block>> {
+        self.get_block(Context::new(), 0).await.or_else(|e| {
+            if e.to_string().contains("GetNone") {
+                Ok(None)
+            } else {
+                Err(e)
+            }
+        })
+    }
+
+    async fn save_block(&self, rich: &RichBlock, resp: &ExecResp) -> ProtocolResult<()> {
+        self.update_latest_proof(Context::new(), rich.block.header.proof.clone())
+            .await?;
+        self.insert_block(Context::new(), rich.block.clone())
+            .await?;
+        self.insert_transactions(Context::new(), rich.block.header.number, rich.txs.clone())
+            .await?;
+        let (receipts, _logs) = rich.generate_receipts_and_logs(resp);
+        self.insert_receipts(Context::new(), rich.block.header.number, receipts)
+            .await?;
+        Ok(())
+    }
+}
+
+impl StorageExt for ImplStorage<RocksAdapter> {}
+
+pub(crate) trait TrieExt<D, H>: Trie<D, H> + Sized
+where
+    D: trie::DB,
+    H: trie::Hasher,
+{
+    fn insert_accounts(mut self, accounts: &[InitialAccount]) -> ProtocolResult<Self> {
+        for account in accounts {
+            let raw_account = Account {
+                nonce:        0u64.into(),
+                balance:      account.balance,
+                storage_root: RLP_NULL,
+                code_hash:    NIL_DATA,
+            }
+            .encode()?;
+            self.insert(account.address.as_bytes().to_vec(), raw_account.to_vec())?;
+        }
+        Ok(self)
+    }
+}
+
+impl<D> TrieExt<D, HasherKeccak> for MPTTrie<D> where D: trie::DB {}

--- a/core/run/src/components/system.rs
+++ b/core/run/src/components/system.rs
@@ -1,0 +1,59 @@
+use std::panic::PanicInfo;
+
+use backtrace::Backtrace;
+
+use protocol::tokio;
+#[cfg(unix)]
+use protocol::tokio::signal::unix as os_impl;
+
+pub(crate) async fn set_ctrl_c_handle() {
+    let ctrl_c_handler = tokio::spawn(async {
+        #[cfg(windows)]
+        let _ = tokio::signal::ctrl_c().await;
+        #[cfg(unix)]
+        {
+            let mut sigtun_int = os_impl::signal(os_impl::SignalKind::interrupt()).unwrap();
+            let mut sigtun_term = os_impl::signal(os_impl::SignalKind::terminate()).unwrap();
+            tokio::select! {
+                _ = sigtun_int.recv() => {}
+                _ = sigtun_term.recv() => {}
+            };
+        }
+    });
+
+    // register channel of panic
+    let (panic_sender, mut panic_receiver) = tokio::sync::mpsc::channel::<()>(1);
+
+    std::panic::set_hook(Box::new(move |info: &PanicInfo| {
+        let panic_sender = panic_sender.clone();
+        panic_log(info);
+        panic_sender.try_send(()).expect("panic_receiver is droped");
+    }));
+
+    tokio::select! {
+        _ = ctrl_c_handler => { log::info!("ctrl + c is pressed, quit.") },
+        _ = panic_receiver.recv() => { log::info!("child thread panic, quit.") },
+    };
+}
+
+fn panic_log(info: &PanicInfo) {
+    let backtrace = Backtrace::new();
+    let thread = std::thread::current();
+    let name = thread.name().unwrap_or("unnamed");
+    let location = info.location().unwrap(); // The current implementation always returns Some
+    let msg = match info.payload().downcast_ref::<&'static str>() {
+        Some(s) => *s,
+        None => match info.payload().downcast_ref::<String>() {
+            Some(s) => &**s,
+            None => "Box<Any>",
+        },
+    };
+    log::error!(
+        target: "panic", "thread '{}' panicked at '{}': {}:{} {:?}",
+        name,
+        msg,
+        location.file(),
+        location.line(),
+        backtrace,
+    );
+}

--- a/core/run/src/error.rs
+++ b/core/run/src/error.rs
@@ -1,0 +1,33 @@
+use protocol::{Display, From, ProtocolError, ProtocolErrorKind};
+
+#[derive(Debug, Display, From)]
+pub enum MainError {
+    #[display(fmt = "The axon configuration read failed {:?}", _0)]
+    ConfigParse(common_config_parser::ParseError),
+
+    #[display(fmt = "{:?}", _0)]
+    Io(std::io::Error),
+
+    #[display(fmt = "Toml fails to parse genesis {:?}", _0)]
+    GenesisTomlDe(toml::de::Error),
+
+    #[display(fmt = "crypto error {:?}", _0)]
+    Crypto(common_crypto::Error),
+
+    #[display(fmt = "{:?}", _0)]
+    Utf8(std::string::FromUtf8Error),
+
+    #[display(fmt = "{:?}", _0)]
+    JSONParse(serde_json::error::Error),
+
+    #[display(fmt = "other error {:?}", _0)]
+    Other(String),
+}
+
+impl std::error::Error for MainError {}
+
+impl From<MainError> for ProtocolError {
+    fn from(error: MainError) -> ProtocolError {
+        ProtocolError::new(ProtocolErrorKind::Main, Box::new(error))
+    }
+}

--- a/core/run/src/key_provider.rs
+++ b/core/run/src/key_provider.rs
@@ -1,0 +1,57 @@
+use core_network::{KeyProvider, SecioError, SecioKeyPair};
+
+use protocol::async_trait;
+
+#[derive(Clone)]
+pub(crate) enum KeyP<K: KeyProvider> {
+    Custom(K),
+    Default(SecioKeyPair),
+}
+
+#[async_trait]
+impl<K> KeyProvider for KeyP<K>
+where
+    K: KeyProvider,
+{
+    type Error = SecioError;
+
+    async fn sign_ecdsa_async<T: AsRef<[u8]> + Send>(
+        &self,
+        message: T,
+    ) -> Result<Vec<u8>, Self::Error> {
+        match self {
+            KeyP::Custom(k) => k.sign_ecdsa_async(message).await.map_err(Into::into),
+            KeyP::Default(k) => k.sign_ecdsa_async(message).await,
+        }
+    }
+
+    /// Constructs a signature for `msg` using the secret key `sk`
+    fn sign_ecdsa<T: AsRef<[u8]>>(&self, message: T) -> Result<Vec<u8>, Self::Error> {
+        match self {
+            KeyP::Custom(k) => k.sign_ecdsa(message).map_err(Into::into),
+            KeyP::Default(k) => k.sign_ecdsa(message),
+        }
+    }
+
+    /// Creates a new public key from the [`KeyProvider`].
+    fn pubkey(&self) -> Vec<u8> {
+        match self {
+            KeyP::Custom(k) => k.pubkey(),
+            KeyP::Default(k) => k.pubkey(),
+        }
+    }
+
+    /// Checks that `sig` is a valid ECDSA signature for `msg` using the
+    /// pubkey.
+    fn verify_ecdsa<P, T, F>(&self, pubkey: P, message: T, signature: F) -> bool
+    where
+        P: AsRef<[u8]>,
+        T: AsRef<[u8]>,
+        F: AsRef<[u8]>,
+    {
+        match self {
+            KeyP::Custom(k) => k.verify_ecdsa(pubkey, message, signature),
+            KeyP::Default(k) => k.verify_ecdsa(pubkey, message, signature),
+        }
+    }
+}

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(clippy::uninlined_format_args, clippy::mutable_key_type)]
 
-use std::{collections::HashMap, panic::PanicInfo, path::Path, sync::Arc, time::Duration};
-
-use backtrace::Backtrace;
+use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
 
 use common_apm::metrics::mempool::{MEMPOOL_CO_QUEUE_LEN, MEMPOOL_LEN_GAUGE};
 use common_apm::{server::run_prometheus_server, tracing::global_tracer_register};
@@ -11,8 +9,6 @@ use common_config_parser::types::{Config, ConfigJaeger, ConfigPrometheus, Config
 use common_crypto::{BlsPrivateKey, BlsPublicKey, Secp256k1, Secp256k1PrivateKey, ToPublicKey};
 
 use protocol::codec::{hex_decode, ProtocolCodec};
-#[cfg(unix)]
-use protocol::tokio::signal::unix as os_impl;
 use protocol::tokio::{
     self, runtime::Builder as RuntimeBuilder, sync::Mutex as AsyncMutex, time::sleep,
 };
@@ -370,8 +366,7 @@ impl Axon {
         // Run consensus
         Self::run_overlord_consensus(metadata, validators, current_block, overlord_consensus);
 
-        Self::set_ctrl_c_handle().await;
-
+        components::system::set_ctrl_c_handle().await;
         components::profiling::stop();
 
         Ok(())
@@ -713,58 +708,6 @@ impl Axon {
                 log::error!("axon-consensus: {:?} error", e);
             }
         });
-    }
-
-    async fn set_ctrl_c_handle() {
-        let ctrl_c_handler = tokio::spawn(async {
-            #[cfg(windows)]
-            let _ = tokio::signal::ctrl_c().await;
-            #[cfg(unix)]
-            {
-                let mut sigtun_int = os_impl::signal(os_impl::SignalKind::interrupt()).unwrap();
-                let mut sigtun_term = os_impl::signal(os_impl::SignalKind::terminate()).unwrap();
-                tokio::select! {
-                    _ = sigtun_int.recv() => {}
-                    _ = sigtun_term.recv() => {}
-                };
-            }
-        });
-
-        // register channel of panic
-        let (panic_sender, mut panic_receiver) = tokio::sync::mpsc::channel::<()>(1);
-
-        std::panic::set_hook(Box::new(move |info: &PanicInfo| {
-            let panic_sender = panic_sender.clone();
-            Self::panic_log(info);
-            panic_sender.try_send(()).expect("panic_receiver is droped");
-        }));
-
-        tokio::select! {
-            _ = ctrl_c_handler => { log::info!("ctrl + c is pressed, quit.") },
-            _ = panic_receiver.recv() => { log::info!("child thread panic, quit.") },
-        };
-    }
-
-    fn panic_log(info: &PanicInfo) {
-        let backtrace = Backtrace::new();
-        let thread = std::thread::current();
-        let name = thread.name().unwrap_or("unnamed");
-        let location = info.location().unwrap(); // The current implementation always returns Some
-        let msg = match info.payload().downcast_ref::<&'static str>() {
-            Some(s) => *s,
-            None => match info.payload().downcast_ref::<String>() {
-                Some(s) => &**s,
-                None => "Box<Any>",
-            },
-        };
-        log::error!(
-            target: "panic", "thread '{}' panicked at '{}': {}:{} {:?}",
-            name,
-            msg,
-            location.file(),
-            location.line(),
-            backtrace,
-        );
     }
 }
 

--- a/core/run/src/tests.rs
+++ b/core/run/src/tests.rs
@@ -18,7 +18,7 @@ use protocol::{
     types::{RichBlock, H256},
 };
 
-use crate::{execute_transactions, init_storage};
+use crate::{execute_transactions, DatabaseGroup};
 
 const DEV_CONFIG_DIR: &str = "../../devtools/chain";
 
@@ -129,21 +129,15 @@ async fn check_genesis_data<'a>(case: &TestCase<'a>) {
         );
     }
     let path_block = tmp_dir.path().join("block");
-    let (storage, trie_db, inner_db) = init_storage(
+    let db_group = DatabaseGroup::new(
         &config.rocksdb,
         path_block,
         config.executor.triedb_cache_size,
     )
-    .expect("initialize storage");
+    .expect("initialize databases");
 
-    let resp = execute_transactions(
-        &genesis,
-        &storage,
-        &trie_db,
-        &inner_db,
-        &chain_spec.accounts,
-    )
-    .expect("execute transactions");
+    let resp = execute_transactions(&genesis, &db_group, &chain_spec.accounts)
+        .expect("execute transactions");
 
     check_hashes(
         case.chain_name,

--- a/core/run/src/tests.rs
+++ b/core/run/src/tests.rs
@@ -134,7 +134,6 @@ async fn check_genesis_data<'a>(case: &TestCase<'a>) {
         path_block,
         config.executor.triedb_cache_size,
     )
-    .await
     .expect("initialize storage");
 
     let resp = execute_transactions(

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -21,6 +21,7 @@ ethereum-types = { version = "0.14", features = ["arbitrary", "codec", "rlp", "s
 ethers-core = "2.0"
 evm = { version = "0.37", features = ["with-serde"] }
 faster-hex = "0.8"
+hasher = "0.1"
 lazy_static = "1.4"
 ophelia = "0.3"
 overlord = "0.4"

--- a/protocol/src/types/executor.rs
+++ b/protocol/src/types/executor.rs
@@ -1,5 +1,6 @@
 pub use ethereum::{AccessList, AccessListItem, Account};
 pub use evm::{backend::Log, Config, ExitError, ExitFatal, ExitReason, ExitRevert, ExitSucceed};
+pub use hasher::HasherKeccak;
 
 use rlp_derive::{RlpDecodable, RlpEncodable};
 

--- a/protocol/src/types/mod.rs
+++ b/protocol/src/types/mod.rs
@@ -7,7 +7,7 @@ pub use ckb_client::*;
 pub use evm::{backend::*, ExitError, ExitRevert, ExitSucceed};
 pub use executor::{
     logs_bloom, AccessList, AccessListItem, Account, Config, ExecResp, ExecutorContext, ExitReason,
-    TxResp,
+    HasherKeccak, TxResp,
 };
 pub use interoperation::*;
 pub use primitive::*;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR refactors the all-in-one file of `core-run`:

- Split the all-in-one file of `core-run` into several files.

  The original file is the 2nd largest file in the whole repository.

  It has 1000+ lines and 70+ lines for importing items.

- Split the "huge" struct `Axon`.

  Examples:

  - <details><summary> :point_right: Disallow "one-time" field, i.e., don't save intermediate data in global.</summary><br />

    Should we have to refresh the fields that only used once?
    We don't have to concern that if there is no "one-time" fields.

    - In `Axon`, the `spec` (only has the `accounts` field), `genesis` and `state_root` are "one-time" fields.

      They are only used when boot the services.

      https://github.com/axonweb3/axon/blob/0ed2ce640b47e77cadbbc41c6b3f0c9b81db5e8c/core/run/src/lib.rs#L84-L90

      Especially `state_root`, it's just an intermediate data which only used once.
      And, it can be replaced with `self.genesis.block.header.state_root`.

      https://github.com/axonweb3/axon/blob/0ed2ce640b47e77cadbbc41c6b3f0c9b81db5e8c/core/run/src/lib.rs#L175
      https://github.com/axonweb3/axon/blob/0ed2ce640b47e77cadbbc41c6b3f0c9b81db5e8c/core/run/src/lib.rs#L575-L579

    </details>

  - <details><summary> :point_right: If a method only use <code>self.aaa.bbb.ccc</code>, then should not use <code>self</code> as the parameter.</summary><br />

    This will result in that's hard to detect minimal dependencies for class methods, so that:
    - The method is hard to reusable.
    - If writes unit tests, it has to construct a huge `Self` with many dummy fields.

    </details>

- Remove all default unspecified addresses.

  Examples:

  - <details><summary> :point_right: The <code>jaeger</code> service listens <code>0.0.0.0:6831</code> as default.</summary>

    https://github.com/axonweb3/axon/blob/0ed2ce640b47e77cadbbc41c6b3f0c9b81db5e8c/core/run/src/lib.rs#L764-L767

    </details>

- Remove lots of unnecessary `unrwap()`.

  Examples:

  - <details><summary> :point_right: The caller function already handle the errors.</summary>

    https://github.com/axonweb3/axon/blob/0ed2ce640b47e77cadbbc41c6b3f0c9b81db5e8c/core/run/src/lib.rs#L739-L755
    https://github.com/axonweb3/axon/blob/0ed2ce640b47e77cadbbc41c6b3f0c9b81db5e8c/core/run/src/lib.rs#L254-L259

    </details>

- Use latest block if possible.

  - <details><summary> :point_right: When initialize <code>MetaData</code>.</summary><br />

    The following code is executed when axon starts:

    https://github.com/axonweb3/axon/blob/28771913c09f85aca488a4b3e50f3fb7fdc6dabc/core/run/src/lib.rs#L316-L323

    Modified as the following code:

    ```diff
      // Get the validator list from current metadata for consensus initialization 
      let metadata_root = AxonExecutorReadOnlyAdapter::from_root( 
          current_state_root, 
          Arc::clone(&trie_db), 
          Arc::clone(&storage), 
    -     Proposal::new_without_state_root(&self.genesis.block.header).into(), 
    +     Proposal::new_without_state_root(&current_block.header).into(), 
      )? 
    ```

  - <details><summary> :point_right: When initialize <code>MemPool</code>.</summary><br />

    The following code is executed when axon starts:

    https://github.com/axonweb3/axon/blob/28771913c09f85aca488a4b3e50f3fb7fdc6dabc/core/run/src/lib.rs#L436-L445

    Modified as the following code:

    ```diff
      let mempool_adapter = DefaultMemPoolAdapter::<Secp256k1, _, _, _, InteroperationImpl>::new(
          network_service.clone(),
          Arc::clone(storage),
          Arc::clone(trie_db),
    -     self.genesis.block.header.chain_id,
    -     self.genesis.block.header.gas_limit.as_u64(),
    +     current_block.header.chain_id,
    +     current_block.header.gas_limit.as_u64(),
          self.config.mempool.pool_size as usize,
          self.config.mempool.broadcast_txs_size,
          self.config.mempool.broadcast_txs_interval,
      );
    ```

### Major Changes

- The jaeger service won't be started if no `tracing_address` is set in the configuration file.

  No default address anymore.

### What is the impact of this PR?

:white_check_mark: No Breaking Change

**PR relation**:

- Ref #1345

  Prepare for the feature in that issue, so that refactor and features are not mixed in one commit.

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Cargo Clippy
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>