### PR TITLE
chore: DO NOT change a tag on a remote repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,18 +139,6 @@ jobs:
           asset_path: ${{ github.workspace }}/axon_${{ needs.version.outputs.tag }}_${{ matrix.REL_PKG }}
           asset_content_type: application/octet-stream
 
-  force-push:
-    runs-on: ubuntu-22.04
-    needs:
-      - version
-      - Upload-release-files
-    steps:
-      - uses: actions/checkout@v4
-      - name: force update major tag
-        run: |
-          git tag v${{ needs.version.outputs.major }} ${{ needs.version.outputs.tag }} -f
-          git push origin refs/tags/v${{ needs.version.outputs.major }} -f
-
   trigger-build-docker-image:
     runs-on: ubuntu-22.04
     needs:


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR resolves https://github.com/axonweb3/axon/issues/1478

"Do NOT change a tag on a remote repository, unless sensitive data was leaked."
It's a commonly accepted convention in the open-source world.

### What is the impact of this PR?

No Breaking Change

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
