### PR TITLE
ci: add `hardfork_test` workflow 

### DIFF
--- a/.github/workflows/hardfork_test.yml
+++ b/.github/workflows/hardfork_test.yml
@@ -1,0 +1,108 @@
+name: Hardfork test
+
+on:
+  push:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  hardfork-test:
+    strategy:
+      matrix:
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-22.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache of Cargo
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
+    - name: Build Axon in the development profile
+      run: cargo build
+
+    - name: Start multiple Axon nodes
+      env:
+        LOG_PATH: ${{ runner.temp }}/${{ matrix.os }}/multi-axon-nodes
+      run: |
+        echo "LOG_PATH: ${{ env.LOG_PATH }}"
+        mkdir -p ${{ env.LOG_PATH }}
+
+        target/debug/axon --version
+
+        sed -i 's/hardforks = \[\]/hardforks = ["None"]/g' devtools/chain/specs/multi_nodes/chain-spec.toml
+        grep "hardforks" devtools/chain/specs/multi_nodes/chain-spec.toml
+
+        for id in 1 2 3 4; do
+          target/debug/axon init \
+            --config     devtools/chain/nodes/node_${id}.toml \
+            --chain-spec devtools/chain/specs/multi_nodes/chain-spec.toml \
+            > ${{ env.LOG_PATH }}/node_${id}.log
+        done
+
+        for id in 1 2 3 4; do
+          target/debug/axon run \
+            --config     devtools/chain/nodes/node_${id}.toml \
+            >> ${{ env.LOG_PATH }}/node_${id}.log &
+        done
+
+        npx zx <<'EOF'
+        import { waitXBlocksPassed } from './devtools/ci/scripts/helper.js'
+        await Promise.all([
+          waitXBlocksPassed('http://127.0.0.1:8001', 4),
+          waitXBlocksPassed('http://127.0.0.1:8002', 4),
+          waitXBlocksPassed('http://127.0.0.1:8003', 4),
+          waitXBlocksPassed('http://127.0.0.1:8004', 4),
+        ])
+        EOF
+      timeout-minutes: 1
+
+    - name: Checkout sunchengzhu/axon-hardfork-test
+      uses: actions/checkout@v4
+      with:
+        repository: sunchengzhu/axon-hardfork-test
+        path: axon-hardfork-test
+
+    - name: Run test cases before hardfork
+      working-directory: axon-hardfork-test
+      run: |
+        npm install
+        npx hardhat test --grep "deploy a normal contract"
+        npx hardhat test --grep "deploy a big contract larger than max_contract_limit"
+        npx hardhat test --grep "check hardfork info before hardfork"
+
+    - name: Hardfork
+      working-directory: axon-hardfork-test
+      run: |
+        bash hardfork.sh ../
+
+    - name: Run test cases after hardfork
+      working-directory: axon-hardfork-test
+      run: |
+        npx hardhat test --grep "check hardfork info after hardfork"
+
+        node_ids=(1 2 3 4)
+        random_value=$(( (RANDOM % ${#node_ids[@]}) + 1 ))
+        echo "Invoke system contract via node_"$random_value
+        npx hardhat test --grep "update max_contract_limit" --network "node_"$random_value
+        npx hardhat test --grep "deploy a big contract smaller than max_contract_limit"
+
+    - name: Archive logs
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: multi-axon-nodes-logs
+        path: |
+          ${{ runner.temp }}/${{ matrix.os }}/multi-axon-nodes/


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR adds `hardfork_test` workflow 

### What is the impact of this PR?

No Breaking Change


<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
