### PR TITLE
refactor: more details for JSON RPC errors

### DIFF
--- a/core/api/src/jsonrpc/error.rs
+++ b/core/api/src/jsonrpc/error.rs
@@ -9,9 +9,9 @@ use crate::jsonrpc::web3_types::BlockId;
 
 #[derive(Clone, Display, Debug)]
 pub enum RpcError {
-    #[display(fmt = "Decode interoperation signature r error")]
+    #[display(fmt = "Decode interoperation signature r error since {}", _0)]
     DecodeInteroperationSigR(String),
-    #[display(fmt = "Decode interoperation signature s error")]
+    #[display(fmt = "Decode interoperation signature s error since {}", _0)]
     DecodeInteroperationSigS(String),
     #[display(fmt = "Invalid address source")]
     InvalidAddressSource,
@@ -56,7 +56,7 @@ pub enum RpcError {
 
     #[display(fmt = "EVM error {}", "decode_revert_msg(&_0.ret)")]
     Evm(TxResp),
-    #[display(fmt = "Internal error")]
+    #[display(fmt = "Internal error: {}", _0)]
     Internal(String),
 }
 


### PR DESCRIPTION
## What this PR does / why we need it?

This PR adds more details to JSON RPC errors.

Since the internal errors have no details, it's difficult to debug.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
