### PR TITLE
fix: fix consensus config encode fn

### DIFF
--- a/core/run/src/tests.rs
+++ b/core/run/src/tests.rs
@@ -49,22 +49,22 @@ const TESTCASES: &[TestCase] = &[
         chain_name:         "single_node",
         config_file:        "config.toml",
         chain_spec_file:    "specs/single_node/chain-spec.toml",
-        input_genesis_hash: "0x766cd8e7a32f698eb1180cd736bad6d316ebd3c185326bf6be24ef34996f545a",
-        genesis_state_root: "0x2131e3b9b90adc4c5e2b5136f3789b982029ab43c610cee0b05d8d2759dbdac4",
+        input_genesis_hash: "0x3428ea0eb8fb33f193e4680772ec6f68279c24bb7f135a8a3f790af6539fc100",
+        genesis_state_root: "0xe7799df5d8256add895412df5889c4ae07bb5c0d7fa438801b910cfef9d5dc37",
     },
     TestCase {
         chain_name:         "multi_nodes",
         config_file:        "nodes/node_1.toml",
         chain_spec_file:    "specs/multi_nodes/chain-spec.toml",
-        input_genesis_hash: "0x6e6160ffd1dcbcec8fa57a9a62479a9ace98f53bfd512fe946fe17f50c08def9",
-        genesis_state_root: "0x754e9d640f31758f44dbdb18b266dcfb87945d96d713f0a28a06bf6dfa665585",
+        input_genesis_hash: "0xa2559187fdb9bc172ee82b40c9f4f166d56d0ba9dc2fc47538e7d95a8d641575",
+        genesis_state_root: "0x04b03f59e424ab276cd3a8c54e9f3d51c8f1c9fc64c4b2fda7accd2ddffb46b4",
     },
     TestCase {
         chain_name:         "multi_nodes_short_epoch_len",
         config_file:        "nodes/node_1.toml",
         chain_spec_file:    "specs/multi_nodes_short_epoch_len/chain-spec.toml",
-        input_genesis_hash: "0x38814e4efa8ec97e659905208d808e5f7118bb039aa7aaee89937dad8bdee756",
-        genesis_state_root: "0xe2cb19b9ce6655838aa5e280d4f6fb06fcf367d454d4bc1c47f5bfd85d75432e",
+        input_genesis_hash: "0xa710efc9621394b5138a0e9a87c7b8586a88f4d26059bcb06ee76cc5e0bf12b0",
+        genesis_state_root: "0x3a9030d8e60478866e618a92c5137e02c1f3dc0b20dc5b51f4e720d7a7a58a0b",
     },
 ];
 
@@ -288,8 +288,9 @@ fn generate_memory_mpt_root(metadata_0: Metadata, metadata_1: Metadata) -> Vec<u
             CONSENSUS_CONFIG.as_bytes().to_vec(),
             encode_consensus_config(
                 H256::from_low_u64_be((HardforkName::None as u64).to_be()),
-                config_0.encode().unwrap().to_vec(),
-            ),
+                config_0,
+            )
+            .unwrap(),
         )
         .unwrap();
     memory_mpt
@@ -303,8 +304,9 @@ fn generate_memory_mpt_root(metadata_0: Metadata, metadata_1: Metadata) -> Vec<u
             CONSENSUS_CONFIG.as_bytes().to_vec(),
             encode_consensus_config(
                 H256::from_low_u64_be((HardforkName::None as u64).to_be()),
-                config_1.encode().unwrap().to_vec(),
-            ),
+                config_1,
+            )
+            .unwrap(),
         )
         .unwrap();
 

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -400,6 +400,20 @@ pub struct ConsensusConfig {
     #[serde(default = "default_max_contract_limit")]
     pub max_contract_limit: u64,
 }
+impl From<ConsensusConfig> for ConsensusConfigV0 {
+    fn from(value: ConsensusConfig) -> Self {
+        ConsensusConfigV0 {
+            gas_limit:       value.gas_limit,
+            interval:        value.interval,
+            precommit_ratio: value.precommit_ratio,
+            propose_ratio:   value.propose_ratio,
+            prevote_ratio:   value.prevote_ratio,
+            brake_ratio:     value.brake_ratio,
+            tx_num_limit:    value.tx_num_limit,
+            max_tx_size:     value.max_tx_size,
+        }
+    }
+}
 
 pub fn default_max_contract_limit() -> u64 {
     0x6000


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR fix consensus config encode fn

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
