### PR TITLE
feat: first hardfork with contract size limit

### DIFF
--- a/builtin-contract/system-contract/contracts/metadata/Metadata.sol
+++ b/builtin-contract/system-contract/contracts/metadata/Metadata.sol
@@ -38,6 +38,7 @@ library MetadataType {
         uint64 max_tx_size;
         uint64 gas_limit;
         uint64 interval;
+        uint64 max_contract_limit;
     }
 
     struct CkbRelatedInfo {
@@ -56,7 +57,11 @@ library MetadataType {
 interface MetadataManager {
     function appendMetadata(MetadataType.Metadata memory metadata) external;
 
-    function updateConsensusConfig(MetadataType.ConsensusConfig memory config) external;
+    function updateConsensusConfig(
+        MetadataType.ConsensusConfig memory config
+    ) external;
 
-    function setCkbRelatedInfo(MetadataType.CkbRelatedInfo memory info) external;
+    function setCkbRelatedInfo(
+        MetadataType.CkbRelatedInfo memory info
+    ) external;
 }

--- a/common/config-parser/src/types/spec.rs
+++ b/common/config-parser/src/types/spec.rs
@@ -213,12 +213,18 @@ impl Genesis {
             // genesis
             extra_data: {
                 vec![ExtraData {
-                    inner: Into::<HardforkInfoInner>::into(HardforkInput {
-                        hardforks:    self.hardforks.clone(),
-                        block_number: 0,
-                    })
-                    .encode()
-                    .unwrap(),
+                    inner: {
+                        let mut info = Into::<HardforkInfoInner>::into(HardforkInput {
+                            hardforks:    self.hardforks.clone(),
+                            block_number: 0,
+                        });
+
+                        if info.flags.is_zero() {
+                            info.flags = H256::from_low_u64_be(HardforkName::all().to_be());
+                        }
+
+                        info.encode().unwrap()
+                    },
                 }]
             },
             base_fee_per_gas: self.base_fee_per_gas,
@@ -258,4 +264,11 @@ impl From<HardforkInput> for HardforkInfoInner {
 #[derive(Clone, Debug, Serialize, Deserialize, Copy, ValueEnum, EnumIter, PartialEq, Eq, Hash)]
 pub enum HardforkName {
     None = 0b0,
+    Andromeda = 0b1,
+}
+
+impl HardforkName {
+    pub fn all() -> u64 {
+        HardforkName::None as u64 | HardforkName::Andromeda as u64
+    }
 }

--- a/common/config-parser/src/types/spec.rs
+++ b/common/config-parser/src/types/spec.rs
@@ -5,6 +5,7 @@ use clap::{
     Args, ValueEnum,
 };
 use serde::{Deserialize, Serialize};
+use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 use common_crypto::Secp256k1RecoverablePrivateKey;
@@ -261,14 +262,21 @@ impl From<HardforkInput> for HardforkInfoInner {
     }
 }
 
+/// inspired by https://www.wikiwand.com/en/IAU_designated_constellations#List
 #[derive(Clone, Debug, Serialize, Deserialize, Copy, ValueEnum, EnumIter, PartialEq, Eq, Hash)]
 pub enum HardforkName {
     None = 0b0,
+    /// If this hardfork is activated, chain validators can modify the EVM
+    /// contract size limit.
     Andromeda = 0b1,
 }
 
 impl HardforkName {
     pub fn all() -> u64 {
-        HardforkName::Andromeda as u64
+        let mut res = 0u64;
+        for name in HardforkName::iter() {
+            res |= name as u64
+        }
+        res
     }
 }

--- a/common/config-parser/src/types/spec.rs
+++ b/common/config-parser/src/types/spec.rs
@@ -209,28 +209,23 @@ impl Genesis {
             transactions_root: RLP_NULL,
             signed_txs_hash: RLP_EMPTY_LIST,
             timestamp: self.timestamp,
-            // todo: if Hardforkinput is empty, it must change to latest hardfork info to init
-            // genesis
-            extra_data: {
-                vec![ExtraData {
-                    inner: {
-                        let mut info = Into::<HardforkInfoInner>::into(HardforkInput {
-                            hardforks:    self.hardforks.clone(),
-                            block_number: 0,
-                        });
-
-                        if info.flags.is_zero() {
-                            info.flags = H256::from_low_u64_be(HardforkName::all().to_be());
-                        }
-
-                        info.encode().unwrap()
-                    },
-                }]
-            },
             base_fee_per_gas: self.base_fee_per_gas,
             chain_id: self.chain_id,
             ..Default::default()
         }
+    }
+
+    pub fn generate_hardfork_info(&self) -> HardforkInfoInner {
+        let mut info = Into::<HardforkInfoInner>::into(HardforkInput {
+            hardforks:    self.hardforks.clone(),
+            block_number: 0,
+        });
+
+        if info.flags.is_zero() {
+            info.flags = H256::from_low_u64_be(HardforkName::all().to_be());
+        }
+
+        info
     }
 }
 

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -155,10 +155,10 @@ fn enabled_and_determined(iter: &[HardforkInfoInner], current_number: u64) -> (H
     if iter.len() < 2 {
         match iter.last() {
             Some(latest) => {
-                if latest.block_number >= current_number {
-                    (latest.flags, H256::zero())
-                } else {
+                if latest.block_number > current_number {
                     (H256::zero(), latest.flags)
+                } else {
+                    (latest.flags, H256::zero())
                 }
             }
             None => (H256::zero(), H256::zero()),

--- a/core/executor/src/system_contract/metadata/abi/metadata_abi.json
+++ b/core/executor/src/system_contract/metadata/abi/metadata_abi.json
@@ -115,6 +115,11 @@
                 "internalType": "uint64",
                 "name": "interval",
                 "type": "uint64"
+              },
+              {
+                "internalType": "uint64",
+                "name": "max_contract_limit",
+                "type": "uint64"
               }
             ],
             "internalType": "struct MetadataType.ConsensusConfig",
@@ -219,6 +224,11 @@
           {
             "internalType": "uint64",
             "name": "interval",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "max_contract_limit",
             "type": "uint64"
           }
         ],

--- a/core/executor/src/system_contract/metadata/abi/metadata_abi.rs
+++ b/core/executor/src/system_contract/metadata/abi/metadata_abi.rs
@@ -11,7 +11,7 @@ pub use metadata_contract::*;
 )]
 pub mod metadata_contract {
     #[rustfmt::skip]
-    const __ABI: &str = "[\n  {\n    \"inputs\": [\n      {\n        \"components\": [\n          {\n            \"components\": [\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"start\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"end\",\n                \"type\": \"uint64\"\n              }\n            ],\n            \"internalType\": \"struct MetadataType.MetadataVersion\",\n            \"name\": \"version\",\n            \"type\": \"tuple\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"epoch\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"components\": [\n              {\n                \"internalType\": \"bytes\",\n                \"name\": \"bls_pub_key\",\n                \"type\": \"bytes\"\n              },\n              {\n                \"internalType\": \"bytes\",\n                \"name\": \"pub_key\",\n                \"type\": \"bytes\"\n              },\n              {\n                \"internalType\": \"address\",\n                \"name\": \"address_\",\n                \"type\": \"address\"\n              },\n              {\n                \"internalType\": \"uint32\",\n                \"name\": \"propose_weight\",\n                \"type\": \"uint32\"\n              },\n              {\n                \"internalType\": \"uint32\",\n                \"name\": \"vote_weight\",\n                \"type\": \"uint32\"\n              }\n            ],\n            \"internalType\": \"struct MetadataType.ValidatorExtend[]\",\n            \"name\": \"verifier_list\",\n            \"type\": \"tuple[]\"\n          },\n          {\n            \"components\": [\n              {\n                \"internalType\": \"address\",\n                \"name\": \"address_\",\n                \"type\": \"address\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"count\",\n                \"type\": \"uint64\"\n              }\n            ],\n            \"internalType\": \"struct MetadataType.ProposeCount[]\",\n            \"name\": \"propose_counter\",\n            \"type\": \"tuple[]\"\n          },\n          {\n            \"components\": [\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"propose_ratio\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"prevote_ratio\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"precommit_ratio\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"brake_ratio\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"tx_num_limit\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"max_tx_size\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"gas_limit\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"interval\",\n                \"type\": \"uint64\"\n              }\n            ],\n            \"internalType\": \"struct MetadataType.ConsensusConfig\",\n            \"name\": \"consensus_config\",\n            \"type\": \"tuple\"\n          }\n        ],\n        \"internalType\": \"struct MetadataType.Metadata\",\n        \"name\": \"metadata\",\n        \"type\": \"tuple\"\n      }\n    ],\n    \"name\": \"appendMetadata\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"components\": [\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"metadata_type_id\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"checkpoint_type_id\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"xudt_args\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"stake_smt_type_id\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"delegate_smt_type_id\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"reward_smt_type_id\",\n            \"type\": \"bytes32\"\n          }\n        ],\n        \"internalType\": \"struct MetadataType.CkbRelatedInfo\",\n        \"name\": \"info\",\n        \"type\": \"tuple\"\n      }\n    ],\n    \"name\": \"setCkbRelatedInfo\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"components\": [\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"propose_ratio\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"prevote_ratio\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"precommit_ratio\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"brake_ratio\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"tx_num_limit\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"max_tx_size\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"gas_limit\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"interval\",\n            \"type\": \"uint64\"\n          }\n        ],\n        \"internalType\": \"struct MetadataType.ConsensusConfig\",\n        \"name\": \"config\",\n        \"type\": \"tuple\"\n      }\n    ],\n    \"name\": \"updateConsensusConfig\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  }\n]\n";
+    const __ABI: &str = "[\n  {\n    \"inputs\": [\n      {\n        \"components\": [\n          {\n            \"components\": [\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"start\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"end\",\n                \"type\": \"uint64\"\n              }\n            ],\n            \"internalType\": \"struct MetadataType.MetadataVersion\",\n            \"name\": \"version\",\n            \"type\": \"tuple\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"epoch\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"components\": [\n              {\n                \"internalType\": \"bytes\",\n                \"name\": \"bls_pub_key\",\n                \"type\": \"bytes\"\n              },\n              {\n                \"internalType\": \"bytes\",\n                \"name\": \"pub_key\",\n                \"type\": \"bytes\"\n              },\n              {\n                \"internalType\": \"address\",\n                \"name\": \"address_\",\n                \"type\": \"address\"\n              },\n              {\n                \"internalType\": \"uint32\",\n                \"name\": \"propose_weight\",\n                \"type\": \"uint32\"\n              },\n              {\n                \"internalType\": \"uint32\",\n                \"name\": \"vote_weight\",\n                \"type\": \"uint32\"\n              }\n            ],\n            \"internalType\": \"struct MetadataType.ValidatorExtend[]\",\n            \"name\": \"verifier_list\",\n            \"type\": \"tuple[]\"\n          },\n          {\n            \"components\": [\n              {\n                \"internalType\": \"address\",\n                \"name\": \"address_\",\n                \"type\": \"address\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"count\",\n                \"type\": \"uint64\"\n              }\n            ],\n            \"internalType\": \"struct MetadataType.ProposeCount[]\",\n            \"name\": \"propose_counter\",\n            \"type\": \"tuple[]\"\n          },\n          {\n            \"components\": [\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"propose_ratio\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"prevote_ratio\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"precommit_ratio\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"brake_ratio\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"tx_num_limit\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"max_tx_size\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"gas_limit\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"interval\",\n                \"type\": \"uint64\"\n              },\n              {\n                \"internalType\": \"uint64\",\n                \"name\": \"max_contract_limit\",\n                \"type\": \"uint64\"\n              }\n            ],\n            \"internalType\": \"struct MetadataType.ConsensusConfig\",\n            \"name\": \"consensus_config\",\n            \"type\": \"tuple\"\n          }\n        ],\n        \"internalType\": \"struct MetadataType.Metadata\",\n        \"name\": \"metadata\",\n        \"type\": \"tuple\"\n      }\n    ],\n    \"name\": \"appendMetadata\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"components\": [\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"metadata_type_id\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"checkpoint_type_id\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"xudt_args\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"stake_smt_type_id\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"delegate_smt_type_id\",\n            \"type\": \"bytes32\"\n          },\n          {\n            \"internalType\": \"bytes32\",\n            \"name\": \"reward_smt_type_id\",\n            \"type\": \"bytes32\"\n          }\n        ],\n        \"internalType\": \"struct MetadataType.CkbRelatedInfo\",\n        \"name\": \"info\",\n        \"type\": \"tuple\"\n      }\n    ],\n    \"name\": \"setCkbRelatedInfo\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"components\": [\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"propose_ratio\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"prevote_ratio\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"precommit_ratio\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"brake_ratio\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"tx_num_limit\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"max_tx_size\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"gas_limit\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"interval\",\n            \"type\": \"uint64\"\n          },\n          {\n            \"internalType\": \"uint64\",\n            \"name\": \"max_contract_limit\",\n            \"type\": \"uint64\"\n          }\n        ],\n        \"internalType\": \"struct MetadataType.ConsensusConfig\",\n        \"name\": \"config\",\n        \"type\": \"tuple\"\n      }\n    ],\n    \"name\": \"updateConsensusConfig\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  }\n]\n";
     /// The parsed JSON ABI of the contract.
     pub static METADATACONTRACT_ABI: ::ethers::contract::Lazy<::ethers::core::abi::Abi> =
         ::ethers::contract::Lazy::new(|| {
@@ -57,13 +57,13 @@ pub mod metadata_contract {
             ))
         }
 
-        /// Calls the contract's `appendMetadata` (0x4677ae59) function
+        /// Calls the contract's `appendMetadata` (0x53ec79e6) function
         pub fn append_metadata(
             &self,
             metadata: Metadata,
         ) -> ::ethers::contract::builders::ContractCall<M, ()> {
             self.0
-                .method_hash([70, 119, 174, 89], (metadata,))
+                .method_hash([83, 236, 121, 230], (metadata,))
                 .expect("method not found (this should never happen)")
         }
 
@@ -77,13 +77,13 @@ pub mod metadata_contract {
                 .expect("method not found (this should never happen)")
         }
 
-        /// Calls the contract's `updateConsensusConfig` (0x3b05ee4f) function
+        /// Calls the contract's `updateConsensusConfig` (0xb76fac01) function
         pub fn update_consensus_config(
             &self,
             config: ConsensusConfig,
         ) -> ::ethers::contract::builders::ContractCall<M, ()> {
             self.0
-                .method_hash([59, 5, 238, 79], (config,))
+                .method_hash([183, 111, 172, 1], (config,))
                 .expect("method not found (this should never happen)")
         }
     }
