### PR TITLE
chore: build and push docker image to ghcr.io

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,4 +1,5 @@
 name: Build docker image
+
 on:
   push:
     tags:
@@ -9,6 +10,7 @@ on:
         type: string
         description: "The tag name for docker images"
         required: true
+
 jobs:
   output_tag_name:
     runs-on: ubuntu-latest
@@ -82,6 +84,3 @@ jobs:
           JOB_ID: "build-arm64-image-${{ github.repository_owner }}-${{ steps.date.outputs.date }}-in-10h"
         run: |
          ./devtools/ci/build-arm64.sh clean
-
-
-

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,8 +1,8 @@
 name: Build docker image
 on:
-  # push:
-  #   branches:
-  #     - main
+  push:
+    tags:
+      - '*'
   workflow_dispatch:
     inputs:
       dispatch:

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   output_tag_name:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       tag_name: ${{ steps.output.outputs.tag_name }}
     steps:
@@ -29,7 +29,7 @@ jobs:
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
 
   build-amd64-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: output_tag_name
     steps:
       - name: Git checkout
@@ -55,7 +55,7 @@ jobs:
           tags: axonweb3/axon:amd64-${{ needs.output_tag_name.outputs.tag_name }}
 
   build-arm64-image:
-    runs-on: [self-hosted,build]
+    runs-on: [self-hosted, build]
     needs: output_tag_name
     env:
       AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit_sha || github.sha }}
       - name: Get Short Commit Hash
-        run: echo "::set-output name=SHORT_COMMIT::$(echo ${{ github.sha }} | cut -c1-8)"      
+        run: echo "::set-output name=SHORT_COMMIT::${GITHUB_SHA::8}"      
       - name: Login to Github resgistry
         uses: docker/login-action@v1
         with:
@@ -38,5 +38,5 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ghcr.io/simon-tl/axon:amd64-${{ steps.short_commit.outputs.SHORT_COMMIT }}
+          tags: ghcr.io/simon-tl/axon:amd64-${{ steps.short_commit.outputs.SHORT_COMMIT  }}
           

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -1,0 +1,117 @@
+name: Build docker image
+on:
+  push:
+    branches:
+      - build-images
+    tags:
+      - '*'      
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA to build'
+        required: true
+
+
+jobs:
+  output_tag_name:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.output.outputs.tag_name }}
+    steps:
+      - name: output tag name for image
+        id: output
+        run: |
+          if [ ${{ github.event_name }} == 'push' ]; then
+            export tag_name=`echo ${{ github.ref }} | awk -F '/' '{print $3}'`
+          fi
+          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+            export tag_name=${{ github.event.inputs.dispatch }}
+          fi
+          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
+
+  build-amd64-image_commit:
+    runs-on: ubuntu-latest
+    needs: output_tag_name
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.commit_sha || github.sha }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/simon-tl/axon:amd64-${{ needs.output_tag_name.outputs.tag_name }}
+
+  build-amd64-image-tag:
+    runs-on: ubuntu-latest
+    needs: output_tag_name
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref || 'main' }}
+      - name: Login to Github resgistry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: axonweb3/axon:amd64-${{ needs.output_tag_name.outputs.tag_name }}
+          
+          
+  # build-arm64-image:
+  #   runs-on: [self-hosted,build]
+  #   needs: output_tag_name
+  #   env:
+  #     AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+  #     AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+  #     AWS_EC2_TYPE:  "c6g.xlarge"
+  #     DOCKER_USER: ${{ secrets.DOCKER_HUB_USERNAME }}
+  #     DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+  #     AXON_TAG: arm64-${{needs.output_tag_name.outputs.tag_name}}
+  #   steps:
+  #     - name: Get Current Date & Set ENV
+  #       id: date
+  #       run: |
+  #         echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+  #     - name: Git checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ github.ref || 'build-arm64-image' }}
+  #     - name: arm64 docker image build
+  #       env:
+  #         JOB_ID: "build-arm64-image-${{ github.repository_owner }}-${{ steps.date.outputs.date }}-in-10h"
+  #       run: |
+  #        ./devtools/ci/build-arm64.sh run
+  #     - name: clean up
+  #       if: ${{ always() }}
+  #       env:
+  #         JOB_ID: "build-arm64-image-${{ github.repository_owner }}-${{ steps.date.outputs.date }}-in-10h"
+  #       run: |
+  #        ./devtools/ci/build-arm64.sh clean
+
+
+

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -37,8 +37,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.commit_sha || github.sha }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Login to Github resgistryb
+        uses: docker/login-action@v1
         with:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -62,8 +62,8 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref || 'main' }}
