### PR TITLE
ci: fix the check logic for Axon node status

### DIFF
--- a/.github/workflows/openzeppelin_test_11.yml
+++ b/.github/workflows/openzeppelin_test_11.yml
@@ -124,6 +124,7 @@ jobs:
 
       - name: Check Axon Status Before Test
         run: |
+          sleep 20
           response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
           http_code=$(echo "$response" | tail -n1)
           response_body=$(echo "$response" | sed '$d')
@@ -135,6 +136,7 @@ jobs:
           fi
 
       - name: Run prepare
+        if: success() || failure()
         id: runtest
         run: |
           cd /home/runner/work/axon/axon/openzeppelin-contracts

--- a/.github/workflows/openzeppelin_test_11.yml
+++ b/.github/workflows/openzeppelin_test_11.yml
@@ -124,16 +124,23 @@ jobs:
 
       - name: Check Axon Status Before Test
         run: |
-          sleep 20
-          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
-          http_code=$(echo "$response" | tail -n1)
-          response_body=$(echo "$response" | sed '$d')
-          if [[ "$http_code" -ne 200 ]]; then
-            echo "Axon status check failed with HTTP status code: $http_code"
-            exit 1
-          else
-            echo "$response_body"
-          fi
+          MAX_RETRIES=10
+          for i in $(seq 1 $MAX_RETRIES); do
+            sleep 10
+            response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+            http_code=$(echo "$response" | tail -n1)
+            response_body=$(echo "$response" | sed '$d')
+            if [[ "$http_code" -eq 200 ]]; then
+              echo "$response_body"
+              exit 0
+            else
+              echo "Axon status check failed with HTTP status code: $http_code, retrying ($i/$MAX_RETRIES)"
+              if [[ "$i" -eq $MAX_RETRIES ]]; then
+                echo "Axon status check failed after $MAX_RETRIES attempts."
+                exit 1
+              fi
+            fi
+          done
 
       - name: Run prepare
         if: success() || failure()

--- a/.github/workflows/openzeppelin_test_16_19.yml
+++ b/.github/workflows/openzeppelin_test_16_19.yml
@@ -124,6 +124,7 @@ jobs:
 
       - name: Check Axon Status Before Test
         run: |
+          sleep 20
           response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
           http_code=$(echo "$response" | tail -n1)
           response_body=$(echo "$response" | sed '$d')
@@ -136,6 +137,7 @@ jobs:
 
       - name: Run prepare
         id: runtest
+        if: success() || failure()
         run: |
           cd /home/runner/work/axon/axon/openzeppelin-contracts
           npm install

--- a/.github/workflows/openzeppelin_test_16_19.yml
+++ b/.github/workflows/openzeppelin_test_16_19.yml
@@ -124,16 +124,23 @@ jobs:
 
       - name: Check Axon Status Before Test
         run: |
-          sleep 20
-          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
-          http_code=$(echo "$response" | tail -n1)
-          response_body=$(echo "$response" | sed '$d')
-          if [[ "$http_code" -ne 200 ]]; then
-            echo "Axon status check failed with HTTP status code: $http_code"
-            exit 1
-          else
-            echo "$response_body"
-          fi
+          MAX_RETRIES=10
+          for i in $(seq 1 $MAX_RETRIES); do
+            sleep 10
+            response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+            http_code=$(echo "$response" | tail -n1)
+            response_body=$(echo "$response" | sed '$d')
+            if [[ "$http_code" -eq 200 ]]; then
+              echo "$response_body"
+              exit 0
+            else
+              echo "Axon status check failed with HTTP status code: $http_code, retrying ($i/$MAX_RETRIES)"
+              if [[ "$i" -eq $MAX_RETRIES ]]; then
+                echo "Axon status check failed after $MAX_RETRIES attempts."
+                exit 1
+              fi
+            fi
+          done
 
       - name: Run prepare
         id: runtest

