### PR TITLE
chore: bump jsonrpsee and ckb related crates version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
  "ckb-logger",
  "ckb-traits",
  "ckb-types",
- "ckb-vm 0.24.6",
+ "ckb-vm",
  "faster-hex 0.6.1",
  "serde",
 ]
@@ -1254,24 +1254,6 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1223acc8054ce96f91c5d99d4942898d0bdadd618c3b14f1acd3e67212991d8e"
-dependencies = [
- "byteorder",
- "bytes",
- "cc",
- "ckb-vm-definitions 0.22.2",
- "derive_more",
- "goblin 0.2.3",
- "goblin 0.4.0",
- "rand 0.7.3",
- "scroll",
- "serde",
-]
-
-[[package]]
-name = "ckb-vm"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc004a826b9bc9319ffae0b8415690e1b5f1482266d55fbd43843aa40ddcd63"
@@ -1279,7 +1261,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "cc",
- "ckb-vm-definitions 0.24.6",
+ "ckb-vm-definitions",
  "derive_more",
  "goblin 0.2.3",
  "goblin 0.4.0",
@@ -1287,12 +1269,6 @@ dependencies = [
  "scroll",
  "serde",
 ]
-
-[[package]]
-name = "ckb-vm-definitions"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af800ae2b6c54b70efa398dab015a09a52eeac2dd1ac3ad32c9bbe224974225"
 
 [[package]]
 name = "ckb-vm-definitions"