@@ -98,7 +98,7 @@ pub mod metadata_contract {
     /// function with signature
     /// `appendMetadata(((uint64,uint64),uint64,(bytes,bytes,address,uint32,
     /// uint32)[],(address,uint64)[],(uint64,uint64,uint64,uint64,uint64,uint64,
-    /// uint64,uint64)))` and selector `0x4677ae59`
+    /// uint64,uint64,uint64)))` and selector `0x53ec79e6`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -111,7 +111,7 @@ pub mod metadata_contract {
     )]
     #[ethcall(
         name = "appendMetadata",
-        abi = "appendMetadata(((uint64,uint64),uint64,(bytes,bytes,address,uint32,uint32)[],(address,uint64)[],(uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64)))"
+        abi = "appendMetadata(((uint64,uint64),uint64,(bytes,bytes,address,uint32,uint32)[],(address,uint64)[],(uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64)))"
     )]
     pub struct AppendMetadataCall {
         pub metadata: Metadata,
@@ -140,7 +140,7 @@ pub mod metadata_contract {
     /// Container type for all input parameters for the `updateConsensusConfig`
     /// function with signature
     /// `updateConsensusConfig((uint64,uint64,uint64,uint64,uint64,uint64,
-    /// uint64,uint64))` and selector `0x3b05ee4f`
+    /// uint64,uint64,uint64))` and selector `0xb76fac01`
     #[derive(
         Clone,
         ::ethers::contract::EthCall,
@@ -153,7 +153,7 @@ pub mod metadata_contract {
     )]
     #[ethcall(
         name = "updateConsensusConfig",
-        abi = "updateConsensusConfig((uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64))"
+        abi = "updateConsensusConfig((uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64))"
     )]
     pub struct UpdateConsensusConfigCall {
         pub config: ConsensusConfig,
@@ -243,7 +243,7 @@ pub mod metadata_contract {
         pub reward_smt_type_id:   [u8; 32],
     }
     /// `ConsensusConfig(uint64,uint64,uint64,uint64,uint64,uint64,uint64,
-    /// uint64)`
+    /// uint64,uint64)`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,
@@ -255,18 +255,19 @@ pub mod metadata_contract {
         Hash,
     )]
     pub struct ConsensusConfig {
-        pub propose_ratio:   u64,
-        pub prevote_ratio:   u64,
-        pub precommit_ratio: u64,
-        pub brake_ratio:     u64,
-        pub tx_num_limit:    u64,
-        pub max_tx_size:     u64,
-        pub gas_limit:       u64,
-        pub interval:        u64,
+        pub propose_ratio:      u64,
+        pub prevote_ratio:      u64,
+        pub precommit_ratio:    u64,
+        pub brake_ratio:        u64,
+        pub tx_num_limit:       u64,
+        pub max_tx_size:        u64,
+        pub gas_limit:          u64,
+        pub interval:           u64,
+        pub max_contract_limit: u64,
     }
     /// `Metadata((uint64,uint64),uint64,(bytes,bytes,address,uint32,uint32)[],
     /// (address,uint64)[],(uint64,uint64,uint64,uint64,uint64,uint64,uint64,
