### PR TITLE
ci: fix Dockerfile and `test-in-docker-compose` job

### DIFF
--- a/.github/workflows/build_image_ghcr.yml
+++ b/.github/workflows/build_image_ghcr.yml
@@ -91,24 +91,33 @@ jobs:
         working-directory: devtools/chain
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout devtools/chain
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          devtools/chain
+          devtools/ci/scripts/helper.js
 
-    - name: Modify Axon image
+    - name: Modify the Axon image of in devtools/chain/docker-compose.yml
       env:
         AXON_IMAGE: "${{ needs.build-amd64-image-to-ghcr.outputs.image_name }}:${{ needs.build-amd64-image-to-ghcr.outputs.image_tag }}"
-      uses: mikefarah/yq@v4
+      uses: mikefarah/yq@v4.35.1
       with:
-        cmd: |
-          echo "Update the image of Axon"
-          yq -i '.services.axon.image = "${{ env.AXON_IMAGE }}"' ./docker-compose.yml
-          echo "====== devtools/chain/docker-compose.yml ======"
-          cat docker-compose.yml
+        cmd: yq -i '.services.axon.image = "${{ env.AXON_IMAGE }}"' 'devtools/chain/docker-compose.yml'
+
+    - name: Review devtools/chain/docker-compose.yml
+      run: |
+        echo "====== devtools/chain/docker-compose.yml ======\n"
+        cat docker-compose.yml
+        echo "===============================================\n"
 
     - name: Run docker compose up and a simple test
       run: |
         docker-compose up -d
         docker-compose ps
         docker-compose logs --tail 6
+
+        echo "TODO: health_check" && sleep 6
 
         npx zx <<'EOF'
         import { waitXBlocksPassed } from '../ci/scripts/helper.js'

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,10 @@ RUN cd /build && cargo build --release
 FROM debian:bookworm-20230612-slim
 WORKDIR /app
 
-RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-        libssl-dev \
-        libc6-dev \
-        ca-certificates; \
-     rm -rf /var/lib/apt/lists/*
-
+COPY --from=builder \
+  /usr/lib/x86_64-linux-gnu/libssl.so.* \
+  /usr/lib/x86_64-linux-gnu/libcrypto.so.* \
+  /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /build/target/release/axon /app/axon
 COPY --from=builder /build/devtools /app/devtools
 

--- a/devtools/chain/docker-compose.yml
+++ b/devtools/chain/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     ports:
     - 8000:8000
     - 127.0.0.1:8100:8100
-    volumes:
-    - ./:/app/devtools/chain
     networks:
     - axon-net
     restart: unless-stopped


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

### This PR
- [fix(Dockerfile): copy libssl.so.* and libcrypto.so.* from builder](https://github.com/axonweb3/axon/pull/1398/commits/1ef65666494bdf5885bdca87f9dd86d0048f9a91)

- [fix test-in-docker-compose job](https://github.com/axonweb3/axon/pull/1398/commits/13fc8aab2e71b52502005ed82b1b28806d228299)

### What is the impact of this PR?

No Breaking Change


<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] E2E Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
