### PR TITLE
refactor!: insert metadata directly and remove genesis transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,7 @@ dependencies = [
  "core-storage",
  "ethers-core",
  "futures",
+ "hasher",
  "log",
  "rlp",
  "serde",

--- a/core/executor/src/system_contract/metadata/mod.rs
+++ b/core/executor/src/system_contract/metadata/mod.rs
@@ -1,6 +1,6 @@
 mod abi;
 pub(crate) mod handle;
-mod segment;
+pub mod segment;
 mod store;
 
 pub use abi::metadata_abi;
@@ -30,7 +30,7 @@ pub const METADATA_CONTRACT_ADDRESS: H160 = system_contract_address(0x1);
 const METADATA_CACHE_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
 
 lazy_static::lazy_static! {
-    static ref EPOCH_SEGMENT_KEY: H256 = Hasher::digest("epoch_segment");
+    pub static ref EPOCH_SEGMENT_KEY: H256 = Hasher::digest("epoch_segment");
     static ref CKB_RELATED_INFO_KEY: H256 = Hasher::digest("ckb_related_info");
     static ref HARDFORK_KEY: H256 = Hasher::digest("hardfork");
     static ref HARDFORK_INFO: ArcSwap<H256> = ArcSwap::new(Arc::new(H256::zero()));

--- a/core/executor/src/system_contract/mod.rs
+++ b/core/executor/src/system_contract/mod.rs
@@ -10,6 +10,7 @@ pub use crate::system_contract::ckb_light_client::{
     CkbLightClientContract, CKB_LIGHT_CLIENT_CONTRACT_ADDRESS,
 };
 pub use crate::system_contract::image_cell::{ImageCellContract, IMAGE_CELL_CONTRACT_ADDRESS};
+use crate::system_contract::metadata::MetadataStore;
 pub use crate::system_contract::metadata::{
     check_ckb_related_info_exist, MetadataContract, METADATA_CONTRACT_ADDRESS,
 };
@@ -27,9 +28,9 @@ use evm::backend::ApplyBackend;
 use parking_lot::RwLock;
 use rocksdb::DB;
 
-use protocol::ckb_blake2b_256;
 use protocol::traits::{CkbDataProvider, ExecutorAdapter};
-use protocol::types::{Bytes, Hasher, SignedTransaction, TxResp, H160, H256};
+use protocol::types::{Bytes, Hasher, Metadata, SignedTransaction, TxResp, H160, H256};
+use protocol::{ckb_blake2b_256, ProtocolResult};
 
 use crate::adapter::RocksTrieDB;
 use crate::system_contract::{
@@ -105,7 +106,27 @@ pub fn swap_header_cell_db(new_db: Arc<RocksTrieDB>) -> Arc<RocksTrieDB> {
         .unwrap_or_else(|| panic!("header cell db is not initialized"))
 }
 
+/// This method init the CKB light client and metadata DB and insert the first
+/// two metadata, so the `metadata_list.len()` should be equal to 2. The Axon
+/// run process contains two part: `init` and `start`. The `init` part
+/// should initialize the DB and insert the first two metadata. The `start` part
+/// only need to initialize the DB. This method should be used in the `init`
+/// process.
 pub fn init<Adapter: ExecutorAdapter + ApplyBackend>(
+    db: Arc<DB>,
+    adapter: &mut Adapter,
+    metadata_list: &[Metadata],
+) -> ProtocolResult<(H256, H256)> {
+    let ret = init_system_contract_db(db, adapter);
+    init_metadata(adapter, ret.0, metadata_list)?;
+
+    Ok(ret)
+}
+
+/// This method only init the CKB light client and metadata DB and should be
+/// used in run process. The return value`tuple[0]` is current metadata MPT
+/// root, `tuple[1]` is current CKB light client MPT root.
+pub fn init_system_contract_db<Adapter: ExecutorAdapter + ApplyBackend>(
     db: Arc<DB>,
     adapter: &mut Adapter,
 ) -> (H256, H256) {
@@ -128,19 +149,38 @@ pub fn init<Adapter: ExecutorAdapter + ApplyBackend>(
         )));
     }
 
-    let current_cell_root =
+    let current_light_client_root =
         adapter.storage(CKB_LIGHT_CLIENT_CONTRACT_ADDRESS, *HEADER_CELL_ROOT_KEY);
 
     // Current cell root is zero means there is no image cell and header contains in
     // the MPT. Because of the empty cell root is zero rather than NLP_NULL, it is
     // necessary to init the ckb light client and image account in state MPT. The
     // initial process is set the storage root of the two accounts as H256::zero().
-    if current_cell_root.is_zero() {
+    if current_light_client_root.is_zero() {
         let changes = generate_mpt_root_changes(adapter, CKB_LIGHT_CLIENT_CONTRACT_ADDRESS);
         adapter.apply(changes, vec![], false);
     }
 
-    (current_metadata_root, current_cell_root)
+    (current_metadata_root, current_light_client_root)
+}
+
+/// This method is used for insert the first two metadata, so the
+/// `metadata_list.len()` should be equal to 2.
+fn init_metadata<Adapter: ExecutorAdapter + ApplyBackend>(
+    adapter: &mut Adapter,
+    metadata_root: H256,
+    metadata_list: &[Metadata],
+) -> ProtocolResult<()> {
+    debug_assert!(metadata_list.len() == 2);
+
+    let mut store = MetadataStore::new(metadata_root)?;
+    store.append_metadata(&metadata_list[0])?;
+    store.append_metadata(&metadata_list[1])?;
+
+    let changes = generate_mpt_root_changes(adapter, METADATA_CONTRACT_ADDRESS);
+    adapter.apply(changes, vec![], false);
+
+    Ok(())
 }
 
 pub fn before_block_hook<Adapter: ExecutorAdapter + ApplyBackend>(adapter: &mut Adapter) {

--- a/core/executor/src/system_contract/mod.rs
+++ b/core/executor/src/system_contract/mod.rs
@@ -10,7 +10,6 @@ pub use crate::system_contract::ckb_light_client::{
     CkbLightClientContract, CKB_LIGHT_CLIENT_CONTRACT_ADDRESS,
 };
 pub use crate::system_contract::image_cell::{ImageCellContract, IMAGE_CELL_CONTRACT_ADDRESS};
-use crate::system_contract::metadata::MetadataStore;
 pub use crate::system_contract::metadata::{
     check_ckb_related_info_exist, MetadataContract, METADATA_CONTRACT_ADDRESS,
 };
@@ -34,7 +33,7 @@ use protocol::{ckb_blake2b_256, ProtocolResult};
 
 use crate::adapter::RocksTrieDB;
 use crate::system_contract::{
-    ckb_light_client::CkbHeaderReader, image_cell::ImageCellReader,
+    ckb_light_client::CkbHeaderReader, image_cell::ImageCellReader, metadata::MetadataStore,
     utils::generate_mpt_root_changes,
 };
 

--- a/core/executor/src/tests/system_script/ckb_light_client.rs
+++ b/core/executor/src/tests/system_script/ckb_light_client.rs
@@ -10,8 +10,8 @@ use crate::system_contract::ckb_light_client::{
     ckb_light_client_abi, CkbHeaderReader, CkbLightClientContract,
 };
 use crate::system_contract::{
-    init, SystemContract, CKB_LIGHT_CLIENT_CONTRACT_ADDRESS, HEADER_CELL_ROOT_KEY,
-    IMAGE_CELL_CONTRACT_ADDRESS,
+    init_system_contract_db, SystemContract, CKB_LIGHT_CLIENT_CONTRACT_ADDRESS,
+    HEADER_CELL_ROOT_KEY, IMAGE_CELL_CONTRACT_ADDRESS,
 };
 use crate::tests::{gen_tx, gen_vicinity};
 
@@ -25,7 +25,7 @@ pub fn test_write_functions() {
     let inner_db = RocksAdapter::new(ROCKSDB_PATH, Default::default())
         .unwrap()
         .inner_db();
-    init(inner_db, &mut backend);
+    init_system_contract_db(inner_db, &mut backend);
 
     // need to refactor to be OO
     test_update_first(&mut backend, &executor);

--- a/core/executor/src/tests/system_script/image_cell.rs
+++ b/core/executor/src/tests/system_script/image_cell.rs
@@ -11,8 +11,8 @@ use crate::system_contract::image_cell::{
     image_cell_abi, CellInfo, CellKey, ImageCellContract, ImageCellReader,
 };
 use crate::system_contract::{
-    init, SystemContract, CKB_LIGHT_CLIENT_CONTRACT_ADDRESS, HEADER_CELL_ROOT_KEY,
-    IMAGE_CELL_CONTRACT_ADDRESS,
+    init_system_contract_db, SystemContract, CKB_LIGHT_CLIENT_CONTRACT_ADDRESS,
+    HEADER_CELL_ROOT_KEY, IMAGE_CELL_CONTRACT_ADDRESS,
 };
 use crate::tests::{gen_tx, gen_vicinity};
 use crate::{CURRENT_HEADER_CELL_ROOT, CURRENT_METADATA_ROOT};
@@ -27,7 +27,7 @@ pub fn test_write_functions() {
     let inner_db = RocksAdapter::new(ROCKSDB_PATH, Default::default())
         .unwrap()
         .inner_db();
-    let (m_root, h_root) = init(inner_db, &mut backend);
+    let (m_root, h_root) = init_system_contract_db(inner_db, &mut backend);
 
     CURRENT_METADATA_ROOT.with(|r| *r.borrow_mut() = m_root);
     CURRENT_HEADER_CELL_ROOT.with(|r| *r.borrow_mut() = h_root);

--- a/core/executor/src/tests/system_script/metadata.rs
+++ b/core/executor/src/tests/system_script/metadata.rs
@@ -22,7 +22,6 @@ static ROCKSDB_PATH: &str = "./free-space/system-contract/metadata";
 
 #[test]
 fn test_write_functions() {
-    env_logger::init();
     let vicinity = gen_vicinity();
     let mut backend = MemoryBackend::new(&vicinity, BTreeMap::new());
 
@@ -48,7 +47,6 @@ fn test_init<'a>(backend: &mut MemoryBackend<'a>, executor: &MetadataContract<Me
     let addr = H160::from_str("0xf000000000000000000000000000000000000000").unwrap();
     let tx = prepare_tx_1(&addr);
     let r = executor.exec_(backend, &tx);
-    println!("{:?}", r);
     assert!(r.exit_reason.is_succeed());
 }
 

--- a/core/executor/src/tests/system_script/metadata.rs
+++ b/core/executor/src/tests/system_script/metadata.rs
@@ -7,7 +7,7 @@ use protocol::types::{MemoryBackend, SignedTransaction, H160, U256};
 
 use crate::{
     system_contract::{
-        init,
+        init_system_contract_db,
         metadata::{
             metadata_abi::{self, ConsensusConfig, Metadata, MetadataVersion, ValidatorExtend},
             MetadataContract, MetadataStore,
@@ -30,7 +30,7 @@ fn test_write_functions() {
     let inner_db = RocksAdapter::new(ROCKSDB_PATH, Default::default())
         .unwrap()
         .inner_db();
-    init(inner_db, &mut backend);
+    init_system_contract_db(inner_db, &mut backend);
 
     test_init(&mut backend, &executor);
 

--- a/core/interoperation/src/tests/mod.rs
+++ b/core/interoperation/src/tests/mod.rs
@@ -60,7 +60,7 @@ impl TestHandle {
         )
         .unwrap();
 
-        core_executor::system_contract::init(inner_db, &mut backend);
+        core_executor::system_contract::init_system_contract_db(inner_db, &mut backend);
 
         handle
     }

--- a/core/run/Cargo.toml
+++ b/core/run/Cargo.toml
@@ -38,6 +38,7 @@ jemallocator = { version = "0.5", features = ["profiling", "stats", "unprefixed_
 
 [dev-dependencies]
 clap = "4.4"
+hasher = "0.1"
 tempfile = "3.6"
 
 [features]

--- a/core/run/src/components/chain_spec.rs
+++ b/core/run/src/components/chain_spec.rs
@@ -1,9 +1,8 @@
 use common_config_parser::types::spec::ChainSpec;
-use common_crypto::{PrivateKey as _, Secp256k1RecoverablePrivateKey, Signature};
+use common_crypto::Secp256k1RecoverablePrivateKey;
 
 use protocol::types::{
-    Block, Eip1559Transaction, Hasher, RichBlock, SignedTransaction, TransactionAction,
-    UnsignedTransaction, UnverifiedTransaction, BASE_FEE_PER_GAS,
+    Block, Eip1559Transaction, RichBlock, TransactionAction, UnsignedTransaction, BASE_FEE_PER_GAS,
 };
 
 pub(crate) trait ChainSpecExt {
@@ -40,27 +39,4 @@ fn build_unverified_transaction(
         action,
     };
     UnsignedTransaction::Eip1559(tx)
-}
-
-#[allow(dead_code)]
-fn build_transaction(
-    priv_key: &Secp256k1RecoverablePrivateKey,
-    tx: UnsignedTransaction,
-    id: u64,
-) -> SignedTransaction {
-    let signature = priv_key.sign_message(
-        &Hasher::digest(tx.encode(Some(id), None))
-            .as_bytes()
-            .try_into()
-            .unwrap(),
-    );
-    let utx = UnverifiedTransaction {
-        unsigned:  tx,
-        signature: Some(signature.to_bytes().into()),
-        chain_id:  Some(id),
-        hash:      Default::default(),
-    }
-    .calc_hash();
-
-    SignedTransaction::from_unverified(utx, None).unwrap()
 }

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -456,7 +456,7 @@ async fn execute_genesis(
         tmp
     };
 
-    let resp = execute_transactions(&partial_genesis, db_group, &spec.accounts, &[
+    let resp = execute_genesis_transactions(&partial_genesis, db_group, &spec.accounts, &[
         metadata_0, metadata_1,
     ])?;
 
@@ -474,7 +474,7 @@ async fn execute_genesis(
     Ok(partial_genesis)
 }
 
-fn execute_transactions(
+fn execute_genesis_transactions(
     rich: &RichBlock,
     db_group: &DatabaseGroup,
     accounts: &[InitialAccount],

--- a/core/run/src/tests.rs
+++ b/core/run/src/tests.rs
@@ -20,7 +20,9 @@ use protocol::{
     types::{Header, Metadata, Proposal, RichBlock, H256},
 };
 
-use crate::{components::chain_spec::ChainSpecExt as _, execute_transactions, DatabaseGroup};
+use crate::{
+    components::chain_spec::ChainSpecExt as _, execute_genesis_transactions, DatabaseGroup,
+};
 
 const DEV_CONFIG_DIR: &str = "../../devtools/chain";
 
@@ -162,7 +164,7 @@ async fn check_genesis_data<'a>(case: &TestCase<'a>) {
         tmp.version.end = tmp.version.start + metadata_0.version.end - 1;
         tmp
     };
-    let resp = execute_transactions(&genesis, &db_group, &chain_spec.accounts, &[
+    let resp = execute_genesis_transactions(&genesis, &db_group, &chain_spec.accounts, &[
         metadata_0, metadata_1,
     ])
     .expect("execute transactions");


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR removes the generation of genesis transactions. The first two metadata and the consensus config are inserted to DB directly.

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