-    /// uint64))`
+    /// uint64,uint64))`
     #[derive(
         Clone,
         ::ethers::contract::EthAbiType,

--- a/core/executor/src/system_contract/metadata/abi/mod.rs
+++ b/core/executor/src/system_contract/metadata/abi/mod.rs
@@ -35,14 +35,15 @@ impl From<Metadata> for metadata_abi::Metadata {
 impl From<ConsensusConfig> for metadata_abi::ConsensusConfig {
     fn from(value: ConsensusConfig) -> Self {
         metadata_abi::ConsensusConfig {
-            propose_ratio:   value.propose_ratio,
-            prevote_ratio:   value.prevote_ratio,
-            precommit_ratio: value.precommit_ratio,
-            brake_ratio:     value.brake_ratio,
-            tx_num_limit:    value.tx_num_limit,
-            max_tx_size:     value.max_tx_size,
-            gas_limit:       value.gas_limit,
-            interval:        value.interval,
+            propose_ratio:      value.propose_ratio,
+            prevote_ratio:      value.prevote_ratio,
+            precommit_ratio:    value.precommit_ratio,
+            brake_ratio:        value.brake_ratio,
+            tx_num_limit:       value.tx_num_limit,
+            max_tx_size:        value.max_tx_size,
+            gas_limit:          value.gas_limit,
+            interval:           value.interval,
+            max_contract_limit: value.max_contract_limit,
         }
     }
 }
@@ -50,14 +51,15 @@ impl From<ConsensusConfig> for metadata_abi::ConsensusConfig {
 impl From<metadata_abi::ConsensusConfig> for ConsensusConfig {
     fn from(value: metadata_abi::ConsensusConfig) -> Self {
         ConsensusConfig {
-            propose_ratio:   value.propose_ratio,
-            prevote_ratio:   value.prevote_ratio,
-            precommit_ratio: value.precommit_ratio,
-            brake_ratio:     value.brake_ratio,
-            tx_num_limit:    value.tx_num_limit,
-            max_tx_size:     value.max_tx_size,
-            gas_limit:       value.gas_limit,
-            interval:        value.interval,
+            propose_ratio:      value.propose_ratio,
+            prevote_ratio:      value.prevote_ratio,
+            precommit_ratio:    value.precommit_ratio,
+            brake_ratio:        value.brake_ratio,
+            tx_num_limit:       value.tx_num_limit,
+            max_tx_size:        value.max_tx_size,
+            gas_limit:          value.gas_limit,
+            interval:           value.interval,
+            max_contract_limit: value.max_contract_limit,
         }
     }
 }

--- a/core/executor/src/system_contract/metadata/handle.rs
+++ b/core/executor/src/system_contract/metadata/handle.rs
@@ -1,4 +1,4 @@
-use protocol::types::{CkbRelatedInfo, HardforkInfo, Metadata, H160, H256};
+use protocol::types::{CkbRelatedInfo, ConsensusConfig, HardforkInfo, Metadata, H160, H256};
 use protocol::ProtocolResult;
 
 use std::sync::Arc;
@@ -61,5 +61,9 @@ impl MetadataHandle {
 
         HARDFORK_INFO.swap(Arc::new(hardfork));
         Ok(())
+    }
+
+    pub fn get_consensus_config(&self) -> ProtocolResult<ConsensusConfig> {
+        MetadataStore::new(self.root)?.get_consensus_config()
     }
 }

--- a/core/executor/src/system_contract/metadata/mod.rs
+++ b/core/executor/src/system_contract/metadata/mod.rs
@@ -5,7 +5,7 @@ mod store;
 
 pub use abi::metadata_abi;
 pub use handle::MetadataHandle;
-pub use store::MetadataStore;
+pub use store::{encode_consensus_config, MetadataStore};
 
 use std::{num::NonZeroUsize, sync::Arc};
 
@@ -32,7 +32,8 @@ const METADATA_CACHE_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1
 lazy_static::lazy_static! {
     pub static ref EPOCH_SEGMENT_KEY: H256 = Hasher::digest("epoch_segment");
     static ref CKB_RELATED_INFO_KEY: H256 = Hasher::digest("ckb_related_info");
-    static ref HARDFORK_KEY: H256 = Hasher::digest("hardfork");
+    pub static ref CONSENSUS_CONFIG: H256 = Hasher::digest("consensus_config");
+    pub static ref HARDFORK_KEY: H256 = Hasher::digest("hardfork");
     static ref HARDFORK_INFO: ArcSwap<H256> = ArcSwap::new(Arc::new(H256::zero()));
     static ref METADATA_CACHE: RwLock<LruCache<Epoch, Metadata>> =  RwLock::new(LruCache::new(METADATA_CACHE_SIZE));
 }
@@ -97,7 +98,7 @@ impl<Adapter: ExecutorAdapter + ApplyBackend> SystemContract<Adapter>
             }
             metadata_abi::MetadataContractCalls::UpdateConsensusConfig(c) => {
                 exec_try!(
-                    store.update_consensus_config(c.config),
+                    store.update_consensus_config(c.config.into()),
                     gas_limit,
                     "[metadata] update consensus config"
                 );

--- a/core/executor/src/system_contract/metadata/mod.rs
+++ b/core/executor/src/system_contract/metadata/mod.rs
@@ -112,6 +112,10 @@ impl<Adapter: ExecutorAdapter + ApplyBackend> SystemContract<Adapter>
 
     fn after_block_hook(&self, adapter: &mut Adapter) {
         let block_number = adapter.block_number();
+        if block_number.is_zero() {
+            return;
+        }
+
         let root = CURRENT_METADATA_ROOT.with(|r| *r.borrow());
 
         let mut store = MetadataStore::new(root).unwrap();
@@ -127,12 +131,6 @@ impl<Adapter: ExecutorAdapter + ApplyBackend> SystemContract<Adapter>
         let hardfork = store.hardfork_info(block_number.as_u64()).unwrap();
 
         HARDFORK_INFO.swap(Arc::new(hardfork));
-
-        if block_number.is_zero() {
-            let changes = generate_mpt_root_changes(adapter, Self::ADDRESS);
-            adapter.apply(changes, vec![], false);
-            return;
-        }
 
         if let Err(e) = store.update_propose_count(block_number.as_u64(), &adapter.origin()) {
             panic!("Update propose count at {:?} failed: {:?}", block_number, e)

--- a/core/executor/src/system_contract/metadata/mod.rs
+++ b/core/executor/src/system_contract/metadata/mod.rs
@@ -34,7 +34,7 @@ lazy_static::lazy_static! {
     static ref CKB_RELATED_INFO_KEY: H256 = Hasher::digest("ckb_related_info");
     pub static ref CONSENSUS_CONFIG: H256 = Hasher::digest("consensus_config");
     pub static ref HARDFORK_KEY: H256 = Hasher::digest("hardfork");
-    static ref HARDFORK_INFO: ArcSwap<H256> = ArcSwap::new(Arc::new(H256::zero()));
+    pub static ref HARDFORK_INFO: ArcSwap<H256> = ArcSwap::new(Arc::new(H256::zero()));
     static ref METADATA_CACHE: RwLock<LruCache<Epoch, Metadata>> =  RwLock::new(LruCache::new(METADATA_CACHE_SIZE));
 }
 
@@ -129,6 +129,8 @@ impl<Adapter: ExecutorAdapter + ApplyBackend> SystemContract<Adapter>
         HARDFORK_INFO.swap(Arc::new(hardfork));
 
         if block_number.is_zero() {
+            let changes = generate_mpt_root_changes(adapter, Self::ADDRESS);
+            adapter.apply(changes, vec![], false);
             return;
         }
 

--- a/core/executor/src/system_contract/metadata/store.rs
+++ b/core/executor/src/system_contract/metadata/store.rs
@@ -174,7 +174,7 @@ impl MetadataStore {
         MetadataInner::decode(raw)
     }
 
-    fn get_consensus_config(&self) -> ProtocolResult<ConsensusConfig> {
+    pub fn get_consensus_config(&self) -> ProtocolResult<ConsensusConfig> {
         let raw = self
             .trie
             .get(CONSENSUS_CONFIG.as_bytes())?

--- a/core/executor/src/system_contract/metadata/store.rs
+++ b/core/executor/src/system_contract/metadata/store.rs
@@ -18,14 +18,15 @@ use crate::{adapter::RocksTrieDB, MPTTrie, CURRENT_METADATA_ROOT};
 
 /// The metadata store does not follow the storage layout of EVM smart contract.
 /// It use MPT called Metadata MPT with the following layout:
-/// | key                  | value                    |
-/// | -------------------- | ------------------------ |
-/// | EPOCH_SEGMENT_KEY    | `EpochSegment.encode()`  |
-/// | CKB_RELATED_INFO_KEY | `CkbRelatedInfo.encode()`|
-/// | HARDFORK_KEY         | `HardforkInfo.encode()`  |
-/// | epoch_0.be_bytes()   | `Metadata.encode()`      |
-/// | epoch_1.be_bytes()   | `Metadata.encode()`      |
-/// | ...                  | ...                      |
+/// | key                  | value                                |
+/// | -------------------- | ------------------------------------ |
+/// | EPOCH_SEGMENT_KEY    | `EpochSegment.encode()`              |
+/// | CKB_RELATED_INFO_KEY | `CkbRelatedInfo.encode()`            |
+/// | HARDFORK_KEY         | `HardforkInfo.encode()`              |
+/// | epoch_0.be_bytes()   | `Metadata.encode()`                  |
+/// | epoch_1.be_bytes()   | `Metadata.encode()`                  |
+/// | CONSENSUS_CONFIG     | `version + ConsensesConfig.encode()` |
+/// | ...                  | ...                                  |
 ///
 /// All these data are stored in a the `c9` column family of RocksDB, and the
 /// root of the Metadata MPT is stored in the storage MPT of the metadata

--- a/core/executor/src/tests/system_script/metadata.rs
+++ b/core/executor/src/tests/system_script/metadata.rs
@@ -206,3 +206,61 @@ fn prepare_validator() -> ValidatorExtend {
         vote_weight:    1u32,
     }
 }
+
+// #[tokio::test]
+// async fn update_consensus_config() {
+//     let config:
+// crate::system_contract::metadata::metadata_abi::ConsensusConfig =
+// ConsensusConfig {         gas_limit:          0x3e7fffffc18,
+//         interval:           0xbb8,
+//         propose_ratio:      0xf,
+//         prevote_ratio:      0xa,
+//         precommit_ratio:    0xa,
+//         brake_ratio:        0xa,
+//         tx_num_limit:       0x4e20,
+//         max_tx_size:        0x186a0000,
+//         max_contract_limit: 0x8000u64,
+//     }
+//     .into();
+
+//     let tx_data =
+//         crate::system_contract::metadata::metadata_abi::UpdateConsensusConfigCall { config }
+//             .encode();
+
+//     send_eth_tx("http://127.0.0.1:8000", tx_data, METADATA_CONTRACT_ADDRESS).await
+// }
+// use ethers::prelude::*;
+// use ethers::signers::{LocalWallet, Signer};
+// use ethers::types::transaction::eip2718::TypedTransaction::Legacy;
+// use ethers::types::{Address, TransactionRequest};
+
+// const ADDRESS: &str = "0x8ab0CF264DF99D83525e9E11c7e4db01558AE1b1";
+// const PRIVATE_KEY: &str =
+// "37aa0f893d05914a4def0460c0a984d3611546cfb26924d7a7ca6e0db9950a2d"; pub async
+// fn send_eth_tx(axon_url: &str, data: Vec<u8>, to: Address) {     let provider
+// = Provider::<Http>::try_from(axon_url).unwrap();
+
+//     let from: Address = ADDRESS.parse().unwrap();
+//     let nonce = provider.get_transaction_count(from, None).await.unwrap();
+
+//     let transaction_request = TransactionRequest::new()
+//         .chain_id(0x41786f6e)
+//         .to(to)
+//         .data(data)
+//         .from(from)
+//         .gas_price(1)
+//         .gas(21000)
+//         .nonce(nonce);
+
+//     let wallet = LocalWallet::from_str(PRIVATE_KEY).expect("failed to create
+// wallet");     let tx = Legacy(transaction_request);
+//     let signature: Signature = wallet.sign_transaction(&tx).await.unwrap();
+
+//     provider
+//         .send_raw_transaction(tx.rlp_signed(&signature))
+//         .await
+//         .unwrap()
+//         .await
+//         .unwrap()
+//         .expect("failed to send eth tx");
+// }

--- a/core/executor/src/tests/system_script/metadata.rs
+++ b/core/executor/src/tests/system_script/metadata.rs
@@ -184,14 +184,15 @@ fn prepare_metadata() -> Metadata {
         verifier_list:    vec![prepare_validator()],
         propose_counter:  vec![],
         consensus_config: ConsensusConfig {
-            gas_limit:       1u64,
-            interval:        0u64,
-            propose_ratio:   1u64,
-            prevote_ratio:   1u64,
-            precommit_ratio: 1u64,
-            brake_ratio:     1u64,
-            tx_num_limit:    1u64,
-            max_tx_size:     1u64,
+            gas_limit:          1u64,
+            interval:           0u64,
+            propose_ratio:      1u64,
+            prevote_ratio:      1u64,
+            precommit_ratio:    1u64,
+            brake_ratio:        1u64,
+            tx_num_limit:       1u64,
+            max_tx_size:        1u64,
+            max_contract_limit: 0x6000u64,
         },
     }
 }

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -441,9 +441,13 @@ async fn execute_genesis(
         tmp
     };
 
-    let resp = execute_genesis_transactions(&partial_genesis, db_group, &spec.accounts, &[
-        metadata_0, metadata_1,
-    ])?;
+    let resp = execute_genesis_transactions(
+        &partial_genesis,
+        db_group,
+        &spec.accounts,
+        &[metadata_0, metadata_1],
+        spec.genesis.generate_hardfork_info(),
+    )?;
 
     partial_genesis.block.header.state_root = resp.state_root;
     partial_genesis.block.header.receipts_root = resp.receipt_root;
@@ -473,6 +477,7 @@ fn execute_genesis_transactions(
     db_group: &DatabaseGroup,
     accounts: &[InitialAccount],
     metadata_list: &[Metadata],
+    hardfork: HardforkInfoInner,
 ) -> ProtocolResult<ExecResp> {
     let state_root = MPTTrie::new(db_group.trie_db())
         .insert_accounts(accounts)
@@ -485,7 +490,7 @@ fn execute_genesis_transactions(
         Proposal::new_without_state_root(&rich.block.header).into(),
     )?;
 
-    system_contract::init(db_group.inner_db(), &mut backend, metadata_list)?;
+    system_contract::init(db_group.inner_db(), &mut backend, metadata_list, hardfork)?;
 
     let resp = AxonExecutor.exec(&mut backend, &rich.txs, &[]);
 

--- a/core/run/src/tests.rs
+++ b/core/run/src/tests.rs
@@ -27,8 +27,8 @@ use protocol::{
     tokio,
     trie::{MemoryDB, PatriciaTrie, Trie as _},
     types::{
-        HardforkInfo, HardforkInfoInner, Header, Metadata, Proposal, RichBlock, H256,
-        RLP_EMPTY_LIST, RLP_NULL,
+        Bloom, BloomInput, HardforkInfo, HardforkInfoInner, Header, Metadata, Proposal, RichBlock,
+        H256, RLP_EMPTY_LIST, RLP_NULL,
     },
 };
 

--- a/core/run/src/tests.rs
+++ b/core/run/src/tests.rs
@@ -12,7 +12,7 @@ use clap::{builder::TypedValueParser as _, Command};
 use hasher::HasherKeccak;
 
 use common_config_parser::types::{
-    spec::{ChainSpec, ChainSpecValueParser, HardforkName, PrivateKeyFileValueParser},
+    spec::{ChainSpec, ChainSpecValueParser, HardforkName},
     Config, ConfigValueParser,
 };
 use core_executor::{
@@ -49,22 +49,22 @@ const TESTCASES: &[TestCase] = &[
         chain_name:         "single_node",
         config_file:        "config.toml",
         chain_spec_file:    "specs/single_node/chain-spec.toml",
-        input_genesis_hash: "0x274c0c52500c3978776d8836b8afe0999a946a010166c12a85a1c45b9cd2c5a2",
-        genesis_state_root: "0x940458498b6ac368ab17e9ede64d0cc1d321bc4ec835e09a333a4151c7785ea1",
+        input_genesis_hash: "0x766cd8e7a32f698eb1180cd736bad6d316ebd3c185326bf6be24ef34996f545a",
+        genesis_state_root: "0x2131e3b9b90adc4c5e2b5136f3789b982029ab43c610cee0b05d8d2759dbdac4",
     },
     TestCase {
         chain_name:         "multi_nodes",
         config_file:        "nodes/node_1.toml",
         chain_spec_file:    "specs/multi_nodes/chain-spec.toml",
-        input_genesis_hash: "0x70cc025ae586f054157f6d8a6558c39c359cde0eb4b9acbdf3f31a8e14a6a6fc",
-        genesis_state_root: "0x9976026c069e8d931d55f93637663e494caae772c2c274ad636de9bc7baf5191",
+        input_genesis_hash: "0x6e6160ffd1dcbcec8fa57a9a62479a9ace98f53bfd512fe946fe17f50c08def9",
+        genesis_state_root: "0x754e9d640f31758f44dbdb18b266dcfb87945d96d713f0a28a06bf6dfa665585",
     },
     TestCase {
         chain_name:         "multi_nodes_short_epoch_len",
         config_file:        "nodes/node_1.toml",
         chain_spec_file:    "specs/multi_nodes_short_epoch_len/chain-spec.toml",
-        input_genesis_hash: "0x4213963522f2d72fa8b33ab4a8b33d79f0d387999f97f38d5c93d9b047baa743",
-        genesis_state_root: "0x33a4f19a7d1bca010f6c3f17904e23f099dd2a022e1f1401fbffed27a1919370",
+        input_genesis_hash: "0x38814e4efa8ec97e659905208d808e5f7118bb039aa7aaee89937dad8bdee756",
+        genesis_state_root: "0xe2cb19b9ce6655838aa5e280d4f6fb06fcf367d454d4bc1c47f5bfd85d75432e",
     },
 ];
 

--- a/core/run/src/tests.rs
+++ b/core/run/src/tests.rs
@@ -264,10 +264,12 @@ fn generate_memory_mpt_root(metadata_0: Metadata, metadata_1: Metadata) -> Vec<u
     memory_mpt
         .insert(EPOCH_SEGMENT_KEY.as_bytes().to_vec(), seg.as_bytes())
         .unwrap();
+
     seg.append_endpoint(metadata_0.version.end).unwrap();
     memory_mpt
         .insert(EPOCH_SEGMENT_KEY.as_bytes().to_vec(), seg.as_bytes())
         .unwrap();
+
     seg.append_endpoint(metadata_1.version.end).unwrap();
     memory_mpt
         .insert(EPOCH_SEGMENT_KEY.as_bytes().to_vec(), seg.as_bytes())
@@ -310,15 +312,13 @@ fn generate_memory_mpt_root(metadata_0: Metadata, metadata_1: Metadata) -> Vec<u
         flags:        H256::from_low_u64_be(HardforkName::all().to_be()),
         block_number: 0,
     };
+    let hardfork = HardforkInfo { inner: vec![info] }
+        .encode()
+        .unwrap()
+        .to_vec();
 
     memory_mpt
-        .insert(
-            HARDFORK_KEY.as_bytes().to_vec(),
-            HardforkInfo { inner: vec![info] }
-                .encode()
-                .unwrap()
-                .to_vec(),
-        )
+        .insert(HARDFORK_KEY.as_bytes().to_vec(), hardfork)
         .unwrap();
     memory_mpt.root().unwrap()
 }

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -288,8 +288,8 @@ impl RichBlock {
 #[cfg(test)]
 mod tests {
     use crate::types::{
-        Block, BlockVersion, ConsensusConfig, Header, Hex, Metadata, MetadataVersion, ProposeCount,
-        RichBlock, ValidatorExtend, H160,
+        primitive::default_max_contract_limit, Block, BlockVersion, ConsensusConfig, Header, Hex,
+        Metadata, MetadataVersion, ProposeCount, RichBlock, ValidatorExtend, H160,
     };
     use std::{
         str::FromStr,
@@ -369,7 +369,7 @@ mod tests {
                 brake_ratio: 10,
                 tx_num_limit: 20000,
                 max_tx_size: 1024,
-                max_contract_limit: 0x6000
+                max_contract_limit: default_max_contract_limit()
             }
         };
 

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -369,6 +369,7 @@ mod tests {
                 brake_ratio: 10,
                 tx_num_limit: 20000,
                 max_tx_size: 1024,
+                max_contract_limit: 0x6000
             }
         };
 

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -371,7 +371,7 @@ impl From<ConsensusConfigV0> for ConsensusConfig {
             brake_ratio:        value.brake_ratio,
             tx_num_limit:       value.tx_num_limit,
             max_tx_size:        value.max_tx_size,
-            max_contract_limit: 0x6000,
+            max_contract_limit: default_max_contract_limit(),
         }
     }
 }
@@ -401,7 +401,7 @@ pub struct ConsensusConfig {
     pub max_contract_limit: u64,
 }
 
-fn default_max_contract_limit() -> u64 {
+pub fn default_max_contract_limit() -> u64 {
     0x6000
 }
 

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -306,10 +306,42 @@ pub struct Metadata {
     pub consensus_config: ConsensusConfig,
 }
 
+impl Metadata {
+    pub fn into_part(self) -> (MetadataInner, ConsensusConfig) {
+        (
+            MetadataInner {
+                version:         self.version,
+                epoch:           self.epoch,
+                verifier_list:   self.verifier_list,
+                propose_counter: self.propose_counter,
+            },
+            self.consensus_config,
+        )
+    }
+
+    pub fn from_parts(inner: MetadataInner, config: ConsensusConfig) -> Self {
+        Metadata {
+            version:          inner.version,
+            epoch:            inner.epoch,
+            verifier_list:    inner.verifier_list,
+            propose_counter:  inner.propose_counter,
+            consensus_config: config,
+        }
+    }
+}
+
+#[derive(RlpEncodable, RlpDecodable, Default, Clone, Debug, PartialEq, Eq)]
+pub struct MetadataInner {
+    pub version:         MetadataVersion,
+    pub epoch:           u64,
+    pub verifier_list:   Vec<ValidatorExtend>,
+    pub propose_counter: Vec<ProposeCount>,
+}
+
 #[derive(
     RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
 )]
