### PR TITLE
fix(API): always return `null` when no receipt was found

### DIFF
--- a/core/api/src/adapter.rs
+++ b/core/api/src/adapter.rs
@@ -75,6 +75,10 @@ where
         self.mempool.insert(ctx, signed_tx).await
     }
 
+    async fn mempool_contains_tx(&self, ctx: Context, tx_hash: &Hash) -> bool {
+        self.mempool.contains(ctx, tx_hash).await
+    }
+
     async fn get_block_by_number(
         &self,
         ctx: Context,

--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use ckb_types::core::cell::{CellProvider, CellStatus};
 use ckb_types::prelude::Entity;
@@ -14,8 +13,7 @@ use protocol::types::{
     U256,
 };
 use protocol::{
-    async_trait, ckb_blake2b_256, codec::ProtocolCodec, lazy::PROTOCOL_VERSION, tokio::time,
-    ProtocolResult,
+    async_trait, ckb_blake2b_256, codec::ProtocolCodec, lazy::PROTOCOL_VERSION, ProtocolResult,
 };
 
 use core_executor::system_contract::DataProvider;

--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -616,7 +616,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
         if let Some(stx) = res {
             if let Some(receipt) = self
                 .adapter
-                .get_receipt_by_tx_hash(ctx.clone(), hash)
+                .get_receipt_by_tx_hash(ctx, hash)
                 .await
                 .map_err(|e| Error::Custom(e.to_string()))?
             {
@@ -624,14 +624,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
             }
         }
 
-        if self.adapter.mempool_contains_tx(ctx, &hash).await {
-            return Ok(None);
-        }
-
-        Err(Error::Custom(format!(
-            "Can not get receipt by hash {:?}",
-            hash
-        )))
+        Ok(None)
     }
 
     #[metrics_rpc("net_peerCount")]

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -198,6 +198,10 @@ where
         self.insert_tx(ctx, tx, is_call_system_script).await
     }
 
+    async fn contains(&self, _ctx: Context, tx_hash: &Hash) -> bool {
+        self.pool.contains(tx_hash)
+    }
+
     async fn package(
         &self,
         _ctx: Context,

--- a/protocol/src/traits/api.rs
+++ b/protocol/src/traits/api.rs
@@ -12,6 +12,8 @@ pub trait APIAdapter: Send + Sync {
         signed_tx: SignedTransaction,
     ) -> ProtocolResult<()>;
 
+    async fn mempool_contains_tx(&self, ctx: Context, tx_hash: &Hash) -> bool;
+
     async fn get_block_by_number(
         &self,
         ctx: Context,

--- a/protocol/src/traits/mempool.rs
+++ b/protocol/src/traits/mempool.rs
@@ -5,6 +5,8 @@ use crate::{async_trait, traits::Context, ProtocolResult};
 pub trait MemPool: Send + Sync {
     async fn insert(&self, ctx: Context, tx: SignedTransaction) -> ProtocolResult<()>;
 
+    async fn contains(&self, ctx: Context, tx_hash: &Hash) -> bool;
+
     async fn package(
         &self,
         ctx: Context,

--- a/tests/e2e/src/eth_getTransactionReceipt.test.js
+++ b/tests/e2e/src/eth_getTransactionReceipt.test.js
@@ -26,7 +26,7 @@ describe("eth_getTransactionReceipt", () => {
     const param1 = await page.$(goto.pageIds.param1Id);
     await testType.type("1"); // 0: none params 1: common params to request 2: more params
     await param1.type("0x18de99824561e6022e3b66797be8dd9f4d0310bceb15dec0e9e3fb18bebd2692");
-    await goto.check(page, "null");
+    await goto.check(page, "-32001");
   });
   /**
    * param1: none

--- a/tests/e2e/src/eth_getTransactionReceipt.test.js
+++ b/tests/e2e/src/eth_getTransactionReceipt.test.js
@@ -26,7 +26,7 @@ describe("eth_getTransactionReceipt", () => {
     const param1 = await page.$(goto.pageIds.param1Id);
     await testType.type("1"); // 0: none params 1: common params to request 2: more params
     await param1.type("0x18de99824561e6022e3b66797be8dd9f4d0310bceb15dec0e9e3fb18bebd2692");
-    await goto.check(page, "-32001");
+    await goto.check(page, "null");
   });
   /**
    * param1: none


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR refactor the process of `eth_getReceiptByHash` API. The new process is:
1. Try to get from storage
	a. If return is `Some`, return
2. Otherwise, return `Ok(None)`

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Fix #1412

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] E2E Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
