### PR TITLE
fix: revert jsonrpc type

### DIFF
--- a/core/api/src/jsonrpc/web3_types.rs
+++ b/core/api/src/jsonrpc/web3_types.rs
@@ -300,7 +300,7 @@ pub struct Web3Block {
     pub number:            U256,
     pub gas_used:          U256,
     pub gas_limit:         U256,
-    pub extra_data:        Vec<Hex>,
+    pub extra_data:        Hex,
     pub logs_bloom:        Option<Bloom>,
     pub timestamp:         U256,
     pub difficulty:        U256,
@@ -331,12 +331,7 @@ impl From<Block> for Web3Block {
             total_difficulty:  Some(b.header.number.into()),
             seal_fields:       vec![],
             base_fee_per_gas:  b.header.base_fee_per_gas,
-            extra_data:        b
-                .header
-                .extra_data
-                .iter()
-                .map(|i| Hex::encode(&i.inner.encode().unwrap()))
-                .collect(),
+            extra_data:        Hex::encode(rlp::encode_list(&b.header.extra_data)),
             size:              Some(b.header.size().into()),
             gas_limit:         b.header.gas_limit,
             gas_used:          b.header.gas_used,
@@ -826,7 +821,7 @@ pub struct FeeHistoryEmpty {
 #[serde(rename_all = "camelCase")]
 pub struct Web3Header {
     pub difficulty:        U256,
-    pub extra_data:        Vec<Hex>,
+    pub extra_data:        Hex,
     pub gas_limit:         U256,
     pub gas_used:          U256,
     pub logs_bloom:        Option<Bloom>,
@@ -854,11 +849,7 @@ impl From<Header> for Web3Header {
             receipts_root:     h.receipts_root,
             miner:             h.proposer,
             difficulty:        U256::one(),
-            extra_data:        h
-                .extra_data
-                .into_iter()
-                .map(|i| Hex::encode(i.inner.encode().unwrap()))
-                .collect(),
+            extra_data:        Hex::encode(rlp::encode_list(&h.extra_data)),
             gas_limit:         h.gas_limit,
             gas_used:          h.gas_used,
             timestamp:         h.timestamp.into(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR revert jsonrpc type to `Hex`

### What is the impact of this PR?

No Breaking Change


<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] E2E Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