-pub struct ConsensusConfig {
+pub struct ConsensusConfigV0 {
     #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub gas_limit:       u64,
     #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
@@ -326,6 +358,51 @@ pub struct ConsensusConfig {
     pub tx_num_limit:    u64,
     #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub max_tx_size:     u64,
+}
+
+impl From<ConsensusConfigV0> for ConsensusConfig {
+    fn from(value: ConsensusConfigV0) -> Self {
+        ConsensusConfig {
+            gas_limit:          value.gas_limit,
+            interval:           value.interval,
+            precommit_ratio:    value.precommit_ratio,
+            propose_ratio:      value.propose_ratio,
+            prevote_ratio:      value.prevote_ratio,
+            brake_ratio:        value.brake_ratio,
+            tx_num_limit:       value.tx_num_limit,
+            max_tx_size:        value.max_tx_size,
+            max_contract_limit: 0x6000,
+        }
+    }
+}
+
+#[derive(
+    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
+)]
+pub struct ConsensusConfig {
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    pub gas_limit:          u64,
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    pub interval:           u64,
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    pub propose_ratio:      u64,
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    pub prevote_ratio:      u64,
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    pub precommit_ratio:    u64,
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    pub brake_ratio:        u64,
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    pub tx_num_limit:       u64,
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    pub max_tx_size:        u64,
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    #[serde(default = "default_max_contract_limit")]
+    pub max_contract_limit: u64,
+}
+
+fn default_max_contract_limit() -> u64 {
+    0x6000
 }
 
 impl From<Metadata> for DurationConfig {


### PR DESCRIPTION
## What this PR does / why we need it?

This PR brings the first hardfork version of the axon. If this hardfork is activated, users can modify the EVM contract size limit.

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
