### PR TITLE
ci: refactor `cargo build` and `cargo clippy` workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,6 @@ You could link a pull request to an issue by using a supported keyword in the pu
 
 **CI Switch**
 
-- [ ] Cargo Clippy
 - [ ] Coverage Test
 - [ ] E2E Tests
 - [ ] Code Format

--- a/.github/workflows/axon-start-with-short-genesis.yml
+++ b/.github/workflows/axon-start-with-short-genesis.yml
@@ -49,8 +49,9 @@ jobs:
         await waitXBlocksPassed('http://127.0.0.1:8000', 2);
         EOF
       timeout-minutes: 1
+
     - name: Archive logs
-      if: always()
+      if: failure()
       uses: actions/upload-artifact@v3
       with:
         name: single-axon-node-logs
@@ -113,7 +114,7 @@ jobs:
       timeout-minutes: 1
 
     - name: Archive logs
-      if: always()
+      if: failure()
       uses: actions/upload-artifact@v3
       with:
         name: multi-axon-nodes-logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build Axon Binary
 
 on:
-  push:
-  pull_request:
-  merge_group:
   workflow_dispatch:
   # Rather than copying and pasting from one workflow to another, you can make workflows reusable.
   # See https://docs.github.com/en/actions/using-workflows/reusing-workflows

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -5,6 +5,13 @@ on:
   pull_request:
   merge_group:
 
+# Ensure that only a single job or workflow using the same concurrency group will run at a time.
+# see https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # only needs to check a group's latest commit
+  cancel-in-progress: true
+
 jobs:
   cargo-clippy:
     strategy:
@@ -29,8 +36,9 @@ jobs:
           target/
         key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
+          ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-clippy
           ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo
-    
+
     - name: Install cargo-clippy
       run: rustup component add clippy
 

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,124 +1,40 @@
 name: Cargo Clippy
+
 on:
   push:
-    branches:
-      - main
   pull_request:
-    types: [ opened, synchronize, reopened ]
   merge_group:
-  workflow_dispatch:
-    inputs:
-      dispatch:
-        type: string
-        description: "Dispatch contains pr context that want to trigger cargo cllipy"
-        required: true
+
 jobs:
-  Dispatch-Clippy:
-    if: contains(github.event_name, 'workflow_dispatch')
-    runs-on: ubuntu-latest
-    outputs:
-      output-sha: ${{ steps.escape_multiple_lines_test_inputs.outputs.result }}
-    steps:
-      - name: Generate axon-bot token
-        if: contains(github.event_name, 'workflow_dispatch') &&
-            github.repository_owner == 'axonweb3' && github.event.inputs.dispatch != 'regression'
-        id: generate_axon_bot_token
-        uses: wow-actions/use-app-token@v2
-        with:
-          app_id: ${{ secrets.AXON_BOT_APP_ID }}
-          private_key: ${{ secrets.AXON_BOT_PRIVATE_KEY }}
-      - name: Event is dispatch
-        if: contains(github.event_name, 'workflow_dispatch') &&
-            github.repository_owner == 'axonweb3' && github.event.inputs.dispatch != 'regression'
-        uses: actions/github-script@v6
-        id: get_sha
-        with:
-          github-token: ${{ steps.generate_axon_bot_token.outputs.BOT_TOKEN }}
-          script: |
-            const dispatch = JSON.parse(`${{ github.event.inputs.dispatch }}`);
-            const pr = (
-             await github.rest.pulls.get({
-               owner: dispatch.repo.owner,
-               repo: dispatch.repo.repo,
-               pull_number: dispatch.issue.number,
-            })
-            ).data.head;
-            github.rest.repos.createCommitStatus({
-              state: 'pending',
-              owner: dispatch.repo.owner,
-              repo: dispatch.repo.repo,
-              context: '${{ github.workflow }}',
-              sha: pr.sha,
-              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-            })
-            return pr.sha
-      - name: Escape multiple lines test inputs
-        if: contains(github.event_name, 'workflow_dispatch') &&
-            github.repository_owner == 'axonweb3' && github.event.inputs.dispatch != 'regression'
-        id: escape_multiple_lines_test_inputs
-        run: |
-          inputs=${{ steps.get_sha.outputs.result}}
-          inputs="${inputs//'%'/'%25'}"
-          inputs="${inputs//'\n'/'%0A'}"
-          inputs="${inputs//'\r'/'%0D'}"
-          echo "result=$inputs" >> $GITHUB_OUTPUT
-      - name: Git checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.escape_multiple_lines_test_inputs.outputs.result || 'main' }}
-      - uses: lyricwulf/abc@v1
-        with:
-          linux: m4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustfmt, clippy
+  cargo-clippy:
+    strategy:
+      matrix:
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-22.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
 
-      - name: cargo-clippy
-        run: make clippy && git diff --exit-code Cargo.lock
-
-  finally:
-    name: Finally
-    needs: [ Dispatch-Clippy ]
-    if: always() && contains(github.event_name, 'workflow_dispatch') &&
-        github.event.inputs.dispatch != 'regression' && github.repository_owner == 'axonweb3'
-    runs-on: ubuntu-latest
     steps:
-      - name: Generate axon-bot token
-        id: generate_axon_bot_token
-        uses: wow-actions/use-app-token@v2
-        with:
-          app_id: ${{ secrets.AXON_BOT_APP_ID }}
-          private_key: ${{ secrets.AXON_BOT_PRIVATE_KEY }}
-      - if: contains(join(needs.*.result, ';'), 'failure') || contains(join(needs.*.result, ';'), 'cancelled')
-        run: exit 1
-      - uses: actions/github-script@v6
-        if: ${{ always() }}
-        with:
-          github-token: ${{ steps.generate_axon_bot_token.outputs.BOT_TOKEN }}
-          script: |
-            github.rest.repos.createCommitStatus({
-              state: '${{ job.status }}',
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              context: '${{ github.workflow }}',
-              sha: '${{ needs.Dispatch-Clippy.outputs.output-sha || 'main'}}',
-              target_url: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-            })
-  Clippy:
-    if: |
-      (contains(fromJson('["dependabot[bot]" ]'), github.actor) && github.event_name == 'pull_request') ||
-      (contains(github.event_name, 'push') && github.ref == 'refs/heads/main' )
-    runs-on: ubuntu-latest
-    steps:
-      - uses: lyricwulf/abc@v1
-        with:
-          linux: m4
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustfmt, clippy
+    - uses: actions/checkout@v3
 
-      - name: cargo-clippy
-        run: make clippy && git diff --exit-code Cargo.lock
+    - name: Cache of Cargo
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo
+    
+    - name: Install cargo-clippy
+      run: rustup component add clippy
+
+    - name: Run cargo-clippy in Makefile
+      run: make clippy && git diff --exit-code Cargo.lock
+
+    - run: ls -lh target


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

1. ci: `build.yml` won't need to be triggered by push event
   Because `build.yml` has been triggered by axon-start-with-short-genesis.yml,
   it won't be triggered by push and pull_request events.

2. ci(clippy): just cache cargo and finish `clippy` quickly
   - clear the complicated ci steps in `clippy.yml` -> let's keep things simple
   - use concurrency ensure that only a clippy job will run in a group

3. start-test ci: only upload logs to GitHub artifact when the test failed
   Because https://github.com/actions/upload-artifact/issues/429

### What is the impact of this PR?

No Breaking Change

<!--
**Special notes for your reviewer**:
NIL

**PR relation**:
- Ref #

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

- Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
  see [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) or [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Cargo Clippy
- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
-->
</details>