### PR TITLE
feat: support set hardfork from command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,8 @@ dependencies = [
  "serde",
  "serde_json",
  "stringreader",
+ "strum 0.25.0",
+ "strum_macros 0.25.2",
  "tentacle-multiaddr",
  "toml 0.7.3",
 ]
@@ -1641,6 +1643,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
+ "strum 0.25.0",
 ]
 
 [[package]]
@@ -2692,7 +2695,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.24.1",
  "syn 2.0.16",
  "tempfile",
  "thiserror",
@@ -6299,8 +6302,14 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
 ]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
@@ -6313,6 +6322,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN set -eux; \
         cmake \
         clang \
         llvm \
+        jq \
         gcc; \
     rm -rf /var/lib/apt/lists/*
 

--- a/common/config-parser/Cargo.toml
+++ b/common/config-parser/Cargo.toml
@@ -11,6 +11,8 @@ reqwest = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 stringreader = "0.1"
+strum = "0.25"
+strum_macros = "0.25"
 tentacle-multiaddr = "0.3"
 toml = "0.7"
 

--- a/core/api/Cargo.toml
+++ b/core/api/Cargo.toml
@@ -10,19 +10,20 @@ beef = "0.5"
 ckb-jsonrpc-types = "0.108"
 ckb-traits = "0.108"
 ckb-types = "0.108"
-jsonrpsee = { version = "0.16", features = ["macros","server"] }
+jsonrpsee = { version = "0.16", features = ["macros", "server"] }
 log = "0.4"
 parking_lot = "0.12"
 pprof = { version = "0.11", features = ["prost-codec"], optional = true }
 rlp = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+strum = "0.25"
 
 common-apm = { path = "../../common/apm" }
 common-config-parser = { path = "../../common/config-parser" }
 core-consensus = { path = "../../core/consensus" }
 core-executor = { path = "../../core/executor" }
-core-interoperation ={ path = "../../core/interoperation" }
+core-interoperation = { path = "../../core/interoperation" }
 either = { version = "1.8", features = ["serde"] }
 protocol = { path = "../../protocol", package = "axon-protocol" }
 

--- a/core/api/src/adapter.rs
+++ b/core/api/src/adapter.rs
@@ -6,8 +6,8 @@ use protocol::traits::{
 use protocol::trie::Trie as _;
 use protocol::types::{
     Account, BigEndianHash, Block, BlockNumber, Bytes, CkbRelatedInfo, ExecutorContext,
-    HardforkInfo, Hash, Header, Metadata, Proposal, Receipt, SignedTransaction, TxResp, H160, H256,
-    MAX_BLOCK_GAS_LIMIT, NIL_DATA, RLP_NULL, U256,
+    HardforkInfo, HardforkInfoInner, Hash, Header, Metadata, Proposal, Receipt, SignedTransaction,
+    TxResp, H160, H256, MAX_BLOCK_GAS_LIMIT, NIL_DATA, RLP_NULL, U256,
 };
 use protocol::{async_trait, codec::ProtocolCodec, trie, ProtocolResult};
 
@@ -288,5 +288,9 @@ where
 
     async fn hardfork_info(&self, ctx: Context) -> ProtocolResult<HardforkInfo> {
         MetadataHandle::new(self.get_metadata_root(ctx).await?).hardfork_infos()
+    }
+
+    async fn hardfork_proposal(&self, ctx: Context) -> ProtocolResult<Option<HardforkInfoInner>> {
+        self.storage.hardfork_proposal(ctx).await
     }
 }

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -150,6 +150,7 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
     }
 }
 
+/// Returns (enabled_flags, determined_flags) in target block height
 fn enabled_and_determined(iter: &[HardforkInfoInner], current_number: u64) -> (H256, H256) {
     if iter.len() < 2 {
         match iter.last() {

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -6,7 +6,9 @@ use strum::IntoEnumIterator;
 use common_config_parser::types::spec::HardforkName;
 use protocol::async_trait;
 use protocol::traits::{APIAdapter, Context};
-use protocol::types::{Block, CkbRelatedInfo, Metadata, Proof, Proposal, H256, U256};
+use protocol::types::{
+    Block, CkbRelatedInfo, HardforkInfoInner, Metadata, Proof, Proposal, H256, U256,
+};
 
 use crate::jsonrpc::web3_types::{BlockId, HardforkStatus};
 use crate::jsonrpc::{AxonRpcServer, RpcResult};
@@ -100,7 +102,7 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
     }
 
     async fn hardfork_infos(&self) -> RpcResult<HashMap<HardforkName, HardforkStatus>> {
-        let actived = self
+        let all_determined = self
             .adapter
             .hardfork_info(Context::new())
             .await
@@ -111,7 +113,6 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
             .hardfork_proposal(Context::new())
             .await
             .map_err(|e| Error::Custom(e.to_string()))?;
-        let actived_latest = actived.inner.last();
 
         let current_number = self
             .adapter
@@ -121,6 +122,9 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
             .unwrap()
             .number;
 
+        let (enabled_latest, determined_latest) =
+            enabled_and_determined(&all_determined.inner, current_number);
+
         let mut hardfork_infos = HashMap::new();
         for hardfork_name in HardforkName::iter() {
             if let Some(p) = proposal.as_ref() {
@@ -128,17 +132,239 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
                     hardfork_infos.insert(hardfork_name, HardforkStatus::Proposed);
                 }
             }
-            if let Some(a) = actived_latest {
-                if a.flags & H256::from_low_u64_be((hardfork_name as u64).to_be()) != H256::zero() {
-                    if a.block_number <= current_number {
-                        hardfork_infos.insert(hardfork_name, HardforkStatus::Enabled);
-                    } else {
-                        hardfork_infos.insert(hardfork_name, HardforkStatus::Activated);
-                    }
-                }
+
+            if determined_latest & H256::from_low_u64_be((hardfork_name as u64).to_be())
+                != H256::zero()
+            {
+                hardfork_infos.insert(hardfork_name, HardforkStatus::Determined);
+            }
+
+            if enabled_latest & H256::from_low_u64_be((hardfork_name as u64).to_be())
+                != H256::zero()
+            {
+                hardfork_infos.insert(hardfork_name, HardforkStatus::Enabled);
             }
         }
 
         Ok(hardfork_infos)
+    }
+}
+
+fn enabled_and_determined(iter: &[HardforkInfoInner], current_number: u64) -> (H256, H256) {
+    if iter.len() < 2 {
+        match iter.last() {
+            Some(latest) => {
+                if latest.block_number >= current_number {
+                    (latest.flags, H256::zero())
+                } else {
+                    (H256::zero(), latest.flags)
+                }
+            }
+            None => (H256::zero(), H256::zero()),
+        }
+    } else {
+        let (determined, enabled) = {
+            let mut determined_latest = None;
+            let mut enabled_latest = None;
+            for hf in iter.iter().rev() {
+                if hf.block_number > current_number {
+                    if determined_latest.is_none() {
+                        determined_latest = Some(hf.clone());
+                    }
+                } else {
+                    enabled_latest = Some(hf.clone())
+                }
+                if enabled_latest.is_some() {
+                    break;
+                }
+            }
+            (
+                determined_latest.map(|i| i.flags).unwrap_or_default(),
+                enabled_latest.map(|i| i.flags).unwrap_or_default(),
+            )
+        };
+
+        (
+            enabled,
+            if determined != H256::zero() {
+                determined ^ enabled
+            } else {
+                determined
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{enabled_and_determined, HardforkInfoInner, H256};
+
+    #[test]
+    fn test_select() {
+        let v1 = vec![HardforkInfoInner {
+            block_number: 0,
+            flags:        H256::zero(),
+        }];
+
+        let (ve1, vd1) = enabled_and_determined(&v1, 0);
+
+        assert_eq!(ve1, H256::zero());
+        assert_eq!(vd1, H256::zero());
+
+        let v2 = vec![HardforkInfoInner {
+            block_number: 0,
+            flags:        {
+                let mut a = [0; 32];
+                a[0] = 0b10;
+                H256::from(a)
+            },
+        }];
+
+        let (ve2, vd2) = enabled_and_determined(&v2, 0);
+
+        assert_eq!(ve2, {
+            let mut a = [0; 32];
+            a[0] = 0b10;
+            H256::from(a)
+        });
+        assert_eq!(vd2, H256::zero());
+
+        let v3 = vec![
+            HardforkInfoInner {
+                block_number: 0,
+                flags:        {
+                    let mut a = [0; 32];
+                    a[0] = 0b10;
+                    H256::from(a)
+                },
+            },
+            HardforkInfoInner {
+                block_number: 5,
+                flags:        {
+                    let mut a = [0; 32];
+                    a[0] = 0b11;
+                    H256::from(a)
+                },
+            },
+        ];
+
+        let (ve3, vd3) = enabled_and_determined(&v3, 0);
+
+        assert_eq!(ve3, {
+            let mut a = [0; 32];
+            a[0] = 0b10;
+            H256::from(a)
+        });
+        assert_eq!(vd3, {
+            let mut a = [0; 32];
+            a[0] = 0b01;
+            H256::from(a)
+        });
+
+        let (ve31, vd31) = enabled_and_determined(&v3, 5);
+
+        assert_eq!(ve31, {
+            let mut a = [0; 32];
+            a[0] = 0b11;
+            H256::from(a)
+        });
+        assert_eq!(vd31, H256::zero());
+
+        let v4 = vec![
+            HardforkInfoInner {
+                block_number: 0,
+                flags:        {
+                    let mut a = [0; 32];
+                    a[0] = 0b10;
+                    H256::from(a)
+                },
+            },
+            HardforkInfoInner {
+                block_number: 5,
+                flags:        {
+                    let mut a = [0; 32];
+                    a[0] = 0b11;
+                    H256::from(a)
+                },
+            },
+            HardforkInfoInner {
+                block_number: 10,
+                flags:        {
+                    let mut a = [0; 32];
+                    a[0] = 0b111;
+                    H256::from(a)
+                },
+            },
+        ];
+
+        let (ve4, vd4) = enabled_and_determined(&v4, 0);
+
+        assert_eq!(ve4, {
+            let mut a = [0; 32];
+            a[0] = 0b10;
+            H256::from(a)
+        });
+        assert_eq!(vd4, {
+            let mut a = [0; 32];
+            a[0] = 0b101;
+            H256::from(a)
+        });
+
+        let (ve41, vd41) = enabled_and_determined(&v4, 2);
+
+        assert_eq!(ve41, {
+            let mut a = [0; 32];
+            a[0] = 0b10;
+            H256::from(a)
+        });
+        assert_eq!(vd41, {
+            let mut a = [0; 32];
+            a[0] = 0b101;
+            H256::from(a)
+        });
+
+        let (ve42, vd42) = enabled_and_determined(&v4, 5);
+
+        assert_eq!(ve42, {
+            let mut a = [0; 32];
+            a[0] = 0b11;
+            H256::from(a)
+        });
+        assert_eq!(vd42, {
+            let mut a = [0; 32];
+            a[0] = 0b100;
+            H256::from(a)
+        });
+
+        let (ve43, vd43) = enabled_and_determined(&v4, 8);
+
+        assert_eq!(ve43, {
+            let mut a = [0; 32];
+            a[0] = 0b11;
+            H256::from(a)
+        });
+        assert_eq!(vd43, {
+            let mut a = [0; 32];
+            a[0] = 0b100;
+            H256::from(a)
+        });
+
+        let (ve44, vd44) = enabled_and_determined(&v4, 10);
+
+        assert_eq!(ve44, {
+            let mut a = [0; 32];
+            a[0] = 0b111;
+            H256::from(a)
+        });
+        assert_eq!(vd44, H256::zero());
+
+        let (ve45, vd45) = enabled_and_determined(&v4, 12);
+
+        assert_eq!(ve45, {
+            let mut a = [0; 32];
+            a[0] = 0b111;
+            H256::from(a)
+        });
+        assert_eq!(vd45, H256::zero());
     }
 }

--- a/core/api/src/jsonrpc/mod.rs
+++ b/core/api/src/jsonrpc/mod.rs
@@ -3,22 +3,22 @@ mod r#impl;
 mod web3_types;
 mod ws_subscription;
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use ckb_jsonrpc_types::{CellInfo, HeaderView as CkbHeaderView, OutPoint};
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use jsonrpsee::{core::Error, proc_macros::rpc};
 
-use common_config_parser::types::Config;
+use common_config_parser::types::{spec::HardforkName, Config};
 use protocol::traits::APIAdapter;
 use protocol::types::{
-    Block, CkbRelatedInfo, HardforkInfo, Hash, Hex, Metadata, Proof, Proposal, H160, H256, U256,
+    Block, CkbRelatedInfo, Hash, Hex, Metadata, Proof, Proposal, H160, H256, U256,
 };
 use protocol::ProtocolResult;
 
 use crate::jsonrpc::web3_types::{
-    BlockId, FilterChanges, RawLoggerFilter, Web3Block, Web3CallRequest, Web3FeeHistory,
-    Web3Filter, Web3Log, Web3Receipt, Web3SyncStatus, Web3Transaction,
+    BlockId, FilterChanges, HardforkStatus, RawLoggerFilter, Web3Block, Web3CallRequest,
+    Web3FeeHistory, Web3Filter, Web3Log, Web3Receipt, Web3SyncStatus, Web3Transaction,
 };
 use crate::jsonrpc::ws_subscription::{ws_subscription_module, HexIdProvider};
 use crate::APIError;
@@ -227,7 +227,7 @@ pub trait AxonRpc {
     async fn get_ckb_related_info(&self) -> RpcResult<CkbRelatedInfo>;
 
     #[method(name = "axon_getHardforkInfo")]
-    async fn hardfork_info(&self) -> RpcResult<HardforkInfo>;
+    async fn hardfork_infos(&self) -> RpcResult<HashMap<HardforkName, HardforkStatus>>;
 }
 
 #[rpc(server)]

--- a/core/api/src/jsonrpc/web3_types.rs
+++ b/core/api/src/jsonrpc/web3_types.rs
@@ -879,8 +879,8 @@ pub struct RawLoggerFilter {
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub enum HardforkStatus {
     Proposed,
+    Determined,
     Enabled,
-    Activated,
 }
 
 #[cfg(test)]

--- a/core/api/src/jsonrpc/web3_types.rs
+++ b/core/api/src/jsonrpc/web3_types.rs
@@ -875,6 +875,14 @@ pub struct RawLoggerFilter {
     pub topics:     Option<Vec<MultiNestType<Hash>>>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub enum HardforkStatus {
+    Proposed,
+    Enabled,
+    Activated,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/cli/src/args/hardfork.rs
+++ b/core/cli/src/args/hardfork.rs
@@ -1,0 +1,28 @@
+use clap::Parser;
+
+use common_config_parser::types::{spec::HardforkInput, Config};
+
+use crate::error::{Error, Result};
+
+#[derive(Parser, Debug)]
+#[command(about = "About Axon hardfork feature")]
+pub struct HardforkArgs {
+    #[arg(
+        short = 'c',
+        long = "config",
+        value_name = "CONFIG_FILE",
+        help = "File path of client configurations."
+    )]
+    pub config: Config,
+
+    #[command(flatten)]
+    hardforks: Option<HardforkInput>,
+}
+
+impl HardforkArgs {
+    pub fn execute(self) -> Result<()> {
+        core_run::set_hardfork_info(self.config, self.hardforks.map(Into::into))
+            .map_err(Error::Running)?;
+        Ok(())
+    }
+}

--- a/core/cli/src/args/mod.rs
+++ b/core/cli/src/args/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod hardfork;
 pub(crate) mod init;
 pub(crate) mod run;

--- a/core/cli/src/lib.rs
+++ b/core/cli/src/lib.rs
@@ -2,7 +2,7 @@ mod args;
 mod error;
 pub(crate) mod utils;
 
-pub use args::{init::InitArgs, run::RunArgs};
+pub use args::{hardfork::HardforkArgs, init::InitArgs, run::RunArgs};
 pub use error::{CheckingVersionError, Error, Result};
 
 use clap::{CommandFactory as _, FromArgMatches as _, Parser, Subcommand};
@@ -21,6 +21,7 @@ struct Cli {
 enum Commands {
     Init(InitArgs),
     Run(RunArgs),
+    Hardfork(HardforkArgs),
 }
 
 pub struct AxonCli {
@@ -60,6 +61,7 @@ impl AxonCli {
         match cli.command {
             Commands::Init(args) => args.execute(kernel_version),
             Commands::Run(args) => args.execute(application_version, kernel_version, key_provider),
+            Commands::Hardfork(args) => args.execute(),
         }
     }
 }

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -637,6 +637,10 @@ where
         }
         Ok(())
     }
+
+    async fn remove_hardfork_proposal(&self, ctx: Context) -> ProtocolResult<()> {
+        self.storage.remove_hardfork_proposal(ctx).await
+    }
 }
 
 impl<M, N, S, DB> OverlordConsensusAdapter<M, N, S, DB>

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -82,6 +82,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<Proposal> for ConsensusEngine<A
             RLP_NULL
         };
 
+        let mut remove = false;
         let extra_data_hardfork = {
             let mut hardfork = self.node_info.hardfork_proposals.write().unwrap();
             match &*hardfork {
@@ -89,6 +90,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<Proposal> for ConsensusEngine<A
                     // remove invalid proposal
                     if v.block_number <= next_number {
                         hardfork.take();
+                        remove = true;
                         Default::default()
                     } else {
                         v.encode().unwrap()
@@ -97,6 +99,10 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<Proposal> for ConsensusEngine<A
                 None => Default::default(),
             }
         };
+
+        if remove {
+            self.adapter.remove_hardfork_proposal(ctx.clone()).await?;
+        }
 
         let proposal = Proposal {
             version:                  BlockVersion::V0,
@@ -652,6 +658,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
         let handle = MetadataHandle::new(root);
         let hardforks = handle.hardfork_infos()?;
 
+        let mut remove = false;
         if let Some(data) = hardforks.inner.last() {
             let mut self_proposal = self.node_info.hardfork_proposals.write().unwrap();
 
@@ -662,7 +669,12 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
             {
                 // remove self hardfork proposal
                 self_proposal.take();
+                remove = true;
             }
+        }
+
+        if remove {
+            self.adapter.remove_hardfork_proposal(ctx.clone()).await?;
         }
 
         if self

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -87,7 +87,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<Proposal> for ConsensusEngine<A
             let mut hardfork = self.node_info.hardfork_proposals.write().unwrap();
             match &*hardfork {
                 Some(v) => {
-                    // remove invalid proposal
+                    // remove invalid proposal if the proposed block height is passed
                     if v.block_number <= next_number {
                         hardfork.take();
                         remove = true;

--- a/core/consensus/src/tests/mod.rs
+++ b/core/consensus/src/tests/mod.rs
@@ -336,4 +336,8 @@ impl CommonConsensusAdapter for MockSyncAdapter {
     ) -> ProtocolResult<()> {
         Ok(())
     }
+
+    async fn remove_hardfork_proposal(&self, _ctx: Context) -> ProtocolResult<()> {
+        Ok(())
+    }
 }

--- a/core/db/src/rocks.rs
+++ b/core/db/src/rocks.rs
@@ -52,6 +52,7 @@ impl RocksAdapter {
             map_category(StorageCategory::EvmState),
             map_category(StorageCategory::MetadataState),
             map_category(StorageCategory::CkbLightClientState),
+            map_category(StorageCategory::Version),
         ];
 
         let (mut opts, cf_descriptors) = if let Some(ref file) = config.options_file {
@@ -294,7 +295,8 @@ impl From<RocksDBError> for ProtocolError {
     }
 }
 
-// Todo: column family "c0" is reserved for store version
+// column family "c0" is reserved for store version
+const C_VERSION: &str = "c0";
 const C_BLOCKS: &str = "c1";
 const C_BLOCK_HEADER: &str = "c2";
 const C_SIGNED_TRANSACTIONS: &str = "c3";
@@ -318,6 +320,7 @@ pub fn map_category(c: StorageCategory) -> &'static str {
         StorageCategory::EvmState => C_EVM_STATE,
         StorageCategory::MetadataState => C_METADATA_STATE,
         StorageCategory::CkbLightClientState => C_CKB_LIGHT_CLIENT_STATE,
+        StorageCategory::Version => C_VERSION,
     }
 }
 

--- a/core/storage/src/schema.rs
+++ b/core/storage/src/schema.rs
@@ -1,5 +1,7 @@
 use protocol::traits::{StorageCategory, StorageSchema};
-use protocol::types::{Block, Bytes, DBBytes, Hash, Header, Proof, Receipt, SignedTransaction};
+use protocol::types::{
+    Block, Bytes, DBBytes, HardforkInfoInner, Hash, Header, Proof, Receipt, SignedTransaction,
+};
 
 use crate::hash_key::{BlockKey, CommonHashKey};
 
@@ -41,3 +43,4 @@ impl_storage_schema_for!(LatestProofSchema, Hash, Proof, Block);
 impl_storage_schema_for!(OverlordWalSchema, Hash, Bytes, Wal);
 impl_storage_schema_for!(EvmCodeSchema, Hash, Bytes, Code);
 impl_storage_schema_for!(EvmCodeAddressSchema, Hash, Hash, Code);
+impl_storage_schema_for!(HardforkSchema, Hash, HardforkInfoInner, Version);

--- a/devtools/chain/quick-start.md
+++ b/devtools/chain/quick-start.md
@@ -50,7 +50,7 @@ curl --location --request POST 'http://127.0.0.1:8000' \
 }'
 
 # Result: a JSON response containing the chain ID of the Axon devnet.
-{"jsonrpc":"2.0","result":"0x7e6","id":42}
+{"jsonrpc":"2.0","result":"0x41786f6e","id":42}
 ```
 
 ### Access [Blockscan](http://127.0.0.1:4020)

--- a/devtools/docker/health_check.sh
+++ b/devtools/docker/health_check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+block_number() {
+    block=$(curl -s 'http://127.0.0.1:8000' \
+            --header 'Content-Type: application/json' \
+            --data '{"jsonrpc":"2.0", "method":"eth_blockNumber", "params": [], "id":42}' | jq '.result' |xargs printf %d 0xF)
+    echo $block
+}
+
+block_stats() {
+    current_block=$(block_number)
+    start_time=$(date +%s)
+    wait_seconds=60
+    
+    while true; do
+        latest_block=$(block_number)
+        if [ $current_block -lt  $latest_block ]
+        then
+            return 0
+        fi
+
+        current_time=$(date +%s)
+        elapsed_seconds=$((current_time - start_time))
+        if [ $elapsed_seconds -ge $wait_seconds ]
+        then
+                break
+        fi
+
+        sleep 1
+    done
+
+    echo "block does not grow in one minute, please check"
+    return 1
+}
+
+
+block_stats

--- a/protocol/src/traits/api.rs
+++ b/protocol/src/traits/api.rs
@@ -1,6 +1,6 @@
 use crate::types::{
-    Account, Block, BlockNumber, Bytes, CkbRelatedInfo, HardforkInfo, Hash, Header, Metadata,
-    Proposal, Receipt, SignedTransaction, TxResp, H160, H256, U256,
+    Account, Block, BlockNumber, Bytes, CkbRelatedInfo, HardforkInfo, HardforkInfoInner, Hash,
+    Header, Metadata, Proposal, Receipt, SignedTransaction, TxResp, H160, H256, U256,
 };
 use crate::{async_trait, traits::Context, ProtocolResult};
 
@@ -107,4 +107,6 @@ pub trait APIAdapter: Send + Sync {
     async fn get_metadata_root(&self, ctx: Context) -> ProtocolResult<H256>;
 
     async fn hardfork_info(&self, ctx: Context) -> ProtocolResult<HardforkInfo>;
+
+    async fn hardfork_proposal(&self, ctx: Context) -> ProtocolResult<Option<HardforkInfoInner>>;
 }

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -26,13 +26,17 @@ pub struct NodeInfo {
 }
 
 impl NodeInfo {
-    pub fn new(chain_id: u64, pubkey: Secp256k1PublicKey) -> Self {
+    pub fn new(
+        chain_id: u64,
+        pubkey: Secp256k1PublicKey,
+        hardfork_info: Option<HardforkInfoInner>,
+    ) -> Self {
         let address = Address::from_pubkey(&pubkey);
         Self {
             chain_id,
             self_pub_key: pubkey,
             self_address: address,
-            hardfork_proposals: Default::default(),
+            hardfork_proposals: Arc::new(RwLock::new(hardfork_info)),
         }
     }
 }
@@ -188,6 +192,8 @@ pub trait CommonConsensusAdapter: Send + Sync {
         weight_map: HashMap<Bytes, u32>,
         signed_voters: Vec<Bytes>,
     ) -> ProtocolResult<()>;
+
+    async fn remove_hardfork_proposal(&self, _ctx: Context) -> ProtocolResult<()>;
 }
 
 #[async_trait]

--- a/protocol/src/traits/storage.rs
+++ b/protocol/src/traits/storage.rs
@@ -1,4 +1,6 @@
-use crate::types::{Block, Bytes, Hash, Header, Proof, Receipt, SignedTransaction, H256};
+use crate::types::{
+    Block, Bytes, HardforkInfoInner, Hash, Header, Proof, Receipt, SignedTransaction, H256,
+};
 use crate::{async_trait, codec::ProtocolCodec, traits::Context, Display, ProtocolResult};
 
 #[derive(Copy, Clone, Display, Debug)]
@@ -13,6 +15,7 @@ pub enum StorageCategory {
     EvmState,
     MetadataState,
     CkbLightClientState,
+    Version,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -109,6 +112,8 @@ pub trait ReadOnlyStorage: Sync + Send {
     ) -> ProtocolResult<Vec<Option<Receipt>>>;
 
     async fn get_latest_proof(&self, ctx: Context) -> ProtocolResult<Proof>;
+
+    async fn hardfork_proposal(&self, _ctx: Context) -> ProtocolResult<Option<HardforkInfoInner>>;
 }
 
 #[async_trait]
@@ -144,6 +149,14 @@ pub trait Storage: ReadOnlyStorage {
     ) -> ProtocolResult<()>;
 
     async fn update_latest_proof(&self, ctx: Context, proof: Proof) -> ProtocolResult<()>;
+
+    async fn set_hardfork_proposal(
+        &self,
+        _ctx: Context,
+        hardfork: HardforkInfoInner,
+    ) -> ProtocolResult<()>;
+
+    async fn remove_hardfork_proposal(&self, _ctx: Context) -> ProtocolResult<()>;
 }
 
 pub enum StorageBatchModify<S: StorageSchema> {


### PR DESCRIPTION
## What this PR does / why we need it?

This PR adds features which support setting hardfork from the command line

like this：
```bash
./target/debug/axon hardfork \
  -c devtools/chain/config.toml \
  --hardfork-start-number 1 --feature f --feature e
```

### What is the impact of this PR?

No Breaking Change

### **PR relation**:
- Ref https://github.com/axonweb3/axon/pull/1404

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] E2E Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
