### PR TITLE
refactor: slightly improve security for secret keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,6 @@ dependencies = [
  "hex",
  "lazy_static",
  "ophelia",
- "ophelia-secp256k1",
  "overlord",
  "rand 0.7.3",
  "rlp",
@@ -342,6 +341,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml 0.7.3",
+ "zeroize",
 ]
 
 [[package]]

--- a/core/consensus/src/consensus.rs
+++ b/core/consensus/src/consensus.rs
@@ -13,6 +13,7 @@ use protocol::{
 
 use common_apm::tracing::{AxonTracer, Tag};
 use common_apm_derive::trace_span;
+use common_crypto::PublicKey as _;
 
 use crate::wal::{ConsensusWal, SignedTxsWAL};
 use crate::{
@@ -124,7 +125,12 @@ impl<Adapter: ConsensusAdapter + 'static> OverlordConsensus<Adapter> {
             .await
             .unwrap();
 
-        let overlord = Overlord::new(node_info.self_pub_key, Arc::clone(&engine), crypto, engine);
+        let overlord = Overlord::new(
+            node_info.self_pub_key.to_bytes(),
+            Arc::clone(&engine),
+            crypto,
+            engine,
+        );
         let overlord_handler = overlord.get_handler();
 
         if status.last_number == 0 {

--- a/core/network/examples/simple.rs
+++ b/core/network/examples/simple.rs
@@ -2,9 +2,7 @@
 
 use core_network::{NetworkConfig, NetworkService, NetworkServiceHandle};
 use protocol::{
-    async_trait,
-    codec::hex_encode,
-    tokio,
+    async_trait, tokio,
     traits::{Context, Gossip, MessageHandler, Priority, Rpc, TrustFeedback},
     types::Bytes,
     ProtocolError,
@@ -71,9 +69,8 @@ impl MessageHandler for Checkout {
 async fn main() {
     env_logger::init();
 
-    let bt_seckey_bytes = "8".repeat(32);
-    let bt_seckey = hex_encode(&bt_seckey_bytes);
-    let bt_keypair = SecioKeyPair::secp256k1_raw_key(bt_seckey_bytes).expect("keypair");
+    let bt_seckey = [8u8; 32];
+    let bt_keypair = SecioKeyPair::secp256k1_raw_key(bt_seckey).expect("keypair");
     let peer_id = bt_keypair.peer_id().to_base58();
 
     if std::env::args().nth(1) == Some("server".to_string()) {
@@ -81,7 +78,8 @@ async fn main() {
 
         let bt_conf = NetworkConfig::new()
             .listen_addr("/ip4/127.0.0.1/tcp/1337".parse().unwrap())
-            .secio_keypair(&bt_seckey);
+            .secio_keypair(&bt_seckey)
+            .unwrap();
         let mut bootstrap = NetworkService::new(bt_conf, bt_keypair);
         let handle = bootstrap.handle();
 

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -17,10 +17,7 @@ use common_apm::metrics::mempool::{MEMPOOL_CO_QUEUE_LEN, MEMPOOL_LEN_GAUGE};
 use common_apm::{server::run_prometheus_server, tracing::global_tracer_register};
 use common_config_parser::types::spec::{ChainSpec, InitialAccount};
 use common_config_parser::types::{Config, ConfigJaeger, ConfigPrometheus, ConfigRocksDB};
-use common_crypto::{
-    BlsPrivateKey, BlsPublicKey, PublicKey, Secp256k1, Secp256k1PrivateKey, Secp256k1PublicKey,
-    ToPublicKey, UncompressedPublicKey,
-};
+use common_crypto::{BlsPrivateKey, BlsPublicKey, Secp256k1, Secp256k1PrivateKey, ToPublicKey};
 
 use protocol::codec::{hex_decode, ProtocolCodec};
 #[cfg(unix)]
@@ -33,8 +30,8 @@ use protocol::traits::{
     Rpc, Storage, SynchronizationAdapter,
 };
 use protocol::types::{
-    Account, Address, Block, ExecResp, MerkleRoot, Metadata, Proposal, RichBlock,
-    SignedTransaction, Validator, ValidatorExtend, H256, NIL_DATA, RLP_NULL,
+    Account, Block, ExecResp, MerkleRoot, Metadata, Proposal, RichBlock, SignedTransaction,
+    Validator, ValidatorExtend, H256, NIL_DATA, RLP_NULL,
 };
 use protocol::{
     async_trait, lazy::CHAIN_ID, trie::DB as TrieDB, Display, From, ProtocolError,
@@ -469,28 +466,9 @@ impl Axon {
         mempool
     }
 
-    fn get_my_pubkey(&self, hex_privkey: Vec<u8>) -> Secp256k1PublicKey {
-        let my_privkey = Secp256k1PrivateKey::try_from(hex_privkey.as_ref())
-            .map_err(MainError::Crypto)
-            .unwrap();
-
-        my_privkey.pub_key()
-    }
-
-    fn get_my_address(&self, hex_privkey: Vec<u8>) -> Address {
-        let my_pubkey = self.get_my_pubkey(hex_privkey);
-
-        Address::from_pubkey_bytes(my_pubkey.to_uncompressed_bytes()).unwrap()
-    }
-
-    fn get_my_hex_privkey(&self) -> Vec<u8> {
-        hex_decode(&self.config.privkey.as_string_trim0x()).unwrap()
-    }
-
     fn init_crypto(&self, validators: &[ValidatorExtend]) -> Arc<OverlordCrypto> {
         // self private key
-        let hex_privkey = self.get_my_hex_privkey();
-        let bls_priv_key = BlsPrivateKey::try_from(hex_privkey.as_ref())
+        let bls_priv_key = BlsPrivateKey::try_from(self.config.privkey.as_ref())
             .map_err(MainError::Crypto)
             .unwrap();
 
@@ -559,12 +537,10 @@ impl Axon {
             .to_string();
         let consensus_wal = Arc::new(ConsensusWal::new(consensus_wal_path));
 
-        let hex_privkey = self.get_my_hex_privkey();
-        let node_info = NodeInfo {
-            chain_id:     self.genesis.block.header.chain_id,
-            self_address: self.get_my_address(hex_privkey.clone()),
-            self_pub_key: self.get_my_pubkey(hex_privkey).to_bytes(),
-        };
+        let my_privkey = Secp256k1PrivateKey::try_from(self.config.privkey.as_ref())
+            .map_err(MainError::Crypto)
+            .unwrap();
+        let node_info = NodeInfo::new(self.genesis.block.header.chain_id, my_privkey.pub_key());
 
         Arc::new(
             OverlordConsensus::new(

--- a/devtools/genesis-generator/src/main.rs
+++ b/devtools/genesis-generator/src/main.rs
@@ -121,7 +121,7 @@ fn get_metadata(config_path: String) -> (Metadata, Metadata) {
         .map(|file_name| {
             let config: Config = parse_file(file_name, false).unwrap();
             let priv_key = config.privkey;
-            get_ve(priv_key.inner(), propose_weight, vote_weight)
+            get_ve(Hex::encode(priv_key.as_ref()), propose_weight, vote_weight)
         })
         .collect::<Vec<_>>();
 

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -23,7 +23,6 @@ evm = { version = "0.37", features = ["with-serde"] }
 faster-hex = "0.8"
 lazy_static = "1.4"
 ophelia = "0.3"
-ophelia-secp256k1 = "0.3"
 overlord = "0.4"
 rand = "0.7"
 rlp = "0.5"
@@ -32,6 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.32", features = ["full"] }
 trie = { package = "cita_trie", git = "https://github.com/KaoImin/cita-trie.git", rev = "eea569c", version = "4.1" }
+zeroize = "1.6.0"
 
 common-crypto = { path = "../common/crypto" }
 common-hasher = { path = "../common/hasher" }

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use common_crypto::Secp256k1PublicKey;
+
 use crate::types::{
     Address, Block, BlockNumber, Bytes, ExecResp, Hash, Header, Hex, MerkleRoot, Metadata,
     PackedTxHashes, Proof, Proposal, Receipt, SignedTransaction, Validator, U256,
@@ -15,8 +17,19 @@ pub enum MessageTarget {
 #[derive(Debug, Clone)]
 pub struct NodeInfo {
     pub chain_id:     u64,
-    pub self_pub_key: Bytes,
+    pub self_pub_key: Secp256k1PublicKey,
     pub self_address: Address,
+}
+
+impl NodeInfo {
+    pub fn new(chain_id: u64, pubkey: Secp256k1PublicKey) -> Self {
+        let address = Address::from_pubkey(&pubkey);
+        Self {
+            chain_id,
+            self_pub_key: pubkey,
+            self_address: address,
+        }
+    }
 }
 
 #[async_trait]

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -5,13 +5,14 @@ pub use ethereum_types::{
     BigEndianHash, Bloom, Public, Secret, Signature, H128, H160, H256, H512, H520, H64, U128, U256,
     U512, U64,
 };
+use zeroize::Zeroizing;
 
 use ophelia::{PublicKey, UncompressedPublicKey};
-use ophelia_secp256k1::Secp256k1PublicKey;
 use overlord::DurationConfig;
 use rlp_derive::{RlpDecodable, RlpEncodable};
 use serde::{de, Deserialize, Serialize};
 
+use common_crypto::Secp256k1PublicKey;
 use common_hasher::keccak256;
 
 use crate::codec::{hex_decode, hex_encode, serialize_uint};
@@ -174,6 +175,13 @@ impl<'de> Deserialize<'de> for Hex {
     }
 }
 
+/// A 256 bits bytes used for sensitive data, such as private keys.
+///
+/// It's implemented a `Drop` handler which erase its memory when it dropped.
+/// This ensures that sensitive data is securely erased from memory when it is
+/// no longer needed.
+pub type Key256Bits = Zeroizing<[u8; 32]>;
+
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Address(pub H160);
 
@@ -248,6 +256,11 @@ impl Address {
         };
 
         Ok(Self::from_hash(hash))
+    }
+
+    pub fn from_pubkey(pubkey: &Secp256k1PublicKey) -> Self {
+        let hash = Hasher::digest(&(pubkey.to_uncompressed_bytes())[1..]);
+        Self::from_hash(hash)
     }
 
     pub fn from_hash(hash: Hash) -> Self {


### PR DESCRIPTION
## What this PR does / why we need it?

- Keep a human-readable string of a private key is very dangerous.

- Do not copy private keys again and again.

- If the memory of a private key is not zeroized after the key dropped, it could be read from other threads and other processes.

  Also, that piece of memory could be read by programs started after axon stopped.

- Remove unnecessary `unwrap()` and structs conversions.

  ```
  +---------------+
  |  Secret Key   |
  | (Hex String)  |    +----------------------------------------------------------------+
  +---------------+    |                                                                |
         |             |             This PR deleted these useless conversions.         |
         v             |                                                                |
  +---------------+    |     +---------------+      +--------+      +--------+          |
  |  Secret Key   |  Clone   |  Secret Key   |----->| Secret |----->| Public |          |
  |    (Bytes)    |--------->|    (Bytes)    |      |   Key  |      |   Key  |          |
  +---------------+    |     +---------------+      +--------+      +--------+          |
         |             |                                                |               |
         v             |                                                v               |
     +--------+        |                         +--------+      +------------+         |
     | Secret |        |               +---------| Public |<-----| Public Key |         |
     |   Key  |        |               |         |   Key  |      |   (Bytes)  |         |
     +--------+        |               |         +--------+      +------------+         |
         |             +---------------|------------------------------------------------+
         v                             v
     +--------+                  +------------+
     | Public |- - - - - - - - ->| Public Key |
     |   Key  |  This PR Added   |   (Bytes)  |
     +--------+                  +------------+
        |                              |
        v                              v
    +----------+                 +----------+
    |   Node   |<----------------| Address  |
    |   Info   |                 |          |
    +----------+                 +----------+
  ```

### What is the impact of this PR?

No Breaking Change

<!--
**Special notes for your reviewer**:
NIL

**PR relation**:
- Ref #

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

- Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
  see [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) or [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Coverage Test
- [x] E2E Tests
- [x] Code Format
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
-->
</details>