### PR TITLE
chore: remove metadata test in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,6 @@ security-audit:
 	@cargo audit --version || cargo install cargo-audit
 	@cargo audit
 
-metadata-test:
-	cd builtin-contract/metadata \
-		&& yarn --from-lock-file && yarn run compile && yarn run test
-
-metadata-genesis-deploy:
-	cd builtin-contract/metadata && yarn run deploy
-
 crosschain-test:
 	cd builtin-contract/crosschain \
 		&& yarn --from-lock-file && yarn run compile && yarn run test
@@ -93,7 +86,7 @@ crosschain-test:
 crosschain-genesis-deploy:
 	cd builtin-contract/crosschain && yarn run deploy
 
-unit-test: test metadata-test crosschain-test
+unit-test: test crosschain-test
 
 schema:
 	make -C core/cross-client/ schema


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR removes `metadata-test` in Makefile because the metadata precompile contract is removed in https://github.com/axonweb3/axon/pull/1449.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
