### PR TITLE
fix: `Hex` serde deserialize

### DIFF
--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -152,7 +152,8 @@ impl<'de> Deserialize<'de> for Hex {
     where
         D: de::Deserializer<'de>,
     {
-        Ok(Hex(withpfx_lowercase::deserialize(deserializer)?))
+        String::deserialize(deserializer)
+            .and_then(|s| Hex::from_str(&s).map_err(serde::de::Error::custom))
     }
 }
 
@@ -532,6 +533,20 @@ mod tests {
             serde_json::to_string(&hex).unwrap(),
             serde_json::to_string(&data).unwrap()
         );
+    }
+
+    #[test]
+    fn test_hex_serde_deserialize() {
+        #[derive(Deserialize)]
+        struct Params {
+            key: Hex,
+        }
+        let test_params: &str = r#"
+            key = "0x1234"
+        "#;
+        let params: Params = toml::from_str(test_params).unwrap();
+        let expected = Hex::from_str("0x1234").unwrap();
+        assert_eq!(params.key, expected);
     }
 
     #[test]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR fixes:

```
running 1 test
test types::primitive::tests::test_hex_serde_deserialize ... FAILED

failures:

failures:
    types::primitive::tests::test_hex_serde_deserialize

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 41 filtered out; finished in 0.00s


--- STDERR:              axon-protocol types::primitive::tests::test_hex_serde_deserialize ---
thread 'types::primitive::tests::test_hex_serde_deserialize' panicked at 'called `Result::unwrap()` on an `Err` value: Error { inner: Error { inner: TomlError { message: "invalid type: string \"0x1234\", expected a borrowed byte array", original: Some("\n            key = \"0x1234\"\n        "), keys: ["key"], span: Some(19..27) } } }', protocol/src/types/primitive.rs:546:58
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

**Special notes for your reviewer**:

Before this PR, the `serde_json` already works well:
https://github.com/axonweb3/axon/blob/c944e248706de540cd8da31cb70f8dce3d8af9a7/protocol/src/types/primitive.rs#L564-L569
https://github.com/axonweb3/axon/blob/c944e248706de540cd8da31cb70f8dce3d8af9a7/protocol/src/types/primitive.rs#L298-L302
https://github.com/axonweb3/axon/blob/c944e248706de540cd8da31cb70f8dce3d8af9a7/protocol/src/types/primitive.rs#L373-L375

<!--
**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] E2E Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
