### PR TITLE
feat(cli): split sub-command `run` to `init` and `run`

### DIFF
--- a/.github/workflows/axon-start-with-short-genesis.yml
+++ b/.github/workflows/axon-start-with-short-genesis.yml
@@ -37,10 +37,13 @@ jobs:
         LOG_FILE: ${{ runner.temp }}/${{ matrix.os }}-single-axon-node.log
       run: |
         target/debug/axon --version | tee ${{ env.LOG_FILE }}
-        target/debug/axon run \
+        target/debug/axon init \
           --config devtools/chain/config.toml \
           --chain-spec devtools/chain/specs/single_node/chain-spec.toml \
-          | tee ${{ env.LOG_FILE }} &
+          | tee -a ${{ env.LOG_FILE }}
+        target/debug/axon run \
+          --config devtools/chain/config.toml \
+          | tee -a ${{ env.LOG_FILE }} &
 
         sleep 10
 
@@ -85,22 +88,36 @@ jobs:
         mkdir -p ${{ env.LOG_PATH }}
 
         target/debug/axon --version
-        target/debug/axon run \
+
+        target/debug/axon init \
           --config devtools/chain/nodes/node_1.toml \
           --chain-spec devtools/chain/specs/multi_nodes_short_epoch_len/chain-spec.toml \
-          > ${{ env.LOG_PATH }}/node_1.log &
-        target/debug/axon run \
+          > ${{ env.LOG_PATH }}/node_1.log
+        target/debug/axon init \
           --config devtools/chain/nodes/node_2.toml \
           --chain-spec devtools/chain/specs/multi_nodes_short_epoch_len/chain-spec.toml \
-          > ${{ env.LOG_PATH }}/node_2.log &
-        target/debug/axon run \
+          > ${{ env.LOG_PATH }}/node_2.log
+        target/debug/axon init \
           --config devtools/chain/nodes/node_3.toml \
           --chain-spec devtools/chain/specs/multi_nodes_short_epoch_len/chain-spec.toml \
-          > ${{ env.LOG_PATH }}/node_3.log &
-        target/debug/axon run \
+          > ${{ env.LOG_PATH }}/node_3.log
+        target/debug/axon init \
           --config devtools/chain/nodes/node_4.toml \
           --chain-spec devtools/chain/specs/multi_nodes_short_epoch_len/chain-spec.toml \
-          > ${{ env.LOG_PATH }}/node_4.log &
+          > ${{ env.LOG_PATH }}/node_4.log
+
+        target/debug/axon run \
+          --config devtools/chain/nodes/node_1.toml \
+          >> ${{ env.LOG_PATH }}/node_1.log &
+        target/debug/axon run \
+          --config devtools/chain/nodes/node_2.toml \
+          >> ${{ env.LOG_PATH }}/node_2.log &
+        target/debug/axon run \
+          --config devtools/chain/nodes/node_3.toml \
+          >> ${{ env.LOG_PATH }}/node_3.log &
+        target/debug/axon run \
+          --config devtools/chain/nodes/node_4.toml \
+          >> ${{ env.LOG_PATH }}/node_4.log &
 
         npx zx <<'EOF'
         import { waitXBlocksPassed } from './devtools/ci/scripts/helper.js'

--- a/.github/workflows/openzeppelin_test_11.yml
+++ b/.github/workflows/openzeppelin_test_11.yml
@@ -108,7 +108,8 @@ jobs:
       - name: Deploy Local Network of Axon
         run: |
           rm -rf ./devtools/chain/data
-          ./target/debug/axon run --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1 &
+          ./target/debug/axon init --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1
+          ./target/debug/axon run  --config devtools/chain/config.toml >> /tmp/log 2>&1 &
 
       - name: Run prepare
         id: runtest

--- a/.github/workflows/openzeppelin_test_16_19.yml
+++ b/.github/workflows/openzeppelin_test_16_19.yml
@@ -108,7 +108,8 @@ jobs:
       - name: Deploy Local Network of Axon
         run: |
           rm -rf ./devtools/chain/data
