### PR TITLE
feat: new hardfork with ckb vm

### DIFF
--- a/common/config-parser/src/types/spec.rs
+++ b/common/config-parser/src/types/spec.rs
@@ -269,6 +269,8 @@ pub enum HardforkName {
     /// If this hardfork is activated, chain validators can modify the EVM
     /// contract size limit.
     Andromeda = 0b1,
+    /// Enable CKB hardfork 2023 with new VM
+    Antlia = 0b10,
 }
 
 impl HardforkName {

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -408,10 +408,7 @@ impl AxonExecutor {
     fn config(&self) -> Config {
         let mut evm_config = Config::london();
         let create_contract_limit = {
-            let latest_hardfork_info = &**HARDFORK_INFO.load();
-            let enable_contract_limit_flag =
-                H256::from_low_u64_be((HardforkName::Andromeda as u64).to_be());
-            if latest_hardfork_info & &enable_contract_limit_flag == enable_contract_limit_flag {
+            if enable_hardfork(HardforkName::Andromeda) {
                 let handle = MetadataHandle::new(CURRENT_METADATA_ROOT.with(|r| *r.borrow()));
                 let consensus_config = handle.get_consensus_config().unwrap();
                 Some(consensus_config.max_contract_limit as usize)
@@ -513,6 +510,13 @@ pub fn is_call_system_script(action: &TransactionAction) -> bool {
 
 pub fn is_transaction_call(action: &TransactionAction, addr: &H160) -> bool {
     action == &TransactionAction::Call(*addr)
+}
+
+pub fn enable_hardfork(name: HardforkName) -> bool {
+    let latest_hardfork_info = &**HARDFORK_INFO.load();
+    let enable_flag = H256::from_low_u64_be((name as u64).to_be());
+
+    latest_hardfork_info & &enable_flag == enable_flag
 }
 
 #[cfg(test)]

--- a/core/interoperation/src/lib.rs
+++ b/core/interoperation/src/lib.rs
@@ -7,16 +7,19 @@ use ckb_script::{TransactionScriptsVerifier, TxVerifyEnv};
 use ckb_traits::CellDataProvider;
 use ckb_types::core::{Cycle, HeaderBuilder, TransactionView};
 use ckb_types::{packed, prelude::Pack};
-use ckb_vm::machine::{asm::AsmCoreMachine, DefaultMachineBuilder, SupportMachine, VERSION1};
-use ckb_vm::{Error as VMError, ISA_B, ISA_IMC, ISA_MOP};
+use ckb_vm::machine::{
+    asm::AsmCoreMachine, DefaultMachineBuilder, SupportMachine, VERSION1, VERSION2,
+};
+use ckb_vm::{Error as VMError, ISA_A, ISA_B, ISA_IMC, ISA_MOP};
 
 use protocol::traits::{CkbDataProvider, Context, Interoperation};
-use protocol::types::{Bytes, CellDep, CellWithData, OutPoint, VMResp};
+use protocol::types::{Bytes, CKBVMVersion, CellDep, CellWithData, OutPoint, VMResp};
 use protocol::{Display, ProtocolError, ProtocolErrorKind, ProtocolResult};
 
 use crate::utils::resolve_transaction;
 
-const ISA: u8 = ISA_IMC | ISA_B | ISA_MOP;
+const ISA_2021: u8 = ISA_IMC | ISA_B | ISA_MOP;
+const ISA_2023: u8 = ISA_IMC | ISA_B | ISA_MOP | ISA_A;
 const GAS_TO_CYCLE_COEF: u64 = 6_000;
 
 // The following information is from CKB block [10976708](https://explorer.nervos.org/block/10976708)
@@ -59,14 +62,18 @@ impl Interoperation for InteroperationImpl {
         data_cell_dep: CellDep,
         args: &[Bytes],
         max_cycles: u64,
+        version: CKBVMVersion,
     ) -> ProtocolResult<VMResp> {
         let data_cell_dep: packed::CellDep = (&data_cell_dep).into();
         let program = data_loader
             .get_cell_data(&data_cell_dep.out_point())
             .ok_or_else(|| InteroperationError::GetProgram((&data_cell_dep.out_point()).into()))?;
-        let mut vm = ckb_vm::machine::asm::AsmMachine::new(
-            DefaultMachineBuilder::new(AsmCoreMachine::new(ISA, VERSION1, max_cycles)).build(),
-        );
+        let core = match version {
+            CKBVMVersion::V2021 => AsmCoreMachine::new(ISA_2021, VERSION1, max_cycles),
+            CKBVMVersion::V2023 => AsmCoreMachine::new(ISA_2023, VERSION2, max_cycles),
+        };
+        let mut vm =
+            ckb_vm::machine::asm::AsmMachine::new(DefaultMachineBuilder::new(core).build());
         let _ = vm
             .load_program(&program, args)
             .map_err(InteroperationError::CkbVM)?;
@@ -85,6 +92,7 @@ impl Interoperation for InteroperationImpl {
         mocked_tx: &TransactionView,
         dummy_input: Option<CellWithData>,
         max_cycles: u64,
+        version: CKBVMVersion,
     ) -> ProtocolResult<Cycle> {
         let rtx = Arc::new(resolve_transaction(&data_loader, mocked_tx, dummy_input)?);
         log::debug!("[mempool]: Verify by ckb vm tx {:?}", rtx);
@@ -93,15 +101,25 @@ impl Interoperation for InteroperationImpl {
         // syscalls3 are enabled. Due to only the hardfork field in consensus and the
         // epoch field in tx_env is used, the provided arguments only need to fill these
         // fields correctly.
-        let (ckb_spec, ckb2023_disabled_env) = (
-            Arc::new(Consensus::default()),
-            Arc::new(TxVerifyEnv::new_commit(
-                &HeaderBuilder::default()
-                    .number(CKB2023_DISABLED_NUMBER.pack())
-                    .epoch(CKB2023_DISABLED_EPOCH.pack())
-                    .build(),
-            )),
-        );
+        let (ckb_spec, ckb2023_disabled_env) = {
+            let env = match version {
+                CKBVMVersion::V2021 => TxVerifyEnv::new_commit(
+                    &HeaderBuilder::default()
+                        .number(CKB2023_DISABLED_NUMBER.pack())
+                        .epoch(CKB2023_DISABLED_EPOCH.pack())
+                        .build(),
+                ),
+                // TODO: Determine 2023 activation time
+                CKBVMVersion::V2023 => TxVerifyEnv::new_commit(
+                    &HeaderBuilder::default()
+                        .number(CKB2023_DISABLED_NUMBER.pack())
+                        .epoch(CKB2023_DISABLED_EPOCH.pack())
+                        .build(),
+                ),
+            };
+
+            (Arc::new(Consensus::default()), Arc::new(env))
+        };
 
         TransactionScriptsVerifier::new(rtx, data_loader, ckb_spec, ckb2023_disabled_env)
             .verify(max_cycles)

--- a/protocol/src/traits/interoperation.rs
+++ b/protocol/src/traits/interoperation.rs
@@ -2,7 +2,7 @@ use ckb_traits::{CellDataProvider, ExtensionProvider, HeaderProvider};
 use ckb_types::core::{cell::CellProvider, Cycle, TransactionView};
 use ckb_types::{packed, prelude::*};
 
-use crate::types::{Bytes, CellDep, CellWithData, SignatureR, SignatureS, VMResp};
+use crate::types::{Bytes, CKBVMVersion, CellDep, CellWithData, SignatureR, SignatureS, VMResp};
 use crate::{lazy::DUMMY_INPUT_OUT_POINT, traits::Context, ProtocolResult};
 
 pub const BYTE_SHANNONS: u64 = 100_000_000;
@@ -36,6 +36,7 @@ pub trait Interoperation: Sync + Send {
         data_cell_dep: CellDep,
         args: &[Bytes],
         max_cycles: u64,
+        vesion: CKBVMVersion,
     ) -> ProtocolResult<VMResp>;
 
     fn verify_by_ckb_vm<DL: CkbDataProvider + Sync + Send + 'static>(
@@ -44,6 +45,7 @@ pub trait Interoperation: Sync + Send {
         mocked_tx: &TransactionView,
         dummy_input: Option<CellWithData>,
         max_cycles: u64,
+        vesion: CKBVMVersion,
     ) -> ProtocolResult<Cycle>;
 
     /// The function construct the `TransactionView` payload required by

--- a/protocol/src/types/interoperation.rs
+++ b/protocol/src/types/interoperation.rs
@@ -135,6 +135,11 @@ impl SignatureR {
     }
 }
 
+pub enum CKBVMVersion {
+    V2021,
+    V2023,
+}
+
 #[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct CKBTxMockByRef {
     pub cell_deps:             Vec<CellDep>,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR enable a new hardfork with ckb vm

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