-      - name: Login to Github resgistry
+          ref: ${{ github.ref || 'build-images' }}
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -79,7 +79,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: axonweb3/axon:amd64-${{ needs.output_tag_name.outputs.tag_name }}
+          tags: simontl/axon:amd64-${{ needs.output_tag_name.outputs.tag_name }}
           
           
   # build-arm64-image:

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Login to Github resgistry
         uses: docker/login-action@v1
         with:
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -11,27 +11,27 @@ on:
 
 
 jobs:
-  output_tag_name:
-    runs-on: ubuntu-latest
-    outputs:
-      tag_name: ${{ steps.output.outputs.tag_name }}
-    steps:
-      - name: output tag name for image
-        id: output
-        run: |
-          if [ ${{ github.event_name }} == 'push' ]; then
-            export tag_name=`echo ${{ github.ref }} | awk -F '/' '{print $3}'`
-            echo ${{ github.ref }} | awk -F '/' '{print $3}' 
-          fi
-          if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
-            export tag_name=${{ github.event.inputs.dispatch }}
-            echo $tag_name
-          fi
-          echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
+  # output_tag_name:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     tag_name: ${{ steps.output.outputs.tag_name }}
+  #   steps:
+  #     - name: output tag name for image
+  #       id: output
+  #       run: |
+  #         if [ ${{ github.event_name }} == 'push' ]; then
+  #           export tag_name=`echo ${{ github.ref }} | awk -F '/' '{print $3}'`
+  #           echo ${{ github.ref }} | awk -F '/' '{print $3}' 
+  #         fi
+  #         if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+  #           export tag_name=${{ github.event.inputs.dispatch }}
+  #           echo $tag_name
+  #         fi
+  #         echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
 
   build-amd64-image_commit:
     runs-on: ubuntu-latest
-    needs: output_tag_name
+    # needs: output_tag_name
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ghcr.io/simon-tl/axon:amd64-${{ needs.output_tag_name.outputs.tag_name }}
+          tags: ghcr.io/simon-tl/axon:amd64-${{ github.sha }}
 
   # build-amd64-image-tag:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -11,24 +11,6 @@ on:
 
 
 jobs:
-  # output_tag_name:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     tag_name: ${{ steps.output.outputs.tag_name }}
-  #   steps:
-  #     - name: output tag name for image
-  #       id: output
-  #       run: |
-  #         if [ ${{ github.event_name }} == 'push' ]; then
-  #           export tag_name=`echo ${{ github.ref }} | awk -F '/' '{print $3}'`
-  #           echo ${{ github.ref }} | awk -F '/' '{print $3}' 
-  #         fi
-  #         if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
-  #           export tag_name=${{ github.event.inputs.dispatch }}
-  #           echo $tag_name
-  #         fi
-  #         echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
-
   build-amd64-image_commit:
     runs-on: ubuntu-latest
     # needs: output_tag_name
@@ -56,65 +38,5 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ghcr.io/simon-tl/axon:amd64-${{ github.sha }}
-
-  # build-amd64-image-tag:
-  #   runs-on: ubuntu-latest
-  #   needs: output_tag_name
-  #   steps:
-  #     - name: Git checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{ github.ref || 'build-images' }}
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{ secrets.DOCKER_HUB_USERNAME }}
-  #         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-  #     - name: Set up QEMU
-  #       uses: docker/setup-qemu-action@v2
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v2
-  #     - name: Build and push
-  #       uses: docker/build-push-action@v4
-  #       with:
-  #         context: .
-  #         file: ./Dockerfile
-  #         platforms: linux/amd64
-  #         push: true
-  #         tags: simontl/axon:amd64-${{ needs.output_tag_name.outputs.tag_name }}
+          tags: ghcr.io/simon-tl/axon:amd64-${{ steps.short_commit.outputs.SHORT_COMMIT }}
           
