### PR TITLE
chore(CI): build a portable binary in CI for different CPU architectures

### DIFF
--- a/.github/workflows/axon-start-with-short-genesis.yml
+++ b/.github/workflows/axon-start-with-short-genesis.yml
@@ -36,8 +36,8 @@ jobs:
         # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
         # related issue: https://github.com/axonweb3/axon/issues/1387
         lscpu
-        # RocksDB uses `-march=native`. Axon uses it too.
-        RUSTFLAGS="-C target-cpu=native" cargo build
+        # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
+        PORTABLE=1 USE_SSE=1 cargo build
 
     - name: Start a single Axon node
       env:
@@ -96,8 +96,8 @@ jobs:
         # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
         # related issue: https://github.com/axonweb3/axon/issues/1387
         lscpu
-        # RocksDB uses `-march=native`. Axon uses it too.
-        RUSTFLAGS="-C target-cpu=native" cargo build
+        # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
+        PORTABLE=1 USE_SSE=1 cargo build
 
     - name: Start multiple Axon nodes
       env:

--- a/.github/workflows/axon-start-with-short-genesis.yml
+++ b/.github/workflows/axon-start-with-short-genesis.yml
@@ -32,7 +32,12 @@ jobs:
         restore-keys: |
           ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
     - name: Build Axon in the development profile
-      run: cargo build
+      run: |
+        # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
+        # related issue: https://github.com/axonweb3/axon/issues/1387
+        lscpu
+        # RocksDB uses `-march=native`. Axon uses it too.
+        RUSTFLAGS="-C target-cpu=native" cargo build
 
     - name: Start a single Axon node
       env:
@@ -87,7 +92,12 @@ jobs:
         restore-keys: |
           ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
     - name: Build Axon in the development profile
-      run: cargo build
+      run: |
+        # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
+        # related issue: https://github.com/axonweb3/axon/issues/1387
+        lscpu
+        # RocksDB uses `-march=native`. Axon uses it too.
+        RUSTFLAGS="-C target-cpu=native" cargo build
 
     - name: Start multiple Axon nodes
       env:

--- a/.github/workflows/hardfork_test.yml
+++ b/.github/workflows/hardfork_test.yml
@@ -35,8 +35,8 @@ jobs:
         # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
         # related issue: https://github.com/axonweb3/axon/issues/1387
         lscpu
-        # RocksDB uses `-march=native`. Axon uses it too.
-        RUSTFLAGS="-C target-cpu=native" cargo build
+        # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
+        PORTABLE=1 USE_SSE=1 cargo build
 
     - name: Start multiple Axon nodes
       env:

--- a/.github/workflows/hardfork_test.yml
+++ b/.github/workflows/hardfork_test.yml
@@ -31,7 +31,12 @@ jobs:
         restore-keys: |
           ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
     - name: Build Axon in the development profile
-      run: cargo build
+      run: |
+        # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
+        # related issue: https://github.com/axonweb3/axon/issues/1387
+        lscpu
+        # RocksDB uses `-march=native`. Axon uses it too.
+        RUSTFLAGS="-C target-cpu=native" cargo build
 
     - name: Start multiple Axon nodes
       env:

--- a/.github/workflows/openzeppelin_test_11.yml
+++ b/.github/workflows/openzeppelin_test_11.yml
@@ -105,7 +105,12 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
       - name: Build Axon in the development profile
-        run: cargo build
+        run: |
+          # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
+          # related issue: https://github.com/axonweb3/axon/issues/1387
+          lscpu
+          # RocksDB uses `-march=native`. Axon uses it too.
+          RUSTFLAGS="-C target-cpu=native" cargo build
 
       - name: Deploy Local Network of Axon
         run: |

--- a/.github/workflows/openzeppelin_test_11.yml
+++ b/.github/workflows/openzeppelin_test_11.yml
@@ -109,8 +109,8 @@ jobs:
           # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
           # related issue: https://github.com/axonweb3/axon/issues/1387
           lscpu
-          # RocksDB uses `-march=native`. Axon uses it too.
-          RUSTFLAGS="-C target-cpu=native" cargo build
+          # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
+          PORTABLE=1 USE_SSE=1 cargo build
 
       - name: Deploy Local Network of Axon
         run: |

--- a/.github/workflows/openzeppelin_test_16_19.yml
+++ b/.github/workflows/openzeppelin_test_16_19.yml
@@ -105,7 +105,12 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
       - name: Build Axon in the development profile
-        run: cargo build
+        run: |
+          # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
+          # related issue: https://github.com/axonweb3/axon/issues/1387
+          lscpu
+          # RocksDB uses `-march=native`. Axon uses it too.
+          RUSTFLAGS="-C target-cpu=native" cargo build
 
       - name: Deploy Local Network of Axon
         run: |

--- a/.github/workflows/openzeppelin_test_16_19.yml
+++ b/.github/workflows/openzeppelin_test_16_19.yml
@@ -109,8 +109,8 @@ jobs:
           # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
           # related issue: https://github.com/axonweb3/axon/issues/1387
           lscpu