-          ./target/debug/axon run --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1 &
+          ./target/debug/axon init --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1
+          ./target/debug/axon run  --config devtools/chain/config.toml >> /tmp/log 2>&1 &
 
       - name: Run prepare
         id: runtest

--- a/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
+++ b/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
@@ -97,7 +97,7 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('/home/runner/work/**/package-lock.json', '/home/runner/work/**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node_modules-
-      
+
       - name: Cache of the axon binary
         uses: actions/cache@v3
         with:
@@ -109,7 +109,8 @@ jobs:
       - name: Deploy Local Network of Axon
         run: |
           rm -rf ./devtools/chain/data
-          ./target/debug/axon run --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1 &
+          ./target/debug/axon init --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1
+          ./target/debug/axon run  --config devtools/chain/config.toml >> /tmp/log 2>&1 &
 
       - name: Run prepare
         id: runtest

--- a/.github/workflows/openzeppelin_test_6_10.yml
+++ b/.github/workflows/openzeppelin_test_6_10.yml
@@ -104,11 +104,12 @@ jobs:
             target/debug/axon
             target/release/axon
           key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
-      
+
       - name: Deploy Local Network of Axon
         run: |
           rm -rf ./devtools/chain/data
-          ./target/debug/axon run --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1 &
+          ./target/debug/axon init --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1
+          ./target/debug/axon run  --config devtools/chain/config.toml >> /tmp/log 2>&1 &
       - name: Run prepare
         id: runtest
         run: |

--- a/.github/workflows/somking_test.yml
+++ b/.github/workflows/somking_test.yml
@@ -23,7 +23,8 @@ jobs:
     - name: Start axon
       run: |
          cd ${{ github.workspace }}/axon
-         ./axon run --config ${{ github.workspace }}/axon/config.toml --chain-spec ${{ github.workspace }}/axon/specs/single_node/chain-spec.toml > /tmp/log 2>&1 &
+         ./axon init --config ${{ github.workspace }}/axon/config.toml --chain-spec ${{ github.workspace }}/axon/specs/single_node/chain-spec.toml > /tmp/log 2>&1
+         ./axon run  --config ${{ github.workspace }}/axon/config.toml >> /tmp/log 2>&1 &
          sleep 120
     - name: Check Axon Status
       run: |

--- a/.github/workflows/v3_core_test.yml
+++ b/.github/workflows/v3_core_test.yml
@@ -97,7 +97,8 @@ jobs:
       - name: Deploy Local Network of Axon
         run: |
           rm -rf ./devtools/chain/data
-          ./target/debug/axon run --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1 &
+          ./target/debug/axon init --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1
+          ./target/debug/axon run  --config devtools/chain/config.toml >> /tmp/log 2>&1 &
       - name: Install dependencies
         run: |
           cd /home/runner/work/axon/axon/v3-core

--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-22.04]
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    env: 
+    env:
       IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
       IS_REGRESSION: ${{ github.event.inputs.dispatch == 'regression' }}
 
@@ -66,10 +66,13 @@ jobs:
       - name: Deploy Local Network of Axon
         run: |
           rm -rf ./devtools/chain/data
-          ./target/debug/axon run \
+          ./target/debug/axon init \
             --config devtools/chain/config.toml \
             --chain-spec devtools/chain/specs/single_node/chain-spec.toml \
-            > /tmp/log 2>&1 &
+            > /tmp/log 2>&1
+          ./target/debug/axon run \
+            --config devtools/chain/config.toml \
+            >> /tmp/log 2>&1 &
 
       - name: Checkout gpBlockchain/axon-test
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN set -eux; \
 COPY --from=builder /build/target/release/axon /app/axon
 COPY --from=builder /build/devtools /app/devtools
 
-CMD ./axon run -c=/app/devtools/chain/config.toml -s=/app/devtools/chain/specs/single_node/chain-spec.toml
+CMD /app/devtools/docker/docker-entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ e2e-test-lint:
 e2e-test:
 	cargo build
 	rm -rf ./devtools/chain/data