--- a/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
+++ b/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
@@ -125,6 +125,7 @@ jobs:
 
       - name: Check Axon Status Before Test
         run: |
+          sleep 20
           response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
           http_code=$(echo "$response" | tail -n1)
           response_body=$(echo "$response" | sed '$d')
@@ -136,6 +137,7 @@ jobs:
           fi
 
       - name: Run prepare
+        if: success() || failure()
         id: runtest
         run: |
           cd /home/runner/work/axon/axon/openzeppelin-contracts

--- a/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
+++ b/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
@@ -125,16 +125,23 @@ jobs:
 
       - name: Check Axon Status Before Test
         run: |
-          sleep 20
-          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
-          http_code=$(echo "$response" | tail -n1)
-          response_body=$(echo "$response" | sed '$d')
-          if [[ "$http_code" -ne 200 ]]; then
-            echo "Axon status check failed with HTTP status code: $http_code"
-            exit 1
-          else
-            echo "$response_body"
-          fi
+          MAX_RETRIES=10
+          for i in $(seq 1 $MAX_RETRIES); do
+            sleep 10
+            response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+            http_code=$(echo "$response" | tail -n1)
+            response_body=$(echo "$response" | sed '$d')
+            if [[ "$http_code" -eq 200 ]]; then
+              echo "$response_body"
+              exit 0
+            else
+              echo "Axon status check failed with HTTP status code: $http_code, retrying ($i/$MAX_RETRIES)"
+              if [[ "$i" -eq $MAX_RETRIES ]]; then
+                echo "Axon status check failed after $MAX_RETRIES attempts."
+                exit 1
+              fi
+            fi
+          done
 
       - name: Run prepare
         if: success() || failure()

--- a/.github/workflows/openzeppelin_test_6_10.yml
+++ b/.github/workflows/openzeppelin_test_6_10.yml
@@ -124,6 +124,7 @@ jobs:
 
       - name: Check Axon Status Before Test
         run: |
+          sleep 20
           response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
           http_code=$(echo "$response" | tail -n1)
           response_body=$(echo "$response" | sed '$d')
@@ -135,6 +136,7 @@ jobs:
           fi
 
       - name: Run prepare
+        if: success() || failure()
         id: runtest
         run: |
           cd /home/runner/work/axon/axon/openzeppelin-contracts

--- a/.github/workflows/openzeppelin_test_6_10.yml
+++ b/.github/workflows/openzeppelin_test_6_10.yml
@@ -124,16 +124,23 @@ jobs:
 
       - name: Check Axon Status Before Test
         run: |
-          sleep 20
-          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
-          http_code=$(echo "$response" | tail -n1)
-          response_body=$(echo "$response" | sed '$d')
-          if [[ "$http_code" -ne 200 ]]; then
-            echo "Axon status check failed with HTTP status code: $http_code"
-            exit 1
-          else
-            echo "$response_body"
-          fi
+          MAX_RETRIES=10
+          for i in $(seq 1 $MAX_RETRIES); do
+            sleep 10
+            response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+            http_code=$(echo "$response" | tail -n1)
+            response_body=$(echo "$response" | sed '$d')
+            if [[ "$http_code" -eq 200 ]]; then
+              echo "$response_body"
+              exit 0
+            else
+              echo "Axon status check failed with HTTP status code: $http_code, retrying ($i/$MAX_RETRIES)"
+              if [[ "$i" -eq $MAX_RETRIES ]]; then
+                echo "Axon status check failed after $MAX_RETRIES attempts."
+                exit 1
+              fi
+            fi
+          done
 
       - name: Run prepare
         if: success() || failure()

--- a/.github/workflows/v3_core_test.yml
+++ b/.github/workflows/v3_core_test.yml
@@ -112,6 +112,7 @@ jobs:
 
       - name: Check Axon Status Before Test
         run: |
+          sleep 20
           response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
           http_code=$(echo "$response" | tail -n1)
           response_body=$(echo "$response" | sed '$d')
