### PR TITLE
fix: the default (or empty) values of genesis fields should be same as normal blocks

### DIFF
--- a/common/config-parser/src/types/spec.rs
+++ b/common/config-parser/src/types/spec.rs
@@ -10,7 +10,10 @@ use strum_macros::EnumIter;
 use common_crypto::Secp256k1RecoverablePrivateKey;
 use protocol::{
     codec::{decode_256bits_key, deserialize_address, ProtocolCodec},
-    types::{ExtraData, HardforkInfoInner, Header, Key256Bits, Metadata, H160, H256, U256},
+    types::{
+        ExtraData, HardforkInfoInner, Header, Key256Bits, Metadata, H160, H256, RLP_EMPTY_LIST,
+        RLP_NULL, U256,
+    },
 };
 
 use crate::parse_file;
@@ -203,6 +206,8 @@ impl Genesis {
     /// Build a `Header` of the genesis block from the user provided parameters.
     pub fn build_header(&self) -> Header {
         Header {
+            transactions_root: RLP_NULL,
+            signed_txs_hash: RLP_EMPTY_LIST,
             timestamp: self.timestamp,
             // todo: if Hardforkinput is empty, it must change to latest hardfork info to init
             // genesis


### PR DESCRIPTION
## What this PR does / why we need it?

This PR closes #1305.

Since no genesis transaction is allowed after #1454 merged:

- `transactions_root` should always be the default value `RLP_NULL` as a normal block.

  https://github.com/axonweb3/axon/blob/412e52ace5a9afe951603c1d922059e5fe5e66ea/core/consensus/src/engine.rs#L75-L83

- `signed_txs_hash` should always be the default value `RLP_EMPTY_LIST` as a normal block

  https://github.com/axonweb3/axon/blob/412e52ace5a9afe951603c1d922059e5fe5e66ea/core/consensus/src/engine.rs#L115
  https://github.com/axonweb3/axon/blob/412e52ace5a9afe951603c1d922059e5fe5e66ea/core/consensus/src/util.rs#L19-L25

- `receipts_root` should always be the default value `RLP_NULL` as a normal block.

  https://github.com/axonweb3/axon/blob/412e52ace5a9afe951603c1d922059e5fe5e66ea/core/executor/src/lib.rs#L188-L196

- `log_bloom` should always calculated from an empty logs vector.

  https://github.com/axonweb3/axon/blob/412e52ace5a9afe951603c1d922059e5fe5e66ea/protocol/src/types/block.rs#L132-L136

  https://github.com/axonweb3/axon/blob/412e52ace5a9afe951603c1d922059e5fe5e66ea/protocol/src/types/block.rs#L145-L147

  :warning: It's not same as `Default::default()`.

  The `Default::default()` is all zeros, but for an empty logs vector, it's not.

  The difference is as following:

  ```diff
    0000000000000000000000000000000000000000000000000000000000000000
  - 0000000000000000000000000000000000000000000000000000000000000000
  + 0000000000000080000000000000000000000000000000000000000000000000
                  ^
  - 0000000000000000000000000000000000000000000000000000000000000000
  + 0000010000001000000000000000000000000000000000000000000000000000
         ^      ^
    0000000000000000000000000000000000000000000000000000000000000000
    0000000000000000000000000000000000000000000000000000000000000000
    0000000000000000000000000000000000000000000000000000000000000000
    0000000000000000000000000000000000000000000000000000000000000000
    0000000000000000000000000000000000000000000000000000000000000000
  ```

- `gas_used` should always be zero.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