-          
-  # build-arm64-image:
-  #   runs-on: [self-hosted,build]
-  #   needs: output_tag_name
-  #   env:
-  #     AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-  #     AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
-  #     AWS_EC2_TYPE:  "c6g.xlarge"
-  #     DOCKER_USER: ${{ secrets.DOCKER_HUB_USERNAME }}
-  #     DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-  #     AXON_TAG: arm64-${{needs.output_tag_name.outputs.tag_name}}
-  #   steps:
-  #     - name: Get Current Date & Set ENV
-  #       id: date
-  #       run: |
-  #         echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-  #     - name: Git checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{ github.ref || 'build-arm64-image' }}
-  #     - name: arm64 docker image build
-  #       env:
-  #         JOB_ID: "build-arm64-image-${{ github.repository_owner }}-${{ steps.date.outputs.date }}-in-10h"
-  #       run: |
-  #        ./devtools/ci/build-arm64.sh run
-  #     - name: clean up
-  #       if: ${{ always() }}
-  #       env:
-  #         JOB_ID: "build-arm64-image-${{ github.repository_owner }}-${{ steps.date.outputs.date }}-in-10h"
-  #       run: |
-  #        ./devtools/ci/build-arm64.sh clean
-
-
-

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -1,42 +1,65 @@
-name: Build docker image commit
+name: Build ghcr.io image
+
 on:
   push:
-    branches:
-      - build-images
+    tags:
+    branches: [ '*docker*' ]
   workflow_dispatch:
     inputs:
       commit_sha:
         description: 'Commit SHA to build'
         required: true
 
-
 jobs:
-  build-amd64-image_commit:
+  build-amd64-image-to-ghcr:
     runs-on: ubuntu-latest
+    env:
+      REGISTRY: 'ghcr.io/'
+      IMAGE_NAME: axon
+
     steps:
-      - name: Git checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.commit_sha || github.sha }}
-      - name: Get Short Commit Hash
-        id: short_commit
-        run: echo "::set-output name=SHORT_COMMIT::${GITHUB_SHA::8}"      
+          ref: ${{ github.event.inputs.commit_sha || '' }}
+
+      # Extract metadata (tags, labels) for the Docker image
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            # minimal (short sha)
+            type=sha,enable=true,prefix=sha-,format=short
+      - name: Echo steps.meta.outputs.bake-file
+        run: cat ${{ steps.meta.outputs.bake-file }}
+
       - name: Login to Github resgistry
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Build and push
-        uses: docker/build-push-action@v2
+      - name: Build and push image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
-          push: true
-          tags: ghcr.io/simon-tl/axon:amd64-${{ steps.short_commit.outputs.SHORT_COMMIT  }}
-          
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+    # TODO: test the image

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit_sha || github.sha }}
       - name: Get Short Commit Hash
+        id: short_commit
         run: echo "::set-output name=SHORT_COMMIT::${GITHUB_SHA::8}"      
       - name: Login to Github resgistry
         uses: docker/login-action@v1

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.commit_sha || github.sha }}
-      - name: Login to Github resgistryb
+      - name: Login to Github resgistry
         uses: docker/login-action@v1
         with:
           username: ${{ github.repository_owner }}
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile
@@ -55,31 +55,31 @@ jobs:
           push: true
           tags: ghcr.io/simon-tl/axon:amd64-${{ needs.output_tag_name.outputs.tag_name }}
 
-  build-amd64-image-tag:
-    runs-on: ubuntu-latest
-    needs: output_tag_name
-    steps:
-      - name: Git checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref || 'build-images' }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build and push
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: simontl/axon:amd64-${{ needs.output_tag_name.outputs.tag_name }}
+  # build-amd64-image-tag:
+  #   runs-on: ubuntu-latest
+  #   needs: output_tag_name
+  #   steps:
+  #     - name: Git checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ github.ref || 'build-images' }}
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKER_HUB_USERNAME }}
+  #         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v2
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
+  #     - name: Build and push
+  #       uses: docker/build-push-action@v4
+  #       with:
+  #         context: .
+  #         file: ./Dockerfile
+  #         platforms: linux/amd64
+  #         push: true
+  #         tags: simontl/axon:amd64-${{ needs.output_tag_name.outputs.tag_name }}
           
           
   # build-arm64-image:

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   build-amd64-image_commit:
     runs-on: ubuntu-latest
-    # needs: output_tag_name
     steps:
       - name: Git checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -37,6 +37,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.commit_sha || github.sha }}
+      - name: Get Short Commit Hash
+        run: echo "::set-output name=SHORT_COMMIT::$(echo ${{ github.sha }} | cut -c1-8)"      
       - name: Login to Github resgistry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/build_image_commit.yml
+++ b/.github/workflows/build_image_commit.yml
@@ -1,10 +1,8 @@
-name: Build docker image
+name: Build docker image commit
 on:
   push:
     branches:
       - build-images