@@ -132,6 +133,7 @@ jobs:
           cd /home/runner/work/axon/axon/v3-core
           yarn compile
       - name: Run tests 0
+        if: success() || failure()
         id: runtest
         run: |
           cd /home/runner/work/axon/axon/v3-core

--- a/.github/workflows/v3_core_test.yml
+++ b/.github/workflows/v3_core_test.yml
@@ -112,16 +112,23 @@ jobs:
 
       - name: Check Axon Status Before Test
         run: |
-          sleep 20
-          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
-          http_code=$(echo "$response" | tail -n1)
-          response_body=$(echo "$response" | sed '$d')
-          if [[ "$http_code" -ne 200 ]]; then
-            echo "Axon status check failed with HTTP status code: $http_code"
-            exit 1
-          else
-            echo "$response_body"
-          fi
+          MAX_RETRIES=10
+          for i in $(seq 1 $MAX_RETRIES); do
+            sleep 10
+            response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+            http_code=$(echo "$response" | tail -n1)
+            response_body=$(echo "$response" | sed '$d')
+            if [[ "$http_code" -eq 200 ]]; then
+              echo "$response_body"
+              exit 0
+            else
+              echo "Axon status check failed with HTTP status code: $http_code, retrying ($i/$MAX_RETRIES)"
+              if [[ "$i" -eq $MAX_RETRIES ]]; then
+                echo "Axon status check failed after $MAX_RETRIES attempts."
+                exit 1
+              fi
+            fi
+          done
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -77,16 +77,23 @@ jobs:
 
       - name: Check Axon Status Before Test
         run: |
-          sleep 20
-          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
-          http_code=$(echo "$response" | tail -n1)
-          response_body=$(echo "$response" | sed '$d')
-          if [[ "$http_code" -ne 200 ]]; then
-            echo "Axon status check failed with HTTP status code: $http_code"
-            exit 1
-          else
-            echo "$response_body"
-          fi
+          MAX_RETRIES=10
+          for i in $(seq 1 $MAX_RETRIES); do
+            sleep 10
+            response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+            http_code=$(echo "$response" | tail -n1)
+            response_body=$(echo "$response" | sed '$d')
+            if [[ "$http_code" -eq 200 ]]; then
+              echo "$response_body"
+              exit 0
+            else
+              echo "Axon status check failed with HTTP status code: $http_code, retrying ($i/$MAX_RETRIES)"
+              if [[ "$i" -eq $MAX_RETRIES ]]; then
+                echo "Axon status check failed after $MAX_RETRIES attempts."
+                exit 1
+              fi
+            fi
+          done
 
       - name: Checkout gpBlockchain/axon-test
         uses: actions/checkout@v4

--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -75,6 +75,19 @@ jobs:
             --config     devtools/chain/config.toml \
             >> /tmp/log 2>&1 &
 
+      - name: Check Axon Status Before Test
+        run: |
+          sleep 20
+          response=$(curl -s -w "\n%{http_code}" http://localhost:8000 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"web3_clientVersion","params": [],"id":1}')
+          http_code=$(echo "$response" | tail -n1)
+          response_body=$(echo "$response" | sed '$d')
+          if [[ "$http_code" -ne 200 ]]; then
+            echo "Axon status check failed with HTTP status code: $http_code"
+            exit 1
+          else
+            echo "$response_body"
+          fi
+
       - name: Checkout gpBlockchain/axon-test
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR is used to fix the problem of https://github.com/axonweb3/axon/pull/1445

### What is the impact of this PR?

No Breaking Change


<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] E2E Tests
- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
| *Cargo Clippy*                            | Run `cargo clippy --all --all-targets --all-features`                     |
| *Coverage Test*                           | Get the unit test coverage report                                         |
| *E2E Test*                                | Run end-to-end test to check interfaces                                   |
| *Code Format*                             | Run `cargo +nightly fmt --all -- --check` and `cargo sort -gwc`           |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
- [ ] Coverage Test
-->
</details>
