### PR TITLE
fix(ci): permit `Label` job to add label to PR

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -1,10 +1,13 @@
 name: PR Lint
+
 concurrency:
   group: Conventional PR-${{ github.ref }}
   cancel-in-progress: true
+
 on:
   pull_request:
     types: ['opened', 'edited', 'reopened', 'synchronize']
+
 jobs:
   WIP:
     runs-on: ubuntu-latest
@@ -31,6 +34,9 @@ jobs:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
   Label:
+    permissions:
+      # permits this job to add a label to pull request
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Add labels based on PR title


### PR DESCRIPTION
## What this PR does / why we need it?

- This PR comes from a forked repo.
- This PR fixed https://github.com/axonweb3/axon/issues/1329

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] E2E Tests
- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
