### PR TITLE
refactor(network): immutable chain id

### DIFF
--- a/core/network/src/peer_manager/mod.rs
+++ b/core/network/src/peer_manager/mod.rs
@@ -1,4 +1,4 @@
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -21,7 +21,7 @@ pub struct PeerManager {
     online:           RwLock<Online>,
     peer_store:       RwLock<PeerStore>,
     bootstraps:       HashMap<PeerId, Multiaddr>,
-    chain_id:         Mutex<String>,
+    chain_id:         String,
     pub public_addrs: RwLock<HashSet<Multiaddr>>,
     config:           Arc<NetworkConfig>,
 
@@ -46,7 +46,7 @@ impl PeerManager {
             peer_store: RwLock::new(PeerStore::load_from_dir_or_default(
                 config.peer_store_path.clone(),
             )),
-            chain_id: Mutex::new(String::new()),
+            chain_id: config.chain_id.to_string(),
             bootstraps,
             public_addrs: RwLock::new(HashSet::new()),
             config,
@@ -180,12 +180,8 @@ impl PeerManager {
         }
     }
 
-    pub fn set_chain_id(&self, chain_id: String) {
-        *self.chain_id.lock() = chain_id;
-    }
-
     pub fn chain_id(&self) -> String {
-        self.chain_id.lock().clone()
+        self.chain_id.clone()
     }
 
     pub fn local_peer_id(&self) -> PeerId {

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -348,10 +348,6 @@ where
         self.config.secio_keypair.peer_id()
     }
 
-    pub fn set_chain_id(&self, chain_id: String) {
-        self.peer_mgr_handle.set_chain_id(chain_id);
-    }
-
     /// Dial just feeler protocol
     pub async fn dial_feeler(&mut self, addr: Multiaddr) {
         let peer_id = extract_peer_id(&addr).unwrap();

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -435,15 +435,14 @@ impl Axon {
         &self,
         key_provider: Option<K>,
     ) -> NetworkService<KeyP<K>> {
-        let network_config = NetworkConfig::from_config(&self.config).unwrap();
+        let network_config =
+            NetworkConfig::from_config(&self.config, self.genesis.block.header.chain_id).unwrap();
 
         let key = key_provider
             .map(KeyP::Custom)
             .unwrap_or(KeyP::Default(network_config.secio_keypair.clone()));
 
-        let network_service = NetworkService::new(network_config, key);
-        network_service.set_chain_id(self.genesis.block.header.chain_id.to_string());
-        network_service
+        NetworkService::new(network_config, key)
     }
 
     fn init_evm_trie_db(&self, inner_db: Arc<RocksDB>) -> Arc<RocksTrieDB> {


### PR DESCRIPTION
## What this PR does / why we need it?

This PR:
- Make the chain id in network service to be immutable.
- Remove a comment which breaks the code format.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Cargo Clippy
- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Unit Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
-->
</details>