### PR TITLE
refactor: impl `Trie` for `MPTTrie`

### DIFF
--- a/core/api/src/adapter.rs
+++ b/core/api/src/adapter.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use protocol::traits::{
     APIAdapter, Context, Executor, ExecutorReadOnlyAdapter, MemPool, Network, ReadOnlyStorage,
 };
+use protocol::trie::Trie as _;
 use protocol::types::{
     Account, BigEndianHash, Block, BlockNumber, Bytes, CkbRelatedInfo, ExecutorContext, Hash,
     Header, Metadata, Proposal, Receipt, SignedTransaction, TxResp, H160, H256,
@@ -231,6 +232,7 @@ where
         let hash: Hash = BigEndianHash::from_uint(&position);
         storage_mpt_tree
             .get(hash.as_bytes())?
+            .map(Into::into)
             .ok_or_else(|| APIError::Adapter("Can't find this position".to_string()).into())
     }
 

--- a/core/executor/benches/bench_transfer.rs
+++ b/core/executor/benches/bench_transfer.rs
@@ -9,6 +9,7 @@ use common_crypto::{
 };
 use protocol::codec::{hex_decode, ProtocolCodec};
 use protocol::traits::Executor;
+use protocol::trie::Trie as _;
 use protocol::types::{
     public_to_address, Account, Address, Eip1559Transaction, ExecutorContext, Hash, Public,
     SignedTransaction, TransactionAction, UnsignedTransaction, UnverifiedTransaction, NIL_DATA,
@@ -52,8 +53,8 @@ impl BenchAdapter {
         };
 
         mpt.insert(
-            DISTRIBUTE_ADDRESS.as_slice(),
-            distribute_account.encode().unwrap().as_ref(),
+            DISTRIBUTE_ADDRESS.as_slice().to_vec(),
+            distribute_account.encode().unwrap().to_vec(),
         )
         .unwrap();
 

--- a/core/executor/benches/bench_vm.rs
+++ b/core/executor/benches/bench_vm.rs
@@ -9,7 +9,7 @@ use core_executor::{AxonExecutor, AxonExecutorApplyAdapter, MPTTrie};
 use protocol::{
     codec::ProtocolCodec,
     traits::{Executor, Storage},
-    trie,
+    trie::{self, Trie as _},
     types::{Account, Address, ExecutorContext},
 };
 
@@ -59,8 +59,11 @@ where
         let db = Arc::new(db);
         let mut mpt = MPTTrie::new(Arc::clone(&db));
 
-        mpt.insert(addr.as_slice(), init_account.encode().unwrap().as_ref())
-            .unwrap();
+        mpt.insert(
+            addr.as_slice().to_vec(),
+            init_account.encode().unwrap().to_vec(),
+        )
+        .unwrap();
 
         let state_root = mpt.commit().unwrap();
         AxonExecutorApplyAdapter::from_root(state_root, db, Arc::new(storage), exec_ctx).unwrap()

--- a/core/executor/src/adapter/backend/apply.rs
+++ b/core/executor/src/adapter/backend/apply.rs
@@ -6,6 +6,7 @@ use protocol::traits::{
     ApplyBackend, Backend, Context, ExecutorAdapter, ExecutorReadOnlyAdapter, ReadOnlyStorage,
     Storage,
 };
+use protocol::trie::Trie;
 use protocol::types::{
     Account, Bytes, ExecutorContext, Hasher, Log, MerkleRoot, H160, H256, NIL_DATA, RLP_NULL, U256,
 };
@@ -130,7 +131,10 @@ where
     fn save_account(&mut self, address: &H160, account: &Account) {
         self.inner
             .trie
-            .insert(address.as_bytes(), &account.encode().unwrap())
+            .insert(
+                address.as_bytes().to_vec(),
+                account.encode().unwrap().to_vec(),
+            )
             .unwrap();
     }
 }
@@ -171,7 +175,7 @@ where
         };
 
         storage.into_iter().for_each(|(k, v)| {
-            let _ = storage_trie.insert(k.as_bytes(), v.as_bytes());
+            let _ = storage_trie.insert(k.as_bytes().to_vec(), v.as_bytes().to_vec());
         });
 
         let storage_root = storage_trie
@@ -207,7 +211,7 @@ where
         {
             self.inner
                 .trie
-                .insert(address.as_bytes(), bytes.as_ref())
+                .insert(address.as_bytes().to_vec(), bytes.to_vec())
                 .unwrap();
         }
 

--- a/core/executor/src/adapter/backend/read_only.rs
+++ b/core/executor/src/adapter/backend/read_only.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use evm::backend::Basic;
 
 use protocol::traits::{Backend, Context, ExecutorReadOnlyAdapter, ReadOnlyStorage};
+use protocol::trie::Trie as _;
 use protocol::types::{
     Account, Bytes, ExecutorContext, MerkleRoot, H160, H256, NIL_DATA, RLP_NULL, U256,
 };
