### PR TITLE
chore: avoid second `axon init` in docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN set -eux; \
 
 RUN cd /build && cargo build --release
 
-# TODO: update the parent image
-FROM debian:bookworm-20211011-slim
+
+FROM debian:bookworm-20230612-slim
 WORKDIR /app
 
 RUN set -eux; \

--- a/devtools/chain/docker-compose.yml
+++ b/devtools/chain/docker-compose.yml
@@ -2,21 +2,16 @@ version: '3.8'
 
 services:
   axon:
-    # TODO: update this image to ghcr.io/axonweb3/axon:dev
-    image: ghcr.io/flouse/axon:dev
+    image: ghcr.io/axonweb3/axon:dev
     ports:
     - 8000:8000
     - 127.0.0.1:8100:8100
     volumes:
-    - ./config.toml:/app/config.toml
-    - ./default.db-options:/app/default.db-options
-    - ./specs/single_node/:/app/single_node_spec/
+    - ./:/app/devtools/chain
     networks:
     - axon-net
     restart: unless-stopped
-    command: |
-      /app/axon init --config=/app/config.toml --chain-spec=/app/single_node_spec/chain-spec.toml
-      /app/axon run  --config=/app/config.toml
+    # CMD: see https://github.com/axonweb3/axon/blob/b89083/devtools/docker/docker-entrypoint.sh
 
   explorer:
     container_name: blockscan


### PR DESCRIPTION

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref https://github.com/axonweb3/axon/pull/1386


<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] E2E Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
