### PR TITLE
ci: fix regression testing workflow

### DIFF
--- a/.github/workflows/regression_testing.yml
+++ b/.github/workflows/regression_testing.yml
@@ -109,7 +109,7 @@ jobs:
 
   output-result:
     runs-on: ubuntu-latest
-    needs: [invoke-fmt-test,invoke-E2E-test,invoke-v3-core-test,invoke-web3-compatible-test,invoke-openzeppelin-test-1-5-and-12-15-test,invoke-OCT-6-10-test,invoke-OCT-11-test,invoke-OCT-16-19-test,invoke-chaos-test]
+    needs: [invoke-fmt-test,invoke-E2E-test,invoke-v3-core-test,invoke-web3-compatible-test,invoke-openzeppelin-test-1-5-and-12-15-test,invoke-OCT-6-10-test,invoke-OCT-11-test,invoke-OCT-16-19-test]
     if: github.repository_owner == 'axonweb3' && always()
     steps:
     - name: send message


### PR DESCRIPTION
## What this PR does / why we need it?

Job 'output-result' depends on unknown job 'invoke-chaos-test'.

### What is the impact of this PR?

No Breaking Change


<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] E2E Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