-	./target/debug/axon run --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1 &
+	./target/debug/axon init --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1
+	./target/debug/axon run  --config devtools/chain/config.toml >> /tmp/log 2>&1 &
 	cd tests/e2e && yarn
 	cd tests/e2e/src && yarn exec http-server &
 	cd tests/e2e && yarn exec wait-on -t 5000 tcp:8000 && yarn exec wait-on -t 5000 tcp:8080 && yarn test
@@ -73,7 +74,8 @@ e2e-test:
 e2e-test-ci:
 	cargo build
 	rm -rf ./devtools/chain/data
-	./target/debug/axon run --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1 &
+	./target/debug/axon init --config devtools/chain/config.toml --chain-spec devtools/chain/specs/single_node/chain-spec.toml > /tmp/log 2>&1
+	./target/debug/axon run  --config devtools/chain/config.toml >> /tmp/log 2>&1 &
 	cd tests/e2e && yarn
 	cd tests/e2e/src && yarn exec http-server &
 	cd tests/e2e && yarn exec wait-on -t 5000 tcp:8000 && yarn exec wait-on -t 5000 tcp:8080 && HEADLESS=true yarn test

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Axon provides the compiled binary on the [release page](`https://github.com/axon
 # Clone from GitHub
 git clone https://github.com/axonweb3/axon.git && cd axon
 # Run release binary for single node
-cargo run --release -- run -c devtools/chain/config.toml -s devtools/chain/specs/single_node/chain-spec.toml
+cargo run --release -- init -c devtools/chain/config.toml -s devtools/chain/specs/single_node/chain-spec.toml
+cargo run --release -- run  -c devtools/chain/config.toml
 
 ```
 

--- a/core/cli/src/args/init.rs
+++ b/core/cli/src/args/init.rs
@@ -1,0 +1,44 @@
+use clap::Parser;
+
+use common_config_parser::types::{spec::ChainSpec, Config};
+use common_version::Version;
+
+use crate::{
+    error::{Error, Result},
+    utils,
+};
+
+#[derive(Parser, Debug)]
+#[command(about = "Initialize new axon data directory")]
+pub struct InitArgs {
+    #[arg(
+        short = 'c',
+        long = "config",
+        value_name = "CONFIG_FILE",
+        help = "File path of client configurations."
+    )]
+    pub config: Config,
+    #[arg(
+        short = 's',
+        long = "chain-spec",
+        value_name = "CHAIN_SPEC_FILE",
+        help = "File path of chain spec."
+    )]
+    pub spec:   ChainSpec,
+}
+
+impl InitArgs {
+    pub(crate) fn execute(self, kernel_version: Version) -> Result<()> {
+        let Self { config, spec } = self;
+        let genesis = spec.genesis.build_rich_block();
+
+        utils::check_version(
+            &config.data_path_for_version(),
+            &kernel_version,
+            utils::latest_compatible_version(),
+        )?;
+        utils::register_log(&config);
+
+        core_run::init(config, spec, genesis).map_err(Error::Running)
+    }
+}

--- a/core/cli/src/args/mod.rs
+++ b/core/cli/src/args/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod init;
 pub(crate) mod run;

--- a/core/cli/src/args/run.rs
+++ b/core/cli/src/args/run.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 
-use common_config_parser::types::{spec::ChainSpec, Config};
+use common_config_parser::types::Config;
 use common_version::Version;