@@ -32,7 +33,7 @@ where
     }
 
     fn get(&self, key: &[u8]) -> Option<Bytes> {
-        self.trie.get(key).ok().flatten()
+        self.trie.get(key).ok().flatten().map(Into::into)
     }
 
     fn get_account(&self, address: &H160) -> Account {

--- a/core/executor/src/debugger/mod.rs
+++ b/core/executor/src/debugger/mod.rs
@@ -12,6 +12,7 @@ use common_config_parser::parse_file;
 use common_crypto::{PrivateKey, Secp256k1RecoverablePrivateKey, Signature};
 use protocol::codec::{hex_decode, ProtocolCodec};
 use protocol::traits::{Backend, Executor};
+use protocol::trie::Trie as _;
 use protocol::types::{
     Account, Eip1559Transaction, ExecResp, ExecutorContext, Hash, Hasher, RichBlock,
     SignedTransaction, TxResp, UnsignedTransaction, UnverifiedTransaction, H160, H256,
@@ -59,8 +60,8 @@ impl EvmDebugger {
             };
 
             mpt.insert(
-                distribute_address.as_bytes(),
-                distribute_account.encode().unwrap().as_ref(),
+                distribute_address.as_bytes().to_vec(),
+                distribute_account.encode().unwrap().to_vec(),
             )
             .unwrap();
         }

--- a/core/executor/src/system_contract/ckb_light_client/mod.rs
+++ b/core/executor/src/system_contract/ckb_light_client/mod.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use ethers::abi::AbiDecode;
 
 use protocol::traits::{ApplyBackend, ExecutorAdapter};
+use protocol::trie::Trie as _;
 use protocol::types::{SignedTransaction, TxResp, H160, H256};
 use protocol::ProtocolResult;
 

--- a/core/interoperation/src/tests/mod.rs
+++ b/core/interoperation/src/tests/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use protocol::codec::ProtocolCodec;
 use protocol::traits::{Context, Executor, Storage};
+use protocol::trie::Trie as _;
 use protocol::types::{
     Account, Address, Bytes, Eip1559Transaction, ExecResp, Proposal, Public, RichBlock,
     SignatureComponents, SignedTransaction, TransactionAction, UnsignedTransaction,
@@ -79,8 +80,8 @@ impl TestHandle {
         let mut mpt = MPTTrie::new(Arc::clone(&self.trie_db));
 
         mpt.insert(
-            distribute_address.as_slice(),
-            distribute_account.encode().unwrap().as_ref(),
+            distribute_address.as_slice().to_vec(),
+            distribute_account.encode().unwrap().to_vec(),
         )
         .unwrap();
 

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -29,6 +29,7 @@ use protocol::traits::{
     Consensus, Context, Executor, Gossip, MemPool, Network, NodeInfo, PeerTrust, ReadOnlyStorage,
     Rpc, Storage, SynchronizationAdapter,
 };
+use protocol::trie::Trie;
 use protocol::types::{
     Account, Block, ExecResp, MerkleRoot, Metadata, Proposal, RichBlock, SignedTransaction,
     Validator, ValidatorExtend, H256, NIL_DATA, RLP_NULL,
@@ -933,10 +934,10 @@ async fn init_storage<P: AsRef<Path>>(
     Ok((storage, trie_db, inner_db))
 }
 
-fn insert_accounts(
-    mpt: &mut MPTTrie<RocksTrieDB>,
-    accounts: &[InitialAccount],
-) -> ProtocolResult<()> {
+fn insert_accounts<DB>(mpt: &mut MPTTrie<DB>, accounts: &[InitialAccount]) -> ProtocolResult<()>
+where
+    DB: TrieDB,
+{
     for account in accounts {
         let raw_account = Account {
             nonce:        0u64.into(),
@@ -945,7 +946,7 @@ fn insert_accounts(
             code_hash:    NIL_DATA,
         }
         .encode()?;
-        mpt.insert(account.address.as_bytes(), &raw_account)?;
+        mpt.insert(account.address.as_bytes().to_vec(), raw_account.to_vec())?;
     }
     Ok(())
 }

--- a/protocol/src/codec/mod.rs
+++ b/protocol/src/codec/mod.rs
@@ -12,7 +12,7 @@ use ethers_core::utils::parse_checksummed;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 use serde::{Deserialize as _, Deserializer, Serializer};
 
-use crate::types::{Address, Bytes, DBBytes, Hex, Key256Bits, TypesError, H160, U256, HEX_PREFIX};
+use crate::types::{Address, Bytes, DBBytes, Hex, Key256Bits, TypesError, H160, HEX_PREFIX, U256};
 use crate::ProtocolResult;
 
 static CHARS: &[u8] = b"0123456789abcdef";

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -65,6 +65,15 @@ impl From<ProtocolError> for String {
     }
 }
 
+impl From<trie::TrieError> for ProtocolError {
+    fn from(error: trie::TrieError) -> Self {
+        ProtocolError {
+            kind:  ProtocolErrorKind::DB,
+            error: Box::new(error),
+        }
+    }
+}
+
 impl Error for ProtocolError {}
 
 pub type ProtocolResult<T> = Result<T, ProtocolError>;


### PR DESCRIPTION
## What this PR does / why we need it?

- I want to add methods to `MPTTrie<DB>` in another crate.

  Limit by the orphan rule, I have to use a trait to add methods to `MPTTrie<DB>`.

  - If I use a trait to add methods to `MPTTrie<DB>`, I could NOT write the following code: 
    ```rust
    pub trait TrieExt<BD>: MPTTrie<DB> {
        /* Use methods of `MPTTrie<DB>` in trait body. */
    }
    ```

    , since `MPTTrie<DB>` is a struct, but I can write the following code:
    ```rust
    pub trait TrieExt: Trie {
        /* Use methods of `Trie` in trait body. */
    }
    ```

- Some methods of `MPTTrie<DB>` are not exposed, for example, `get_proof(..)` and `verify_proof(..)`.

- Another reason:

  In fact, `MPTTrie<DB>` is a `Trie`, we should use it as `Trie` directly.

  `Trie` is in a higher level of `TrieDB` in abstract.

  Treat `MPTTrie<DB>` as as a `TrieDB` is not reasonable.

### What is the impact of this PR?

No Breaking Change

<!--
**Special notes for your reviewer**:
NIL

**PR relation**:
- Ref #

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

- Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
  see [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) or [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
-->
</details>