@@ -1825,7 +1801,7 @@ dependencies = [
  "ckb-script",
  "ckb-traits",
  "ckb-types",
- "ckb-vm 0.22.2",
+ "ckb-vm",
  "core-db",
  "core-executor",
  "core-rpc-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,15 +92,6 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
@@ -233,7 +224,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -544,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "blake2b-ref"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95916998c798756098a4eb1b3f2cd510659705a9817bf203d61abd30fbec3e7b"
+checksum = "294d17c72e0ba59fad763caa112368d0672083779cdebbb97164f4bb4c1e339a"
 
 [[package]]
 name = "blake2b-rs"
@@ -605,16 +596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 dependencies = [
  "sha2 0.9.9",
-]
-
-[[package]]
-name = "bstr"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -885,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-chain-spec"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78df45446aaa86b06a77b8b145cffa79950e7ede293cebcd114a62e74c29dbf"
+checksum = "dbd58081d4ac4f08d068b52c5a07f0b379d93aad0dfa8344c6890429a9b73c2b"
 dependencies = [
  "ckb-constant",
  "ckb-crypto",
@@ -907,24 +888,24 @@ dependencies = [
 
 [[package]]
 name = "ckb-channel"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "920f26cc48cadcaf6f7bcc3960fde9f9f355633b6361da8ef31e1e1c00fc8858"
+checksum = "701e6829c3dcbae46dd2442de63d080046480a6c2bb4951dbf419ad092459402"
 dependencies = [
  "crossbeam-channel",
 ]
 
 [[package]]
 name = "ckb-constant"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302566408e5b296663ac5e8245bf71824ca2c7c2ef19a57fcc15939dd66527e9"
+checksum = "9d5c980d4724770f72a37bceffa26ea64dd914891e45e856e2a3792fdb4a5a18"
 
 [[package]]
 name = "ckb-crypto"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac31177b0a8bf3acd563c042775e40494e437b2bbbae96ac2473eec3a4da95d"
+checksum = "df80db694e42b64a5774ae551daff3c8310cd99bb528643dbe0dd409abb298e7"
 dependencies = [
  "ckb-fixed-hash",
  "faster-hex 0.6.1",
@@ -936,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-dao-utils"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1929c9627923fe1d22151361d74f5a5aa0dda77016d020307a54486eae11cb3c"
+checksum = "5e158ce5a4e9d1fcd08d9dee87332474572c629c6273cca0aea80ba24892a403"
 dependencies = [
  "byteorder",
  "ckb-error",
@@ -947,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-error"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446a519d8a847d97f1c8ece739dc1748751a9a2179249c96c45cced0825a7aa5"
+checksum = "34cfd733cabcb4262ee679c02733864b13c8fa879e3aabc078fe0ec727cd95d6"
 dependencies = [
  "anyhow",
  "ckb-occupied-capacity",
@@ -959,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00cbbc455b23748b32e06d16628a03e30d56ffa057f17093fdf5b42d4fb6c879"
+checksum = "3b1dfab045fffa31cae9680d73e1f09833ca1abfb807dc4b9544739c94c23fd0"
 dependencies = [
  "ckb-fixed-hash-core",
  "ckb-fixed-hash-macros",
@@ -969,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-core"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e644a4e026625b4be5a04cdf6c02043080e79feaf77d9cdbb2f0e6553f751"
+checksum = "bdd1727a6ecd4d0bcab604cb1ef707fe92e939fa6e9a438f9f25bf05208cb080"
 dependencies = [
  "faster-hex 0.6.1",
  "serde",
@@ -980,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-macros"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cfc980ef88c217825172eb46df269f47890f5e78a38214416f13b3bd17a4b4"
+checksum = "7b5da34c32585c35715fcde4e3a1dd3b0346d7af43506c5e51c613f01483e4f9"
 dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro2",
@@ -991,10 +972,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "ckb-hash"
-version = "0.108.0"
+name = "ckb-gen-types"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d9b683e89ae4ffdd5aaf4172eab00b6bbe7ea24e2abf77d3eb850ba36e8983"
+checksum = "a3bc54ca99b09e1eb5fc6c49bb1156644ce57fce9c6f52b5c13110b9a3143f7e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ckb-error",
+ "ckb-fixed-hash",
+ "ckb-hash",
+ "ckb-occupied-capacity",
+ "molecule",
+ "numext-fixed-uint",
+]
+
+[[package]]
+name = "ckb-hash"
+version = "0.111.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c88e5e2d6454be488fa5cf8b49175879353c6af969ff210dd6416f315b53120"
 dependencies = [
  "blake2b-ref",
  "blake2b-rs",
@@ -1002,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-jsonrpc-types"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac087657eaf964e729f40b3c929d3dac74a2cd8bb38d5e588756e2495711f810"
+checksum = "d789a71538da07871c11aecbd28d6c632bb426bdfeed5fc2fa1b455e31152468"
 dependencies = [
  "ckb-types",
  "faster-hex 0.6.1",
@@ -1028,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-logger"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911c4695ddf82f78da8f514b359092bbe231f58c2669c93b1cfc9a2030b125bb"
+checksum = "939fa09ca3534248d3d452552546f016fc7e11346644fbc5b55d2ad38d3e80e7"
 dependencies = [
  "log",
 ]
@@ -1045,10 +1041,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "ckb-occupied-capacity"
-version = "0.108.0"
+name = "ckb-mock-tx-types"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2a1dd0d4ba5dafba1e30d437c1148b20f42edb76b6794323e05bda626754eb"
+checksum = "dcd5b156c36f03ad6053e174e26a874088c8e9098c3a2e80ec93dc9831ecfac3"
+dependencies = [
+ "ckb-jsonrpc-types",
+ "ckb-traits",
+ "ckb-types",
+ "serde",
+]
+
+[[package]]
+name = "ckb-occupied-capacity"
+version = "0.111.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "358ad364465a5a359575642c12952ba8735a148382789d65ddd5231cd21899fc"
 dependencies = [
  "ckb-occupied-capacity-core",
  "ckb-occupied-capacity-macros",
@@ -1056,18 +1064,18 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity-core"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ebba3d564098a84c83f4740e1dce48a5e2da759becdb47e3c7965f0808e6e92"
+checksum = "de2dc06db98f8a995cb7145bc56dbd17bb0c8ab2e59a07aaa40f2c956c2451dd"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ckb-occupied-capacity-macros"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6321bba85cdf9724029d8c906851dd4a90906869b42f9100b16645a1261d4c"
+checksum = "b1709e0f101026c4ef29b1593692e480b03cdb4e0dace1e348494c6554d50d35"
 dependencies = [
  "ckb-occupied-capacity-core",
  "quote",
@@ -1076,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-pow"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9167b427f42874e68e20e6946d5211709979ff1d86c0061a71c2f6a6aa17659"
+checksum = "481e76388993d7e6e0dd797e8532c60398901787e28d0638ca114254257b8813"
 dependencies = [
  "byteorder",
  "ckb-hash",
@@ -1090,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-rational"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2519249f8d47fa758d3fb3cf3049327c69ce0f2acd79d61427482c8661d3dbd"
+checksum = "bd3959391a4fb05d6a2578aa8db75732ada1ce381fb34d6eeaf09d395702e63c"
 dependencies = [
  "numext-fixed-uint",
  "serde",
@@ -1100,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-resource"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3abddc968d7f1e70584ab04180c347380a44acbe0b60e26cc96208ec8885279"
+checksum = "03222b0613cf3f55cb181471d7a84879b6fba5e920e2e1c7ba2c2315614bd387"
 dependencies = [
  "ckb-system-scripts",
  "ckb-types",
@@ -1126,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "ckb-script"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b4754a2f0ccea5ea1934822bd18a3a66c46344d8c3872cb20ffdcf0851fab9"
+checksum = "8c9075ad901eae97925f491b6be675d7b19bf7b10eaa94a88f6e8070c0cd00ba"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -1137,30 +1145,34 @@ dependencies = [
  "ckb-logger",
  "ckb-traits",
  "ckb-types",
- "ckb-vm",
+ "ckb-vm 0.24.6",
  "faster-hex 0.6.1",
  "serde",
 ]
 
 [[package]]
 name = "ckb-sdk"
-version = "2.5.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b201220ac5762353f9313fbbc3c4cee2a6a924c16c17df51517644991575cc1"
+checksum = "9ded3042867b04f20456f17a1f752f2604a24659f3aeec1928917d9ee6b659d4"
 dependencies = [
  "anyhow",
  "bech32 0.8.1",
  "bitflags",
  "bytes",
+ "ckb-chain-spec",
  "ckb-crypto",
  "ckb-dao-utils",
  "ckb-hash",
  "ckb-jsonrpc-types",
+ "ckb-mock-tx-types",
  "ckb-resource",
  "ckb-script",
  "ckb-traits",
  "ckb-types",
  "dashmap",
+ "derive-getters",
+ "dyn-clone",
  "enum-repr-derive",
  "futures",
  "jsonrpc-core",
@@ -1195,40 +1207,44 @@ dependencies = [
 
 [[package]]
 name = "ckb-traits"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9d5827f20a396dfb785398db484fe50de93d76c02e1e32287832604a9dda91"
+checksum = "ca049aba2cb2d1208c6044accb497b17290ad56de629f6a4b95eded67a43fd40"
 dependencies = [
  "ckb-types",
 ]
 
 [[package]]
 name = "ckb-types"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c22b3b1ca8f88a8f48e2f73321c0605281c9c6f1e1c4d651c6138265c22291e"
+checksum = "b6ec737e4957418bbd0f4091e8565a89bbd8f6fc37a20360820e44d1f1e44e58"
 dependencies = [
  "bit-vec",
  "bytes",
  "ckb-channel",
+ "ckb-constant",
  "ckb-error",
  "ckb-fixed-hash",
+ "ckb-gen-types",
  "ckb-hash",
  "ckb-merkle-mountain-range",
  "ckb-occupied-capacity",
  "ckb-rational",
  "derive_more",
+ "golomb-coded-set",
  "merkle-cbt",
  "molecule",
  "numext-fixed-uint",
  "once_cell",
+ "paste",
 ]
 
 [[package]]
 name = "ckb-util"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d165c6958601dfbfa4cd00c9263ecfb013b4ccb6d9e1d3187bfa62801abc7d"
+checksum = "011b907b18aa706fc224a1309f14eadd9cc14c42cf2258ca3010d1324bc20f10"
 dependencies = [
  "linked-hash-map",
  "once_cell",
@@ -1245,7 +1261,25 @@ dependencies = [
  "byteorder",
  "bytes",
  "cc",
- "ckb-vm-definitions",
+ "ckb-vm-definitions 0.22.2",
+ "derive_more",
+ "goblin 0.2.3",
+ "goblin 0.4.0",
+ "rand 0.7.3",
+ "scroll",
+ "serde",
+]
+
+[[package]]
+name = "ckb-vm"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc004a826b9bc9319ffae0b8415690e1b5f1482266d55fbd43843aa40ddcd63"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "cc",
+ "ckb-vm-definitions 0.24.6",
  "derive_more",
  "goblin 0.2.3",
  "goblin 0.4.0",
@@ -1259,6 +1293,15 @@ name = "ckb-vm-definitions"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4af800ae2b6c54b70efa398dab015a09a52eeac2dd1ac3ad32c9bbe224974225"
+
+[[package]]
+name = "ckb-vm-definitions"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ced3ff9d79b53d93c106720f6c1f855694290e33581850e05c859500eee83f"
+dependencies = [
+ "paste",
+]
 
 [[package]]
 name = "clang-sys"
@@ -1348,7 +1391,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1776,12 +1819,13 @@ dependencies = [
  "axon-protocol",
  "cardano-message-signing",
  "cardano-serialization-lib",
+ "ckb-chain-spec",
  "ckb-error",
  "ckb-jsonrpc-types",
  "ckb-script",
  "ckb-traits",
  "ckb-types",
- "ckb-vm",
+ "ckb-vm 0.22.2",
  "core-db",
  "core-executor",
  "core-rpc-client",
@@ -2149,6 +2193,17 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0122f262bf9c9a367829da84f808d9fb128c10ef283bbe7b0922a77cf07b2747"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2650,7 +2705,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.32",
+ "syn 2.0.37",
  "tokio",
  "toml 0.7.3",
  "url",
@@ -2670,7 +2725,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2697,7 +2752,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.24.1",
- "syn 2.0.32",
+ "syn 2.0.37",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -3130,7 +3185,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3242,19 +3297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "globset"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
-dependencies = [
- "aho-corasick 0.7.20",
- "bstr",
- "fnv",
- "log",
- "regex",
-]
-
-[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,6 +3338,15 @@ dependencies = [
  "log",
  "plain",
  "scroll",
+]
+
+[[package]]
+name = "golomb-coded-set"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7076c0cd6257d84b785b0f22c36443dd47a5e86a1256d7ef82c8cb88ea9a7e"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3809,30 +3860,28 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.16.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
+checksum = "9ad9b31183a8bcbe843e32ca8554ad2936633548d95a7bb6a8e14c767dea6b05"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.16.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
+checksum = "35dc957af59ce98373bcdde0c1698060ca6c2d2e9ae357b459c7158b6df33330"
 dependencies = [
  "anyhow",
- "arrayvec",
  "async-trait",
  "beef",
- "futures-channel",
  "futures-util",
- "globset",
  "hyper",
  "jsonrpsee-types",
  "parking_lot 0.12.1",
@@ -3848,9 +3897,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.16.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa6da1e4199c10d7b1d0a6e5e8bd8e55f351163b6f4b3cbb044672a69bd4c1c"
+checksum = "cef91b1017a4edb63f65239381c18de39f88d0e0760ab626d806e196f7f51477"
 dependencies = [
  "heck",
  "proc-macro-crate",
@@ -3861,19 +3910,20 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.16.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb69dad85df79527c019659a992498d03f8495390496da2f07e6c24c2b356fc"
+checksum = "24f4e2f3d223d810e363fb8b5616ec4c6254243ee7f452d05ac281cdc9cf76b2"
 dependencies = [
- "futures-channel",
  "futures-util",
  "http",
  "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "route-recognizer",
  "serde",
  "serde_json",
  "soketto",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3883,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.16.2"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd522fe1ce3702fd94812965d7bb7a3364b1c9aba743944c5a00529aae80f8c"
+checksum = "fa9e25aec855b2a7d3ed90fded6c41e8c3fb72b63f071e1be3f0004eba19b625"
 dependencies = [
  "anyhow",
  "beef",
@@ -4192,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "molecule"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc8276c02a006bddad7d1c28c1a88f30421e1b5f0ba0ca96ceb8077c7d20c01"
+checksum = "d4fd9767ab5e5f2ea40f71ff4c8bdb633c50509052e093c2fdd0e390a749dfa3"
 dependencies = [
  "bytes",
  "cfg-if 1.0.0",
@@ -4424,7 +4474,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4554,7 +4604,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4936,7 +4986,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5065,7 +5115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617feabb81566b593beb4886fb8c1f38064169dae4dccad0e3220160c3b37203"
 dependencies = [
  "proc-macro2",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5475,7 +5525,7 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick",
  "memchr",
  "regex-syntax 0.7.1",
 ]
@@ -5624,6 +5674,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "route-recognizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rug"
@@ -5999,7 +6055,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6335,7 +6391,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6424,9 +6480,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6591,7 +6647,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6743,7 +6799,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6915,7 +6971,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -7586,7 +7642,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/common/apm-derive/Cargo.toml
+++ b/common/apm-derive/Cargo.toml
@@ -17,7 +17,7 @@ syn = { version = "1.0", features = ["full"] }
 [dev-dependencies]
 async-trait = "0.1"
 common-apm = { path = "../apm" }
-jsonrpsee = { version = "0.16", features = ["macros"] }
+jsonrpsee = { version = "0.20", features = ["macros"] }
 log = "0.4"
 
 protocol = { path = "../../protocol", package = "axon-protocol" }

--- a/common/config-parser/src/lib.rs
+++ b/common/config-parser/src/lib.rs
@@ -1,11 +1,7 @@
 pub mod types;
 use serde::de;
 
-use std::error;
-use std::fmt;
-use std::fs;
-use std::io;
-use std::path::Path;
+use std::{error, fmt, fs, io, path::Path};
 
 /// Parse a config from reader.
 pub fn parse_reader<R: io::Read, T: de::DeserializeOwned>(r: &mut R) -> Result<T, ParseError> {

--- a/common/config-parser/src/types/spec.rs
+++ b/common/config-parser/src/types/spec.rs
@@ -8,9 +8,10 @@ use std::{
 
 use clap::{
     builder::{StringValueParser, TypedValueParser, ValueParserFactory},
-    Args,
+    Args, ValueEnum,
 };
 use serde::{Deserialize, Serialize};
+use strum_macros::EnumIter;
 
 use common_crypto::Secp256k1RecoverablePrivateKey;
 use protocol::{
@@ -274,9 +275,6 @@ impl Genesis {
         }
     }
 }
-
-use clap::ValueEnum;
-use strum_macros::EnumIter;
 
 #[derive(Clone, Debug, Deserialize, Args)]
 pub struct HardforkInput {

--- a/core/api/Cargo.toml
+++ b/core/api/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 [dependencies]
 # async-graphql = { version = "3.0", features = ["tracing"] }
 beef = "0.5"
-ckb-jsonrpc-types = "0.108"
-ckb-traits = "0.108"
-ckb-types = "0.108"
-jsonrpsee = { version = "0.16", features = ["macros", "server"] }
+ckb-jsonrpc-types = "0.111"
+ckb-traits = "0.111"
+ckb-types = "0.111"
+jsonrpsee = { version = "0.20", features = ["macros", "server"] }
 log = "0.4"
 parking_lot = "0.12"
 pprof = { version = "0.11", features = ["prost-codec"], optional = true }

--- a/core/api/src/jsonrpc/error.rs
+++ b/core/api/src/jsonrpc/error.rs
@@ -23,7 +23,7 @@ pub enum RpcError {
     GasPriceIsZero,
     #[display(fmt = "Gas price is too large")]
     GasPriceIsTooLarge,
-    #[display(fmt = "Gas limit is too low")]
+    #[display(fmt = "Gas limit is less than 21000")]
     GasLimitIsTooLow,
     #[display(fmt = "Gas limit is too large")]
     GasLimitIsTooLarge,
@@ -45,7 +45,7 @@ pub enum RpcError {
     InvalidNewestBlock(BlockId),
     #[display(fmt = "Invalid position {}", _0)]
     InvalidPosition(u64),
-    #[display(fmt = "Cannot find block")]
+    #[display(fmt = "Cannot find the block")]
     CannotFindBlock,
     #[display(fmt = "Invalid reward percentiles {} {}", _0, _1)]
     InvalidRewardPercentiles(f64, f64),

--- a/core/api/src/jsonrpc/error.rs
+++ b/core/api/src/jsonrpc/error.rs
@@ -1,41 +1,152 @@
-use jsonrpsee::core::Error;
-use jsonrpsee::types::error::{CallError, ErrorObject};
+use jsonrpsee::types::{error::ErrorObject, ErrorObjectOwned};
 
-use protocol::codec::hex_encode;
 use protocol::types::{ExitReason, TxResp};
+use protocol::{codec::hex_encode, Display};
 
 use core_executor::decode_revert_msg;
 
-const EXEC_ERROR: i32 = -32015;
+use crate::jsonrpc::web3_types::BlockId;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Display, Debug)]
 pub enum RpcError {
+    #[display(fmt = "Decode interoperation signature r error")]
+    DecodeInteroperationSigR(String),
+    #[display(fmt = "Decode interoperation signature s error")]
+    DecodeInteroperationSigS(String),
+    #[display(fmt = "Invalid address source")]
+    InvalidAddressSource,
+    #[display(fmt = "Missing dummy input cell")]
+    MissingDummyInputCell,
+    #[display(fmt = "Cannot find image cell")]
+    CannotFindImageCell,
+    #[display(fmt = "Gas price is zero")]
+    GasPriceIsZero,
+    #[display(fmt = "Gas price is too large")]
+    GasPriceIsTooLarge,
+    #[display(fmt = "Gas limit is too low")]
+    GasLimitIsTooLow,
+    #[display(fmt = "Gas limit is too large")]
+    GasLimitIsTooLarge,
+    #[display(fmt = "Gas limit is zero")]
+    GasLimitIsZero,
+    #[display(fmt = "Transaction is not signed")]
+    TransactionIsNotSigned,
+    #[display(fmt = "Cannot get receipt by hash")]
+    CannotGetReceiptByHash,
+    #[display(fmt = "Cannot get latest block")]
+    CannotGetLatestBlock,
+    #[display(fmt = "Invalid block hash")]
+    InvalidBlockHash,
+    #[display(fmt = "Invalid from block number {}", _0)]
+    InvalidFromBlockNumber(u64),
+    #[display(fmt = "Invalid block range from {} to {} limit to {}", _0, _1, _2)]
+    InvalidBlockRange(u64, u64, u64),
+    #[display(fmt = "Invalid newest block {:?}", _0)]
+    InvalidNewestBlock(BlockId),
+    #[display(fmt = "Invalid position {}", _0)]
+    InvalidPosition(u64),
+    #[display(fmt = "Cannot find block")]
+    CannotFindBlock,
+    #[display(fmt = "Invalid reward percentiles {} {}", _0, _1)]
+    InvalidRewardPercentiles(f64, f64),
+    #[display(fmt = "Invalid from block number and to block number union")]
+    InvalidFromBlockAndToBlockUnion,
+    #[display(fmt = "Invalid filter id {}", _0)]
+    CannotFindFilterId(u64),
+
+    #[display(fmt = "CKB-VM error {}", "decode_revert_msg(&_0.ret)")]
     VM(TxResp),
+    #[display(fmt = "Internal error")]
+    Internal(String),
 }
 
-impl From<RpcError> for Error {
+impl From<RpcError> for String {
     fn from(err: RpcError) -> Self {
-        match err {
-            RpcError::VM(resp) => vm_err(resp),
+        err.to_string()
+    }
+}
+
+impl RpcError {
+    fn code(&self) -> i32 {
+        match self {
+            RpcError::DecodeInteroperationSigR(_) => -40001,
+            RpcError::DecodeInteroperationSigS(_) => -40002,
+            RpcError::InvalidAddressSource => -40003,
+            RpcError::MissingDummyInputCell => -40004,
+            RpcError::CannotFindImageCell => -40005,
+            RpcError::GasPriceIsZero => -40006,
+            RpcError::GasPriceIsTooLarge => -40007,
+            RpcError::GasLimitIsTooLow => -40008,
+            RpcError::GasLimitIsTooLarge => -40009,
+            RpcError::GasLimitIsZero => -40010,
+            RpcError::TransactionIsNotSigned => -40011,
+            RpcError::CannotGetReceiptByHash => -40012,
+            RpcError::CannotGetLatestBlock => -40013,
+            RpcError::InvalidBlockHash => -40014,
+            RpcError::InvalidFromBlockNumber(_) => -40015,
+            RpcError::InvalidBlockRange(_, _, _) => -40016,
+            RpcError::InvalidNewestBlock(_) => -40017,
+            RpcError::InvalidPosition(_) => -40018,
+            RpcError::CannotFindBlock => -40019,
+            RpcError::InvalidRewardPercentiles(_, _) => -40020,
+            RpcError::InvalidFromBlockAndToBlockUnion => -40021,
+            RpcError::CannotFindFilterId(_) => -40022,
+
+            RpcError::VM(_) => -49998,
+            RpcError::Internal(_) => -49999,
         }
     }
 }
 
-pub fn vm_err(resp: TxResp) -> Error {
-    let data = match resp.exit_reason {
+impl From<RpcError> for ErrorObjectOwned {
+    fn from(err: RpcError) -> Self {
+        let none_data: Option<String> = None;
+        let err_code = err.code();
+        match &err {
+            RpcError::DecodeInteroperationSigR(msg) => {
+                ErrorObject::owned(err_code, err.clone(), Some(msg))
+            }
+            RpcError::DecodeInteroperationSigS(msg) => {
+                ErrorObject::owned(err_code, err.clone(), Some(msg))
+            }
+            RpcError::InvalidAddressSource => ErrorObject::owned(err_code, err, none_data),
+            RpcError::MissingDummyInputCell => ErrorObject::owned(err_code, err, none_data),
+            RpcError::CannotFindImageCell => ErrorObject::owned(err_code, err, none_data),
+            RpcError::GasPriceIsZero => ErrorObject::owned(err_code, err, none_data),
+            RpcError::GasPriceIsTooLarge => ErrorObject::owned(err_code, err, none_data),
+            RpcError::GasLimitIsTooLow => ErrorObject::owned(err_code, err, none_data),
+            RpcError::GasLimitIsTooLarge => ErrorObject::owned(err_code, err, none_data),
+            RpcError::GasLimitIsZero => ErrorObject::owned(err_code, err, none_data),
+            RpcError::TransactionIsNotSigned => ErrorObject::owned(err_code, err, none_data),
+            RpcError::CannotGetReceiptByHash => ErrorObject::owned(err_code, err, none_data),
+            RpcError::CannotGetLatestBlock => ErrorObject::owned(err_code, err, none_data),
+            RpcError::InvalidBlockHash => ErrorObject::owned(err_code, err, none_data),
+            RpcError::InvalidFromBlockNumber(_) => ErrorObject::owned(err_code, err, none_data),
+            RpcError::InvalidBlockRange(_, _, _) => ErrorObject::owned(err_code, err, none_data),
+            RpcError::InvalidNewestBlock(_) => ErrorObject::owned(err_code, err, none_data),
+            RpcError::InvalidPosition(_) => ErrorObject::owned(err_code, err, none_data),
+            RpcError::CannotFindBlock => ErrorObject::owned(err_code, err, none_data),
+            RpcError::InvalidRewardPercentiles(_, _) => {
+                ErrorObject::owned(err_code, err, none_data)
+            }
+            RpcError::InvalidFromBlockAndToBlockUnion => {
+                ErrorObject::owned(err_code, err, none_data)
+            }
+            RpcError::CannotFindFilterId(_) => ErrorObject::owned(err_code, err, none_data),
+
+            RpcError::VM(resp) => {
+                ErrorObject::owned(err_code, err.clone(), Some(vm_err(resp.clone())))
+            }
+            RpcError::Internal(msg) => ErrorObject::owned(err_code, err.clone(), Some(msg)),
+        }
+    }
+}
+
+pub fn vm_err(resp: TxResp) -> String {
+    match resp.exit_reason {
         ExitReason::Revert(_) => format!("0x{}", hex_encode(&resp.ret),),
         ExitReason::Error(err) => format!("{:?}", err),
         ExitReason::Fatal(fatal) => format!("{:?}", fatal),
         _ => unreachable!(),
-    };
-
-    into_rpc_err(ErrorObject::owned(
-        EXEC_ERROR,
-        decode_revert_msg(&resp.ret),
-        Some(data),
-    ))
-}
-
-fn into_rpc_err(obj: ErrorObject<'static>) -> Error {
-    CallError::Custom(obj).into()
+    }
 }

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -106,19 +106,19 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
             .adapter
             .hardfork_info(Context::new())
             .await
-            .map_err(|e| Error::Custom(e.to_string()))?;
+            .map_err(|e| RpcError::Internal(e.to_string()))?;
 
         let proposal = self
             .adapter
             .hardfork_proposal(Context::new())
             .await
-            .map_err(|e| Error::Custom(e.to_string()))?;
+            .map_err(|e| RpcError::Internal(e.to_string()))?;
 
         let current_number = self
             .adapter
             .get_block_header_by_number(Default::default(), None)
             .await
-            .map_err(|e| Error::Custom(e.to_string()))?
+            .map_err(|e| RpcError::Internal(e.to_string()))?
             .unwrap()
             .number;
 

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use jsonrpsee::core::Error;
+use jsonrpsee::{core::RpcResult, types::error::ErrorCode};
 use strum::IntoEnumIterator;
 
 use common_config_parser::types::spec::HardforkName;
@@ -11,7 +11,7 @@ use protocol::types::{
 };
 
 use crate::jsonrpc::web3_types::{BlockId, HardforkStatus};
-use crate::jsonrpc::{AxonRpcServer, RpcResult};
+use crate::jsonrpc::{error::RpcError, AxonRpcServer};
 
 pub struct AxonRpcImpl<Adapter> {
     adapter: Arc<Adapter>,
@@ -34,9 +34,9 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
                     .await
             }
             BlockId::Latest => self.adapter.get_block_by_number(Context::new(), None).await,
-            _ => return Err(Error::InvalidRequestId),
+            _ => return Err(ErrorCode::InvalidRequest.into()),
         }
-        .map_err(|e| Error::Custom(e.to_string()))?;
+        .map_err(|e| RpcError::Internal(e.to_string()))?;
 
         Ok(ret)
     }
@@ -54,7 +54,7 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
             .adapter
             .get_metadata_by_number(Context::new(), Some(block_number.as_u64()))
             .await
-            .map_err(|e| Error::Custom(e.to_string()))?;
+            .map_err(|e| RpcError::Internal(e.to_string()))?;
 
         Ok(ret)
     }
@@ -65,14 +65,14 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
             .adapter
             .get_block_by_number(Context::new(), Some(block_number - 1))
             .await
-            .map_err(|e| Error::Custom(e.to_string()))?
-            .ok_or_else(|| Error::Custom("prev block not found".to_string()))?;
+            .map_err(|e| RpcError::Internal(e.to_string()))?
+            .ok_or_else(|| RpcError::Internal("prev block not found".to_string()))?;
         let block = self
             .adapter
             .get_block_by_number(Context::new(), Some(block_number))
             .await
-            .map_err(|e| Error::Custom(e.to_string()))?
-            .ok_or_else(|| Error::Custom("block not found".to_string()))?;
+            .map_err(|e| RpcError::Internal(e.to_string()))?
+            .ok_or_else(|| RpcError::Internal("block not found".to_string()))?;
 
         Ok(Proposal::new_with_state_root(
             &block.header,
@@ -86,7 +86,7 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
             .adapter
             .get_metadata_by_number(Context::new(), None)
             .await
-            .map_err(|e| Error::Custom(e.to_string()))?;
+            .map_err(|e| RpcError::Internal(e.to_string()))?;
 
         Ok(ret)
     }
@@ -96,7 +96,7 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
             .adapter
             .get_ckb_related_info(Context::new())
             .await
-            .map_err(|e| Error::Custom(e.to_string()))?;
+            .map_err(|e| RpcError::Internal(e.to_string()))?;
 
         Ok(ret)
     }

--- a/core/api/src/jsonrpc/impl/ckb_light_client.rs
+++ b/core/api/src/jsonrpc/impl/ckb_light_client.rs
@@ -4,13 +4,13 @@ use ckb_jsonrpc_types::{CellData, CellInfo, HeaderView as CkbHeaderView, JsonByt
 use ckb_traits::HeaderProvider;
 use ckb_types::core::cell::{CellProvider, CellStatus};
 use ckb_types::{packed, prelude::Pack};
+use jsonrpsee::core::RpcResult;
 
 use core_executor::DataProvider;
-use jsonrpsee::core::Error;
 use protocol::traits::{APIAdapter, Context};
 use protocol::{async_trait, ckb_blake2b_256, types::H256};
 
-use crate::jsonrpc::{CkbLightClientRpcServer, RpcResult};
+use crate::jsonrpc::{error::RpcError, CkbLightClientRpcServer};
 
 #[derive(Clone, Debug)]
 pub struct CkbLightClientRpcImpl<Adapter: APIAdapter> {
@@ -24,7 +24,7 @@ impl<Adapter: APIAdapter + 'static> CkbLightClientRpcServer for CkbLightClientRp
             .adapter
             .get_image_cell_root(Context::new())
             .await
-            .map_err(|e| Error::Custom(e.to_string()))?;
+            .map_err(|e| RpcError::Internal(e.to_string()))?;
         Ok(DataProvider::new(root)
             .get_header(&(hash.0.pack()))
             .map(Into::into))
@@ -40,7 +40,7 @@ impl<Adapter: APIAdapter + 'static> CkbLightClientRpcServer for CkbLightClientRp
             .adapter
             .get_image_cell_root(Context::new())
             .await
-            .map_err(|e| Error::Custom(e.to_string()))?;
+            .map_err(|e| RpcError::Internal(e.to_string()))?;
 
         match DataProvider::new(root).cell(&out_point, false) {
             CellStatus::Live(c) => {

--- a/core/db/src/rocks.rs
+++ b/core/db/src/rocks.rs
@@ -295,7 +295,6 @@ impl From<RocksDBError> for ProtocolError {
     }
 }
 
-// column family "c0" is reserved for store version
 const C_VERSION: &str = "c0";
 const C_BLOCKS: &str = "c1";
 const C_BLOCK_HEADER: &str = "c2";

--- a/core/executor/Cargo.toml
+++ b/core/executor/Cargo.toml
@@ -8,8 +8,8 @@ version = "0.1.0"
 arc-swap = "1.6"
 az = "1.2"
 bn = { package = "substrate-bn", version = "0.6" }
-ckb-traits = "0.108"
-ckb-types = "0.108"
+ckb-traits = "0.111"
+ckb-types = "0.111"
 common-apm = { path = "../../common/apm" }
 common-config-parser = { path = "../../common/config-parser" }
 common-crypto = { path = "../../common/crypto" }
@@ -36,8 +36,8 @@ thiserror = "1.0"
 
 [dev-dependencies]
 bytemuck = "1.13"
-ckb-jsonrpc-types = "0.108"
-ckb-types = "0.108"
+ckb-jsonrpc-types = "0.111"
+ckb-types = "0.111"
 common-crypto = { path = "../../common/crypto" }
 core-rpc-client = { path = "../rpc-client" }
 core-storage = { path = "../storage" }

--- a/core/executor/src/precompiles/verify_by_ckb_vm.rs
+++ b/core/executor/src/precompiles/verify_by_ckb_vm.rs
@@ -30,7 +30,7 @@ impl PrecompileContract for CkbVM {
         if let Some(gas) = gas_limit {
             let res = InteroperationImpl::verify_by_ckb_vm(
                 Default::default(),
-                &DataProvider::new(CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow())),
+                DataProvider::new(CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow())),
                 &InteroperationImpl::dummy_transaction(
                     SignatureR::new_by_ref(
                         payload.cell_deps(),

--- a/core/interoperation/Cargo.toml
+++ b/core/interoperation/Cargo.toml
@@ -7,10 +7,11 @@ edition = "2021"
 
 [dependencies]
 arc-swap = "1.5"
-ckb-error = "0.108"
-ckb-script = "0.108"
-ckb-traits = "0.108"
-ckb-types = "0.108"
+ckb-chain-spec = "0.111"
+ckb-error = "0.111"
+ckb-script = "0.111"
+ckb-traits = "0.111"
+ckb-types = "0.111"
 ckb-vm = { version = "0.22.2", features = ["asm"] }
 lazy_static = "1.4"
 log = "0.4"
@@ -20,7 +21,7 @@ protocol = { path = "../../protocol", package = "axon-protocol", default-feature
 [dev-dependencies]
 cardano-serialization-lib = "7.0"
 cardano-message-signing = { git = "https://github.com/ashuralyk/message-signing", branch = "rust" }
-ckb-jsonrpc-types = "0.108"
+ckb-jsonrpc-types = "0.111"
 ed25519-dalek = "1.0"
 ethers-core = "2.0"
 serde_json = "1.0"

--- a/core/interoperation/Cargo.toml
+++ b/core/interoperation/Cargo.toml
@@ -12,7 +12,7 @@ ckb-error = "0.111"
 ckb-script = "0.111"
 ckb-traits = "0.111"
 ckb-types = "0.111"
-ckb-vm = { version = "0.22.2", features = ["asm"] }
+ckb-vm = { version = "=0.24.6", features = ["asm"] }
 lazy_static = "1.4"
 log = "0.4"
 

--- a/core/interoperation/src/lib.rs
+++ b/core/interoperation/src/lib.rs
@@ -3,16 +3,17 @@
 mod tests;
 pub mod utils;
 
-use std::error::Error;
+use std::{error::Error, sync::Arc};
 
-use ckb_script::TransactionScriptsVerifier;
-use ckb_traits::{CellDataProvider, HeaderProvider};
-use ckb_types::core::{cell::CellProvider, Cycle, TransactionView};
-use ckb_types::packed;
+use ckb_chain_spec::consensus::Consensus;
+use ckb_script::{TransactionScriptsVerifier, TxVerifyEnv};
+use ckb_traits::CellDataProvider;
+use ckb_types::core::{Cycle, HeaderBuilder, TransactionView};
+use ckb_types::{h256, packed, prelude::Pack, H256};
 use ckb_vm::machine::{asm::AsmCoreMachine, DefaultMachineBuilder, SupportMachine, VERSION1};
 use ckb_vm::{Error as VMError, ISA_B, ISA_IMC, ISA_MOP};
 
-use protocol::traits::{Context, Interoperation};
+use protocol::traits::{CkbDataProvider, Context, Interoperation};
 use protocol::types::{Bytes, CellDep, CellWithData, OutPoint, VMResp};
 use protocol::{Display, ProtocolError, ProtocolErrorKind, ProtocolResult};
 
@@ -20,6 +21,13 @@ use crate::utils::resolve_transaction;
 
 const ISA: u8 = ISA_IMC | ISA_B | ISA_MOP;
 const GAS_TO_CYCLE_COEF: u64 = 6_000;
+
+// The following information is from CKB block [10976708](https://explorer.nervos.org/block/10976708)
+// which is CKB2023 disabled.
+const CKB2023_DISABLED_NUMBER: u64 = 10_976_708;
+const CKB2023_DISABLED_EPOCH: u64 = 0x53c007f0020c8;
+const CKB2023_DISABLED_PARENT_HASH: H256 =
+    h256!("0xeed08d487af4723238ef82b4e4388e2ad2dc8dc28e4e759f5d891eeab79ff3ff");
 
 pub const fn gas_to_cycle(gas: u64) -> u64 {
     gas * GAS_TO_CYCLE_COEF
@@ -74,17 +82,34 @@ impl Interoperation for InteroperationImpl {
         })
     }
 
-    fn verify_by_ckb_vm<DL: CellProvider + CellDataProvider + HeaderProvider>(
+    /// Todo: After CKB2023 is enabled, a hardfork is needed to support the new
+    /// VM version and syscalls.
+    fn verify_by_ckb_vm<DL: CkbDataProvider + Sync + Send + 'static>(
         _ctx: Context,
-        data_loader: &DL,
+        data_loader: DL,
         mocked_tx: &TransactionView,
         dummy_input: Option<CellWithData>,
         max_cycles: u64,
     ) -> ProtocolResult<Cycle> {
-        let rtx = resolve_transaction(data_loader, mocked_tx, dummy_input)?;
+        let rtx = Arc::new(resolve_transaction(&data_loader, mocked_tx, dummy_input)?);
         log::debug!("[mempool]: Verify by ckb vm tx {:?}", rtx);
 
-        TransactionScriptsVerifier::new(&rtx, data_loader)
+        // The consensus and tx_env arguments are used for judge if the VM version2 and
+        // syscalls3 are enabled. Due to only the hardfork field in consensus and the
+        // epoch field in tx_env is used, the provided arguments only need to fill these
+        // fields correctly.
+        let (ckb_spec, ckb2023_disabled_env) = {
+            let consensus = Arc::new(Consensus::default());
+            let header = HeaderBuilder::default()
+                .number(CKB2023_DISABLED_NUMBER.pack())
+                .epoch(CKB2023_DISABLED_EPOCH.pack())
+                .parent_hash(CKB2023_DISABLED_PARENT_HASH.pack())
+                .build();
+            let tx_env = Arc::new(TxVerifyEnv::new_commit(&header));
+            (consensus, tx_env)
+        };
+
+        TransactionScriptsVerifier::new(rtx, data_loader, ckb_spec, ckb2023_disabled_env)
             .verify(max_cycles)
             .map_err(|e| InteroperationError::Ckb(e).into())
     }

--- a/core/interoperation/src/lib.rs
+++ b/core/interoperation/src/lib.rs
@@ -9,7 +9,7 @@ use ckb_chain_spec::consensus::Consensus;
 use ckb_script::{TransactionScriptsVerifier, TxVerifyEnv};
 use ckb_traits::CellDataProvider;
 use ckb_types::core::{Cycle, HeaderBuilder, TransactionView};
-use ckb_types::{h256, packed, prelude::Pack, H256};
+use ckb_types::{packed, prelude::Pack};
 use ckb_vm::machine::{asm::AsmCoreMachine, DefaultMachineBuilder, SupportMachine, VERSION1};
 use ckb_vm::{Error as VMError, ISA_B, ISA_IMC, ISA_MOP};
 
@@ -26,8 +26,6 @@ const GAS_TO_CYCLE_COEF: u64 = 6_000;
 // which is CKB2023 disabled.
 const CKB2023_DISABLED_NUMBER: u64 = 10_976_708;
 const CKB2023_DISABLED_EPOCH: u64 = 0x53c007f0020c8;
-const CKB2023_DISABLED_PARENT_HASH: H256 =
-    h256!("0xeed08d487af4723238ef82b4e4388e2ad2dc8dc28e4e759f5d891eeab79ff3ff");
 
 pub const fn gas_to_cycle(gas: u64) -> u64 {
     gas * GAS_TO_CYCLE_COEF
@@ -98,16 +96,15 @@ impl Interoperation for InteroperationImpl {
         // syscalls3 are enabled. Due to only the hardfork field in consensus and the
         // epoch field in tx_env is used, the provided arguments only need to fill these
         // fields correctly.
-        let (ckb_spec, ckb2023_disabled_env) = {
-            let consensus = Arc::new(Consensus::default());
-            let header = HeaderBuilder::default()
-                .number(CKB2023_DISABLED_NUMBER.pack())
-                .epoch(CKB2023_DISABLED_EPOCH.pack())
-                .parent_hash(CKB2023_DISABLED_PARENT_HASH.pack())
-                .build();
-            let tx_env = Arc::new(TxVerifyEnv::new_commit(&header));
-            (consensus, tx_env)
-        };
+        let (ckb_spec, ckb2023_disabled_env) = (
+            Arc::new(Consensus::default()),
+            Arc::new(TxVerifyEnv::new_commit(
+                &HeaderBuilder::default()
+                    .number(CKB2023_DISABLED_NUMBER.pack())
+                    .epoch(CKB2023_DISABLED_EPOCH.pack())
+                    .build(),
+            )),
+        );
 
         TransactionScriptsVerifier::new(rtx, data_loader, ckb_spec, ckb2023_disabled_env)
             .verify(max_cycles)

--- a/core/mempool/Cargo.toml
+++ b/core/mempool/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-types = "0.108"
+ckb-types = "0.111"
 crossbeam-queue = "0.3"
 dashmap = { version = "5.5", features = ["rayon"] }
-futures = { version = "0.3", features = [ "async-await" ] }
+futures = { version = "0.3", features = ["async-await"] }
 log = "0.4"
 parking_lot = "0.12"
 rlp = "0.5"

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -319,7 +319,7 @@ where
 
                 InteroperationImpl::verify_by_ckb_vm(
                     Default::default(),
-                    &DataProvider::new(root),
+                    DataProvider::new(root),
                     &InteroperationImpl::dummy_transaction(
                         r.clone(),
                         s,

--- a/core/rpc-client/Cargo.toml
+++ b/core/rpc-client/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-jsonrpc-types = "0.108"
-ckb-sdk = "2.5"
-ckb-types = "0.108"
+ckb-jsonrpc-types = "0.111"
+ckb-sdk = "3.0"
+ckb-types = "0.111"
 futures = "0.3"
 jsonrpc-core = "18.0"
 reqwest = { version = "0.11", features = ["json"] }

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -26,13 +26,12 @@ use protocol::types::{
 use protocol::{
     async_trait, tokio, Display, From, ProtocolError, ProtocolErrorKind, ProtocolResult,
 };
-use schema::HardforkSchema;
 
 use crate::cache::StorageCache;
 use crate::hash_key::{BlockKey, CommonHashKey, CommonPrefix};
 use crate::schema::{
     BlockHashNumberSchema, BlockHeaderSchema, BlockSchema, EvmCodeAddressSchema, EvmCodeSchema,
-    LatestBlockSchema, LatestProofSchema, ReceiptBytesSchema, ReceiptSchema,
+    HardforkSchema, LatestBlockSchema, LatestProofSchema, ReceiptBytesSchema, ReceiptSchema,
     TransactionBytesSchema, TransactionSchema, TxHashNumberSchema,
 };
 

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -9,15 +9,21 @@ arc-swap = "1.6"
 async-trait = "0.1"
 bincode = "1.3"
 bytes = { version = "1.5", features = ["serde"] }
-ckb-hash = "0.108"
-ckb-jsonrpc-types = "0.108"
-ckb-sdk = "2.5"
-ckb-traits = "0.108"
-ckb-types = "0.108"
+ckb-hash = "0.111"
+ckb-jsonrpc-types = "0.111"
+ckb-sdk = "3.0"
+ckb-traits = "0.111"
+ckb-types = "0.111"
 creep = "0.2"
 derive_more = "0.99"
 ethereum = { version = "0.14", features = ["with-codec", "with-serde"] }
-ethereum-types = { version = "0.14", features = ["arbitrary", "codec", "rlp", "serialize", "std"] }
+ethereum-types = { version = "0.14", features = [
+    "arbitrary",
+    "codec",
+    "rlp",
+    "serialize",
+    "std",
+] }
 ethers-core = "2.0"
 evm = { version = "0.37", features = ["with-serde"] }
 faster-hex = "0.8"

--- a/protocol/src/traits/interoperation.rs
+++ b/protocol/src/traits/interoperation.rs
@@ -1,4 +1,4 @@
-use ckb_traits::{CellDataProvider, HeaderProvider};
+use ckb_traits::{CellDataProvider, ExtensionProvider, HeaderProvider};
 use ckb_types::core::{cell::CellProvider, Cycle, TransactionView};
 use ckb_types::{packed, prelude::*};
 
@@ -24,6 +24,11 @@ const fn signature_hash_cell_bytes() -> u64 {
     32 + 32 + 1 + 8
 }
 
+pub trait CkbDataProvider:
+    Clone + CellDataProvider + CellProvider + HeaderProvider + ExtensionProvider
+{
+}
+
 pub trait Interoperation: Sync + Send {
     fn call_ckb_vm<DL: CellDataProvider>(
         ctx: Context,
@@ -33,9 +38,9 @@ pub trait Interoperation: Sync + Send {
         max_cycles: u64,
     ) -> ProtocolResult<VMResp>;
 
-    fn verify_by_ckb_vm<DL: CellProvider + CellDataProvider + HeaderProvider>(
+    fn verify_by_ckb_vm<DL: CkbDataProvider + Sync + Send + 'static>(
         ctx: Context,
-        data_loader: &DL,
+        data_loader: DL,
         mocked_tx: &TransactionView,
         dummy_input: Option<CellWithData>,
         max_cycles: u64,

--- a/protocol/src/traits/mod.rs
+++ b/protocol/src/traits/mod.rs
@@ -15,7 +15,9 @@ pub use consensus::{
 };
 pub use creep::{Cloneable, Context};
 pub use executor::{ApplyBackend, Backend, Executor, ExecutorAdapter, ExecutorReadOnlyAdapter};
-pub use interoperation::{Interoperation, BYTE_SHANNONS, SIGNATURE_HASH_CELL_OCCUPIED_CAPACITY};
+pub use interoperation::{
+    CkbDataProvider, Interoperation, BYTE_SHANNONS, SIGNATURE_HASH_CELL_OCCUPIED_CAPACITY,
+};
 pub use mempool::{MemPool, MemPoolAdapter};
 pub use network::{
     Gossip, MessageCodec, MessageHandler, Network, PeerTag, PeerTrust, Priority, Rpc, TrustFeedback,

--- a/tests/e2e/src/eth_getStorageAt.test.js
+++ b/tests/e2e/src/eth_getStorageAt.test.js
@@ -92,7 +92,7 @@ describe("eth_getStorageAt", () => {
     await param1.type(testDataInfo.contractAddress);
     await param2.type("0x02");
     await param3.type("0xffffffffff");
-    await goto.check(page, "Can't find this block");
+    await goto.check(page, "Cannot find the block");
   });
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR:
1. Bump CKB related crates version to 0.111 which include 2023 hardfork.
2. Bump [jsonrpsee](https://crates.io/crates/jsonrpsee) version to 0.20 which includes some [breaking changes](https://github.com/paritytech/jsonrpsee/blob/master/CHANGELOG.md)

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] E2E Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