-use core_run::{Axon, KeyProvider};
+use core_run::KeyProvider;
 
 use crate::{
     error::{Error, Result},
@@ -10,7 +10,7 @@ use crate::{
 };
 
 #[derive(Parser, Debug)]
-#[command(about = "Run axon process")]
+#[command(about = "Run axon service")]
 pub struct RunArgs {
     #[arg(
         short = 'c',
@@ -19,13 +19,6 @@ pub struct RunArgs {
         help = "File path of client configurations."
     )]
     pub config: Config,
-    #[arg(
-        short = 's',
-        long = "chain-spec",
-        value_name = "CHAIN_SPEC_FILE",
-        help = "File path of chain spec."
-    )]
-    pub spec:   ChainSpec,
 }
 
 impl RunArgs {
@@ -35,8 +28,7 @@ impl RunArgs {
         kernel_version: Version,
         key_provider: Option<K>,
     ) -> Result<()> {
-        let Self { config, spec } = self;
-        let genesis = spec.genesis.build_rich_block();
+        let Self { config } = self;
 
         utils::check_version(
             &config.data_path_for_version(),
@@ -45,8 +37,7 @@ impl RunArgs {
         )?;
         utils::register_log(&config);
 
-        Axon::new(application_version.to_string(), config, spec, genesis)
-            .run(key_provider)
-            .map_err(Error::Running)
+        let version = application_version.to_string();
+        core_run::run(version, config, key_provider).map_err(Error::Running)
     }
 }

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -2,7 +2,7 @@ mod args;
 mod error;
 pub(crate) mod utils;
 
-pub use args::run::RunArgs;
+pub use args::{init::InitArgs, run::RunArgs};
 pub use error::{CheckingVersionError, Error, Result};
 
 use clap::{CommandFactory as _, FromArgMatches as _, Parser, Subcommand};
@@ -19,6 +19,7 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
+    Init(InitArgs),
     Run(RunArgs),
 }
 
@@ -57,6 +58,7 @@ impl AxonCli {
             inner: cli,
         } = self;
         match cli.command {
+            Commands::Init(args) => args.execute(kernel_version),
             Commands::Run(args) => args.execute(application_version, kernel_version, key_provider),
         }
     }

--- a/core/run/Cargo.toml
+++ b/core/run/Cargo.toml
@@ -12,7 +12,6 @@ rlp = "0.5"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-tempfile = "3.6"
 toml = "0.7"
 
 common-apm = { path = "../../common/apm" }
@@ -38,6 +37,7 @@ jemallocator = { version = "0.5", features = ["profiling", "stats", "unprefixed_
 
 [dev-dependencies]
 clap = "4.3"
+tempfile = "3.6"
 
 [features]
 jemalloc = ["dep:jemallocator", "dep:jemalloc-ctl", "dep:common-memory-tracker"]

--- a/core/run/src/tests.rs
+++ b/core/run/src/tests.rs
@@ -132,6 +132,7 @@ async fn check_genesis_data<'a>(case: &TestCase<'a>) {
     let db_group = DatabaseGroup::new(
         &config.rocksdb,
         path_block,
+        true,
         config.executor.triedb_cache_size,
     )
     .expect("initialize databases");

--- a/devtools/chain/docker-compose.yml
+++ b/devtools/chain/docker-compose.yml
@@ -15,7 +15,8 @@ services:
     - axon-net
     restart: unless-stopped
     command: |
-      /app/axon run --config=/app/config.toml --chain-spec=/app/single_node_spec/chain-spec.toml
+      /app/axon init --config=/app/config.toml --chain-spec=/app/single_node_spec/chain-spec.toml
+      /app/axon run  --config=/app/config.toml
 
   explorer:
     container_name: blockscan

--- a/devtools/docker/docker-entrypoint.sh
+++ b/devtools/docker/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+DATA_DIR="/app/devtools/chain/data"
+CONFIG_FILE="/app/devtools/chain/config.toml"
+CHAIN_SPEC_FILE="/app/devtools/chain/specs/single_node/chain-spec.toml"
+
+if [ ! -e "${DATA_DIR}" ]; then
+    /app/axon init -c=${CONFIG_FILE} -s=${CHAIN_SPEC_FILE}
+fi
+/app/axon run -c=${CONFIG_FILE}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR resolves #1345.

### What is the impact of this PR?

Breaking Change

- Command line interface

  - Before execute `axon run`, users have to initialize the chain data with `axon init`.

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] E2E Tests
- [ ] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
