### PR TITLE
fix: fix evm config init

### DIFF
--- a/core/api/src/jsonrpc/error.rs
+++ b/core/api/src/jsonrpc/error.rs
@@ -54,8 +54,8 @@ pub enum RpcError {
     #[display(fmt = "Invalid filter id {}", _0)]
     CannotFindFilterId(u64),
 
-    #[display(fmt = "CKB-VM error {}", "decode_revert_msg(&_0.ret)")]
-    VM(TxResp),
+    #[display(fmt = "EVM error {}", "decode_revert_msg(&_0.ret)")]
+    Evm(TxResp),
     #[display(fmt = "Internal error")]
     Internal(String),
 }
@@ -92,7 +92,7 @@ impl RpcError {
             RpcError::InvalidFromBlockAndToBlockUnion => -40021,
             RpcError::CannotFindFilterId(_) => -40022,
 
-            RpcError::VM(_) => -49998,
+            RpcError::Evm(_) => -49998,
             RpcError::Internal(_) => -49999,
         }
     }
@@ -134,7 +134,7 @@ impl From<RpcError> for ErrorObjectOwned {
             }
             RpcError::CannotFindFilterId(_) => ErrorObject::owned(err_code, err, none_data),
 
-            RpcError::VM(resp) => {
+            RpcError::Evm(resp) => {
                 ErrorObject::owned(err_code, err.clone(), Some(vm_err(resp.clone())))
             }
             RpcError::Internal(msg) => ErrorObject::owned(err_code, err.clone(), Some(msg)),

--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -522,7 +522,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
             return Ok(call_hex_result);
         }
 
-        Err(RpcError::VM(resp).into())
+        Err(RpcError::Evm(resp).into())
     }
 
     #[metrics_rpc("eth_estimateGas")]
@@ -557,7 +557,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
             return Ok(resp.gas_used.into());
         }
 
-        Err(RpcError::VM(resp).into())
+        Err(RpcError::Evm(resp).into())
     }
 
     #[metrics_rpc("eth_getCode")]

--- a/core/executor/src/tests/system_script/metadata.rs
+++ b/core/executor/src/tests/system_script/metadata.rs
@@ -252,8 +252,11 @@ fn prepare_validator() -> ValidatorExtend {
 //         .gas(21000)
 //         .nonce(nonce);
 
-//     let wallet = LocalWallet::from_str(PRIVATE_KEY).expect("failed to create
-// wallet");     let tx = Legacy(transaction_request);
+//     let wallet = LocalWallet::from_str(PRIVATE_KEY).expect(
+//         "failed to create
+// wallet",
+//     );
+//     let tx = Legacy(transaction_request);
 //     let signature: Signature = wallet.sign_transaction(&tx).await.unwrap();
 
 //     provider


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR fixes evm config init with hardfork features

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
