### PR TITLE
ci(unit test): avoid using cargo-clippy cache

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -36,7 +36,6 @@ jobs:
         key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-test
-          ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo
 
     - name: Run Rust unit-test
       run: make test


### PR DESCRIPTION
## Related Error Action Run
- https://github.com/axonweb3/axon/actions/runs/5960347027/job/16167491634#step:4:265

## What this PR does / why we need it?

This PR fixes https://github.com/axonweb3/axon/pull/1354#issuecomment-1691150649

Because there is only 14 GB of SSD space on a GitHub hosted runner.
see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

Axon is a big project.
`cargo clippy` and `cargo test` can not be run together in a GitHub-hosted nunner.

### What is the impact of this PR?

No Breaking Change


<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
-->
</details>