-          # RocksDB uses `-march=native`. Axon uses it too.
-          RUSTFLAGS="-C target-cpu=native" cargo build
+          # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
+          PORTABLE=1 USE_SSE=1 cargo build
 
       - name: Deploy Local Network of Axon
         run: |

--- a/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
+++ b/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
@@ -106,7 +106,12 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
       - name: Build Axon in the development profile
-        run: cargo build
+        run: |
+          # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
+          # related issue: https://github.com/axonweb3/axon/issues/1387
+          lscpu
+          # RocksDB uses `-march=native`. Axon uses it too.
+          RUSTFLAGS="-C target-cpu=native" cargo build
 
       - name: Deploy Local Network of Axon
         run: |

--- a/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
+++ b/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
@@ -110,8 +110,8 @@ jobs:
           # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
           # related issue: https://github.com/axonweb3/axon/issues/1387
           lscpu
-          # RocksDB uses `-march=native`. Axon uses it too.
-          RUSTFLAGS="-C target-cpu=native" cargo build
+          # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
+          PORTABLE=1 USE_SSE=1 cargo build
 
       - name: Deploy Local Network of Axon
         run: |

--- a/.github/workflows/openzeppelin_test_6_10.yml
+++ b/.github/workflows/openzeppelin_test_6_10.yml
@@ -105,7 +105,12 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
       - name: Build Axon in the development profile
-        run: cargo build
+        run: |
+          # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
+          # related issue: https://github.com/axonweb3/axon/issues/1387
+          lscpu
+          # RocksDB uses `-march=native`. Axon uses it too.
+          RUSTFLAGS="-C target-cpu=native" cargo build
 
       - name: Deploy Local Network of Axon
         run: |

--- a/.github/workflows/openzeppelin_test_6_10.yml
+++ b/.github/workflows/openzeppelin_test_6_10.yml
@@ -109,8 +109,8 @@ jobs:
           # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
           # related issue: https://github.com/axonweb3/axon/issues/1387
           lscpu
-          # RocksDB uses `-march=native`. Axon uses it too.
-          RUSTFLAGS="-C target-cpu=native" cargo build
+          # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
+          PORTABLE=1 USE_SSE=1 cargo build
 
       - name: Deploy Local Network of Axon
         run: |

--- a/.github/workflows/v3_core_test.yml
+++ b/.github/workflows/v3_core_test.yml
@@ -97,8 +97,8 @@ jobs:
           # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
           # related issue: https://github.com/axonweb3/axon/issues/1387
           lscpu
-          # RocksDB uses `-march=native`. Axon uses it too.
-          RUSTFLAGS="-C target-cpu=native" cargo build
+          # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
+          PORTABLE=1 USE_SSE=1 cargo build
 
       - name: Deploy Local Network of Axon
         run: |

--- a/.github/workflows/v3_core_test.yml
+++ b/.github/workflows/v3_core_test.yml
@@ -93,7 +93,12 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
       - name: Build Axon in the development profile
-        run: cargo build
+        run: |
+          # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
+          # related issue: https://github.com/axonweb3/axon/issues/1387
+          lscpu
+          # RocksDB uses `-march=native`. Axon uses it too.
+          RUSTFLAGS="-C target-cpu=native" cargo build
 
       - name: Deploy Local Network of Axon
         run: |

--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -65,7 +65,12 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
       - name: Build Axon in the development profile
-        run: cargo build
+        run: |
+          # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
+          # related issue: https://github.com/axonweb3/axon/issues/1387
+          lscpu
+          # RocksDB uses `-march=native`. Axon uses it too.
+          RUSTFLAGS="-C target-cpu=native" cargo build
       - name: Deploy Local Network of Axon
         run: |
           ./target/debug/axon init \

--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -69,8 +69,8 @@ jobs:
           # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
           # related issue: https://github.com/axonweb3/axon/issues/1387
           lscpu
-          # RocksDB uses `-march=native`. Axon uses it too.
-          RUSTFLAGS="-C target-cpu=native" cargo build
+          # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
+          PORTABLE=1 USE_SSE=1 cargo build
       - name: Deploy Local Network of Axon
         run: |
           ./target/debug/axon init \


### PR DESCRIPTION
## What this PR does / why we need it?

This PR tries to:
- fix https://github.com/axonweb3/axon/issues/1387
- fix `Illegal instruction` issues recorded in https://github.com/axonweb3/axon/issues/1374


> PORTABLE=1: This flag is used to build a portable binary that can run on different machines with different CPU architectures. It disables the use of CPU-specific optimizations and generates code that is compatible with a wide range of CPUs

> USE_SSE=1: This flag enables the use of SSE instructions, which are a set of CPU instructions that can perform multiple operations on multiple data elements in parallel. SSE instructions can significantly improve performance for certain types of computations, such as multimedia processing

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
