### PR TITLE
refactor: remove the limitation of set ckb related info

### DIFF
--- a/core/consensus/src/util.rs
+++ b/core/consensus/src/util.rs
@@ -38,6 +38,8 @@ pub fn time_now() -> u64 {
 /// `keccak256` hash calculation at the end of each height. The reason why not
 /// use address directly is that the `PeerId` is binding with public key not
 /// address.
+/// The `common_ref` do not affect the signature verification, it is a
+/// placeholder.
 pub struct OverlordCrypto {
     private_key: BlsPrivateKey,
     addr_pubkey: RwLock<HashMap<Bytes, BlsPublicKey>>,

--- a/core/executor/src/system_contract/metadata/mod.rs
+++ b/core/executor/src/system_contract/metadata/mod.rs
@@ -86,10 +86,6 @@ impl<Adapter: ExecutorAdapter + ApplyBackend> SystemContract<Adapter>
                 );
             }
             metadata_abi::MetadataContractCalls::SetCkbRelatedInfo(c) => {
-                if !adapter.block_number().is_zero() {
-                    return revert_resp(gas_limit);
-                }
-
                 exec_try!(
                     store.set_ckb_related_info(&c.info.into()),
                     gas_limit,

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -368,6 +368,7 @@ fn init_crypto(
         bls_pub_keys.insert(address, pub_key);
     }
 
+    // The `common_ref` is a placeholder, use empty string.
     let crypto = OverlordCrypto::new(bls_priv_key, bls_pub_keys, String::new());
     Ok(Arc::new(crypto))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR remove the limitation of `set_ckb_related_info` in metadata system contract. The method can be called by a validator in any time. After set the info, developer can get the info through rpc `axon_getCkbRelatedInfo`.
Besides, add some annotation for the `common_ref` of `OverlordCrypto`.

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #1501
- Close #1508 

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
