### PR TITLE
ci: use `Cache of Cargo` for workflows

### DIFF
--- a/.github/workflows/openzeppelin_test_11.yml
+++ b/.github/workflows/openzeppelin_test_11.yml
@@ -97,13 +97,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node_modules-
 
-      - name: Cache of the axon binary
+      - name: Cache of Cargo
         uses: actions/cache@v3
         with:
           path: |
-            target/debug/axon
-            target/release/axon
-          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build Axon in the development profile
+        run: cargo build
 
       - name: Deploy Local Network of Axon
         run: |
@@ -116,6 +121,18 @@ jobs:
           ./target/debug/axon run  \
             --config     devtools/chain/config.toml \
             >> /tmp/log 2>&1 &
+
+      - name: Check Axon Status Before Test
+        run: |
+          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+          http_code=$(echo "$response" | tail -n1)
+          response_body=$(echo "$response" | sed '$d')
+          if [[ "$http_code" -ne 200 ]]; then
+            echo "Axon status check failed with HTTP status code: $http_code"
+            exit 1
+          else
+            echo "$response_body"
+          fi
 
       - name: Run prepare
         id: runtest

--- a/.github/workflows/openzeppelin_test_16_19.yml
+++ b/.github/workflows/openzeppelin_test_16_19.yml
@@ -97,13 +97,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node_modules-
 
-      - name: Cache of the axon binary
+      - name: Cache of Cargo
         uses: actions/cache@v3
         with:
           path: |
-            target/debug/axon
-            target/release/axon
-          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build Axon in the development profile
+        run: cargo build
 
       - name: Deploy Local Network of Axon
         run: |
@@ -116,6 +121,18 @@ jobs:
           ./target/debug/axon run  \
             --config     devtools/chain/config.toml \
             >> /tmp/log 2>&1 &
+
+      - name: Check Axon Status Before Test
+        run: |
+          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+          http_code=$(echo "$response" | tail -n1)
+          response_body=$(echo "$response" | sed '$d')
+          if [[ "$http_code" -ne 200 ]]; then
+            echo "Axon status check failed with HTTP status code: $http_code"
+            exit 1
+          else
+            echo "$response_body"
+          fi
 
       - name: Run prepare
         id: runtest

--- a/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
+++ b/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
@@ -98,13 +98,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node_modules-
 
-      - name: Cache of the axon binary
+      - name: Cache of Cargo
         uses: actions/cache@v3
         with:
           path: |
-            target/debug/axon
-            target/release/axon
-          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build Axon in the development profile
+        run: cargo build
 
       - name: Deploy Local Network of Axon
         run: |
@@ -117,6 +122,18 @@ jobs:
           ./target/debug/axon run  \
             --config     devtools/chain/config.toml \
             >> /tmp/log 2>&1 &
+
+      - name: Check Axon Status Before Test
+        run: |
+          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+          http_code=$(echo "$response" | tail -n1)
+          response_body=$(echo "$response" | sed '$d')
+          if [[ "$http_code" -ne 200 ]]; then
+            echo "Axon status check failed with HTTP status code: $http_code"
+            exit 1
+          else
+            echo "$response_body"
+          fi
 
       - name: Run prepare
         id: runtest

--- a/.github/workflows/openzeppelin_test_6_10.yml
+++ b/.github/workflows/openzeppelin_test_6_10.yml
@@ -97,13 +97,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node_modules-
 
-      - name: Cache of the axon binary
+      - name: Cache of Cargo
         uses: actions/cache@v3
         with:
           path: |
-            target/debug/axon
-            target/release/axon
-          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build Axon in the development profile
+        run: cargo build
 
       - name: Deploy Local Network of Axon
         run: |
@@ -116,6 +121,19 @@ jobs:
           ./target/debug/axon run  \
             --config     devtools/chain/config.toml \
             >> /tmp/log 2>&1 &
+
+      - name: Check Axon Status Before Test
+        run: |
+          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+          http_code=$(echo "$response" | tail -n1)
+          response_body=$(echo "$response" | sed '$d')
+          if [[ "$http_code" -ne 200 ]]; then
+            echo "Axon status check failed with HTTP status code: $http_code"
+            exit 1
+          else
+            echo "$response_body"
+          fi
+
       - name: Run prepare
         id: runtest
         run: |

--- a/.github/workflows/v3_core_test.yml
+++ b/.github/workflows/v3_core_test.yml
@@ -82,17 +82,21 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20.x
-
       - id: yarn-cache
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - name: Cache of the axon binary
+      - name: Cache of Cargo
         uses: actions/cache@v3
         with:
           path: |
-            target/debug/axon
-            target/release/axon
-          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-axon-${{ github.sha }}
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build Axon in the development profile
+        run: cargo build
 
       - name: Deploy Local Network of Axon
         run: |
@@ -105,6 +109,19 @@ jobs:
           ./target/debug/axon run  \
             --config     devtools/chain/config.toml \
             >> /tmp/log 2>&1 &
+
+      - name: Check Axon Status Before Test
+        run: |
+          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+          http_code=$(echo "$response" | tail -n1)
+          response_body=$(echo "$response" | sed '$d')
+          if [[ "$http_code" -ne 200 ]]; then
+            echo "Axon status check failed with HTTP status code: $http_code"
+            exit 1
+          else
+            echo "$response_body"
+          fi
+
       - name: Install dependencies
         run: |
           cd /home/runner/work/axon/axon/v3-core


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

1. use "Cache of Cargo" 
2. check Axon node status before test
### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Fix the problem of https://github.com/axonweb3/axon/pull/1444 checks not passing

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] E2E Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
