### PR TITLE
ci: remove `invoke-chaos-test` job in regression_testing.yml

### DIFF
--- a/.github/workflows/regression_testing.yml
+++ b/.github/workflows/regression_testing.yml
@@ -107,19 +107,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           inputs: '{ "dispatch": "regression" }'
 
-  invoke-chaos-test:
-    if: github.repository_owner == 'axonweb3'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Invoke OCT 16-19 test
-        id: invoke-chaos-test
-        uses: aurelien-baudet/workflow-dispatch@v2
-        with:
-          workflow:  OCT 16-19
-          wait-for-completion-timeout: 2h
-          token: ${{ secrets.GITHUB_TOKEN }}
-          inputs: '{ "dispatch": "regression" }'
-
   output-result:
     runs-on: ubuntu-latest
     needs: [invoke-fmt-test,invoke-E2E-test,invoke-v3-core-test,invoke-web3-compatible-test,invoke-openzeppelin-test-1-5-and-12-15-test,invoke-OCT-6-10-test,invoke-OCT-11-test,invoke-OCT-16-19-test,invoke-chaos-test]


### PR DESCRIPTION
## What this PR does / why we need it?

![image](https://github.com/axonweb3/axon/assets/1297478/15cc6c3f-b8c8-4667-b702-c8c41d4a79df)

I am not sure why `Invoke OCT 16-19 test` in the `invoke-chaos-test` job.
It might be a copy-and-paste bug.

Since https://github.com/axonweb3/axon/actions/workflows/chaos.yml is not working and disabled for now, I just deleted it.

### What is the impact of this PR?

No Breaking Change


<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] E2E Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
