### PR TITLE
refactor: remove default value `0000 0000 0000 0000` of `Hex`

### DIFF
--- a/protocol/src/lazy.rs
+++ b/protocol/src/lazy.rs
@@ -5,7 +5,7 @@ use crate::{ckb_blake2b_256, types::Hex};
 
 lazy_static::lazy_static! {
     pub static ref CHAIN_ID: ArcSwap<u64> = ArcSwap::from_pointee(Default::default());
-    pub static ref PROTOCOL_VERSION: ArcSwap<Hex> = ArcSwap::from_pointee(Default::default());
+    pub static ref PROTOCOL_VERSION: ArcSwap<Hex> = ArcSwap::from_pointee(Hex::with_length(8));
 
     pub static ref DUMMY_INPUT_OUT_POINT: packed::OutPoint
         = packed::OutPointBuilder::default()

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -79,6 +79,10 @@ impl Hex {
         Hex(Bytes::default())
     }
 
+    pub fn with_length(len: usize) -> Self {
+        Hex(vec![0u8; len].into())
+    }
+
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -105,12 +109,6 @@ impl Hex {
 
     fn is_prefixed(s: &str) -> bool {
         s.starts_with(HEX_PREFIX)
-    }
-}
-
-impl Default for Hex {
-    fn default() -> Self {
-        Hex(vec![0u8; 8].into())
     }
 }
 
@@ -459,7 +457,7 @@ pub struct Validator {
     pub vote_weight:    u32,
 }
 
-#[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+#[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ValidatorExtend {
     pub bls_pub_key:    Hex,
     pub pub_key:        Hex,
@@ -488,6 +486,18 @@ impl From<&ValidatorExtend> for Validator {
             pub_key:        ve.pub_key.as_bytes(),
             propose_weight: ve.propose_weight,
             vote_weight:    ve.vote_weight,
+        }
+    }
+}
+
+impl Default for ValidatorExtend {
+    fn default() -> Self {
+        Self {
+            bls_pub_key:    Hex::with_length(8),
+            pub_key:        Hex::with_length(8),
+            address:        Default::default(),
+            propose_weight: Default::default(),
+            vote_weight:    Default::default(),
         }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR closes #1388.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>