### PR TITLE
fix: rlp encode and decode of `Proposal` struct

### DIFF
--- a/protocol/src/codec/block.rs
+++ b/protocol/src/codec/block.rs
@@ -23,7 +23,7 @@ impl Decodable for BlockVersion {
 
 impl Encodable for Proposal {
     fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(11)
+        s.begin_list(12)
             .append(&self.version)
             .append(&self.prev_hash)
             .append(&self.proposer)
@@ -32,6 +32,7 @@ impl Encodable for Proposal {
             .append(&self.signed_txs_hash)
             .append(&self.timestamp)
             .append(&self.number)
+            .append_list(&self.extra_data)
             .append(&self.proof)
             .append(&self.call_system_script_count)
             .append_list(&self.tx_hashes);
@@ -50,12 +51,12 @@ impl Decodable for Proposal {
             timestamp:                r.val_at(6)?,
             number:                   r.val_at(7)?,
             gas_limit:                MAX_BLOCK_GAS_LIMIT.into(),
-            extra_data:               Default::default(),
+            extra_data:               r.list_at(8)?,
             base_fee_per_gas:         BASE_FEE_PER_GAS.into(),
-            proof:                    r.val_at(8)?,
+            proof:                    r.val_at(9)?,
             chain_id:                 **CHAIN_ID.load(),
-            call_system_script_count: r.val_at(9)?,
-            tx_hashes:                r.list_at(10)?,
+            call_system_script_count: r.val_at(10)?,
+            tx_hashes:                r.list_at(11)?,
         })
     }
 }
@@ -75,9 +76,14 @@ impl Codec for Proposal {
 #[cfg(test)]
 mod tests {
     use crate::traits::MessageCodec;
-    use crate::types::{Block, Header, Proof};
+    use crate::types::{Block, Bytes, ExtraData, Header, Proof, H160, H256};
+    use rand::random;
 
     use super::*;
+
+    fn rand_bytes(len: usize) -> Bytes {
+        (0..len).map(|_| random::<u8>()).collect::<Vec<_>>().into()
+    }
 
     #[test]
     fn test_version_codec() {
@@ -116,10 +122,31 @@ mod tests {
 
     #[test]
     fn test_proposal_codec() {
+        let mock_proof = Proof {
+            number:     random(),
+            round:      random(),
+            block_hash: H256::random(),
+            signature:  rand_bytes(65),
+            bitmap:     rand_bytes(32),
+        };
         let mut proposal = Proposal {
-            gas_limit: 30000000u64.into(),
-            base_fee_per_gas: 1337u64.into(),
-            ..Default::default()
+            version:                  BlockVersion::V0,
+            prev_hash:                H256::random(),
+            proposer:                 H160::random(),
+            prev_state_root:          H256::random(),
+            transactions_root:        H256::random(),
+            signed_txs_hash:          H256::random(),
+            timestamp:                random(),
+            number:                   random(),
+            gas_limit:                30000000u64.into(),
+            extra_data:               vec![ExtraData {
+                inner: H256::random().0.to_vec().into(),
+            }],
+            base_fee_per_gas:         1337u64.into(),
+            proof:                    mock_proof,
+            chain_id:                 0,
+            call_system_script_count: random(),
+            tx_hashes:                vec![H256::random()],
         };
         let bytes = proposal.encode_msg().unwrap();
         let decode: Proposal = Proposal::decode_msg(bytes).unwrap();

--- a/protocol/src/codec/block.rs
+++ b/protocol/src/codec/block.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use overlord::Codec;
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 
-use crate::types::{BlockVersion, Bytes, Proposal, BASE_FEE_PER_GAS, MAX_BLOCK_GAS_LIMIT};
+use crate::types::{BlockVersion, Bytes, Proposal, BASE_FEE_PER_GAS};
 use crate::{codec::error::CodecError, lazy::CHAIN_ID, ProtocolError};
 
 impl Encodable for BlockVersion {
@@ -23,7 +23,7 @@ impl Decodable for BlockVersion {
 
 impl Encodable for Proposal {
     fn rlp_append(&self, s: &mut RlpStream) {
-        s.begin_list(12)
+        s.begin_list(13)
             .append(&self.version)
             .append(&self.prev_hash)
             .append(&self.proposer)
@@ -32,6 +32,7 @@ impl Encodable for Proposal {
             .append(&self.signed_txs_hash)
             .append(&self.timestamp)
             .append(&self.number)
+            .append(&self.gas_limit.as_u64())
             .append_list(&self.extra_data)
             .append(&self.proof)
             .append(&self.call_system_script_count)
@@ -50,13 +51,13 @@ impl Decodable for Proposal {
             signed_txs_hash:          r.val_at(5)?,
             timestamp:                r.val_at(6)?,
             number:                   r.val_at(7)?,
-            gas_limit:                MAX_BLOCK_GAS_LIMIT.into(),
-            extra_data:               r.list_at(8)?,
+            gas_limit:                r.val_at::<u64>(8)?.into(),
+            extra_data:               r.list_at(9)?,
             base_fee_per_gas:         BASE_FEE_PER_GAS.into(),
-            proof:                    r.val_at(9)?,
+            proof:                    r.val_at(10)?,
             chain_id:                 **CHAIN_ID.load(),
-            call_system_script_count: r.val_at(10)?,
-            tx_hashes:                r.list_at(11)?,
+            call_system_script_count: r.val_at(11)?,
+            tx_hashes:                r.list_at(12)?,
         })
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR fix the rlp encode and decode of `Proposal` struct. The previous version omit the `extra_data` field.

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
