### PR TITLE
fix: incorrect usage of Makefile since #1416

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ e2e-test:
 		>> /tmp/log 2>&1 &
 	cd tests/e2e && yarn
 	cd tests/e2e/src && yarn exec http-server &
-	cd tests/e2e && yarn exec wait-on -t 5000 tcp:8000 && yarn exec wait-on -t 5000 tcp:8080 && yarn test
+	cd tests/e2e && yarn exec wait-on -t 5000 tcp:8000 && yarn exec wait-on -t 5000 tcp:8080 && HEADLESS="$(HEADLESS)" yarn test
 	pkill -2 axon
 	pkill -2 http-server
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR fix an incorrect usage of Makefile introduced since #1416.

The target-specific variable values are not applied in the environment directly, they have to be passed via a explicit set, except the variables which used in built-in target rules.

<details><summary> :point_right: A simple example to explain this rule and the exception. (useful)</summary>

- A simple `Makefile`:
  ```Makefile
  aaa:
          @true && WIIL_BE_SET="$(WIIL_BE_SET)" ./check-env
  
  bbb: WIIL_BE_SET=true
  bbb: WONT_BE_SET=true
  bbb: aaa

  # The variables which used in built-in target rules don't require a explicit set.
  # When users execute `make build`, `CFLAGS = -g` will be applied.
  a.o: a.c
  build: CFLAGS = -g
  build: a.o
  clean:
          rm *.o
  ```

- A simple bash script `check-env`:

  ```bash
  #!/usr/bin/env bash
  
  echo "will_be_set = [${WIIL_BE_SET}]"
  echo "wont_be_set = [${WONT_BE_SET}]"
  ```

- The result of tests:

  ```prompt
  > make aaa
  will_be_set = []
  wont_be_set = []
  > make bbb
  will_be_set = [true]
  wont_be_set = []
  > make clean a.o
  cc    -c -o a.o a.c
  > make clean build
  cc -g    -c -o a.o a.c
  ```

</details>

References:
- [GNU Makefile Docs: 6.11 Target-specific Variable Values](https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html)

### What is the impact of this PR?

No Breaking Change

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] E2E Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