-    tags:
-      - '*'      
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -23,9 +21,11 @@ jobs:
         run: |
           if [ ${{ github.event_name }} == 'push' ]; then
             export tag_name=`echo ${{ github.ref }} | awk -F '/' '{print $3}'`
+            echo ${{ github.ref }} | awk -F '/' '{print $3}' 
           fi
           if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
             export tag_name=${{ github.event.inputs.dispatch }}
+            echo $tag_name
           fi
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build_image_ghcr.yml
+++ b/.github/workflows/build_image_ghcr.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to Github resgistry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}

--- a/.github/workflows/build_image_ghcr.yml
+++ b/.github/workflows/build_image_ghcr.yml
@@ -2,8 +2,8 @@ name: Build ghcr.io image
 
 on:
   push:
+    branches: [ 'main', '*docker*', '*dev*' ]
     tags:
-    branches: [ '*docker*' ]
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -16,6 +16,10 @@ jobs:
     env:
       REGISTRY: 'ghcr.io/'
       IMAGE_NAME: axon
+    # If you specify the access for any of these scopes, all of those that are not specified are set to none.
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v3
@@ -40,18 +44,17 @@ jobs:
       - name: Echo steps.meta.outputs.bake-file
         run: cat ${{ steps.meta.outputs.bake-file }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to Github resgistry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: Build and push image to ${{ env.REGISTRY }}${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
         uses: docker/build-push-action@v4
         with:
@@ -70,5 +73,3 @@ jobs:
           docker run --rm ${{ env.IMAGE }} /app/axon --version
 
     # TODO: test the image
-
-    

--- a/.github/workflows/build_image_ghcr.yml
+++ b/.github/workflows/build_image_ghcr.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-amd64-image-to-ghcr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       REGISTRY: 'ghcr.io/'
       IMAGE_NAME: axon

--- a/.github/workflows/build_image_ghcr.yml
+++ b/.github/workflows/build_image_ghcr.yml
@@ -62,4 +62,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Check versions of the binaries in ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          IMAGE: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        run: |
+          docker run --rm ${{ env.IMAGE }} /app/axon --version
+
     # TODO: test the image
+
+    

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: Release
+
 on:
   push:
     tags:
       - v*.*.*
-    # branches:
-    #   - "main"
+
 jobs:
   version:
     runs-on: ubuntu-20.04
@@ -110,6 +110,7 @@ jobs:
         with:
           name: axon_${{ needs.version.outputs.tag }}_${{ matrix.job.REL_PKG }}
           path: axon_${{ needs.version.outputs.tag }}_${{ matrix.job.REL_PKG }}
+
   Upload-release-files:
     runs-on: ubuntu-20.04
     strategy:
@@ -137,6 +138,7 @@ jobs:
           asset_name: axon_${{ needs.version.outputs.tag }}_${{ matrix.REL_PKG }}
           asset_path: ${{ github.workspace }}/axon_${{ needs.version.outputs.tag }}_${{ matrix.REL_PKG }}
           asset_content_type: application/octet-stream
+
   force-push:
     runs-on: ubuntu-20.04
     needs:
@@ -148,7 +150,6 @@ jobs:
         run: |
           git tag v${{ needs.version.outputs.major }} ${{ needs.version.outputs.tag }} -f
           git push origin refs/tags/v${{ needs.version.outputs.major }} -f
-
 
   trigger-somking-test:
     runs-on: ubuntu-20.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.69 as builder
+FROM rust:1.70 as builder
 
 WORKDIR /build
 COPY . .
@@ -14,6 +14,7 @@ RUN set -eux; \
 
 RUN cd /build && cargo build --release
 
+# TODO: update the parent image
 FROM debian:bookworm-20211011-slim
 WORKDIR /app
 


### PR DESCRIPTION
## What this PR does / why we need it?

This PR added the `build_image_ghcr` workflow.

The images stored in ghcr.io are supposed to be used for testing.
Tags or branches following the rules[ 'main', '*docker*', '*dev*' ] will trigger this workflow.

When Axon has a new release tag, `build_image.yml` will also push the corresponding image to Docker Hub.

### What is the impact of this PR?

- No Breaking Change
- Acceptance and DevOps team can pick a docker image from ghcr.io more quickly without long time building.

## **Special notes for your reviewer**

Suggestions are welcome.

**PR relation**:
- replace/close https://github.com/axonweb3/axon/pull/1347

<!--


**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

- Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
  see [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) or [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Coverage Test
- [ ] E2E Tests
- [ ] Code Format
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
-->
</details>