### PR TITLE
fix: check mempool when call `eth_getTransactionByHash`

### DIFF
--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: axonweb3/axon-test
-          ref: 0e2e379ac17175c301115127ea679f1d0085ddc3
+          ref: be8b502423fa41d4656ec2369d3ee5a729f56326
           path: axon-test
 
       - uses: actions/setup-node@v4

--- a/core/api/src/adapter.rs
+++ b/core/api/src/adapter.rs
@@ -142,7 +142,11 @@ where
         ctx: Context,
         tx_hash: Hash,
     ) -> ProtocolResult<Option<SignedTransaction>> {
-        self.storage.get_transaction_by_hash(ctx, &tx_hash).await
+        if let Some(tx) = self.mempool.get_tx_from_mem(ctx.clone(), &tx_hash) {
+            Ok(Some(tx))
+        } else {
+            self.storage.get_transaction_by_hash(ctx, &tx_hash).await
+        }
     }
 
     async fn get_transactions_by_hashes(

--- a/core/api/src/jsonrpc/error.rs
+++ b/core/api/src/jsonrpc/error.rs
@@ -31,8 +31,6 @@ pub enum RpcError {
     GasLimitIsZero,
     #[display(fmt = "Transaction is not signed")]
     TransactionIsNotSigned,
-    #[display(fmt = "Cannot get receipt by hash")]
-    CannotGetReceiptByHash,
     #[display(fmt = "Cannot get latest block")]
     CannotGetLatestBlock,
     #[display(fmt = "Invalid block hash")]
@@ -80,7 +78,6 @@ impl RpcError {
             RpcError::GasLimitIsTooLarge => -40009,
             RpcError::GasLimitIsZero => -40010,
             RpcError::TransactionIsNotSigned => -40011,
-            RpcError::CannotGetReceiptByHash => -40012,
             RpcError::CannotGetLatestBlock => -40013,
             RpcError::InvalidBlockHash => -40014,
             RpcError::InvalidFromBlockNumber(_) => -40015,
@@ -118,7 +115,6 @@ impl From<RpcError> for ErrorObjectOwned {
             RpcError::GasLimitIsTooLarge => ErrorObject::owned(err_code, err, none_data),
             RpcError::GasLimitIsZero => ErrorObject::owned(err_code, err, none_data),
             RpcError::TransactionIsNotSigned => ErrorObject::owned(err_code, err, none_data),
-            RpcError::CannotGetReceiptByHash => ErrorObject::owned(err_code, err, none_data),
             RpcError::CannotGetLatestBlock => ErrorObject::owned(err_code, err, none_data),
             RpcError::InvalidBlockHash => ErrorObject::owned(err_code, err, none_data),
             RpcError::InvalidFromBlockNumber(_) => ErrorObject::owned(err_code, err, none_data),

--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -335,7 +335,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
             {
                 Ok(Some((stx, receipt).into()))
             } else {
-                Err(RpcError::CannotGetReceiptByHash.into())
+                Ok(Some(stx.into()))
             }
         } else {
             Ok(None)

--- a/core/mempool/src/pool.rs
+++ b/core/mempool/src/pool.rs
@@ -11,7 +11,7 @@ use parking_lot::{Mutex, RwLock};
 
 use protocol::tokio::{self, time::sleep};
 use protocol::types::{BlockNumber, Bytes, Hash, PackedTxHashes, SignedTransaction, H160, U256};
-use protocol::ProtocolResult;
+use protocol::{ProtocolResult, MEMPOOL_REFRESH_TIMEOUT};
 
 use crate::tx_wrapper::{PendingQueue, TxPtr, TxWrapper};
 use crate::MemPoolError;
@@ -72,7 +72,7 @@ impl PriorityPool {
                     }
                 }
 
-                sleep(Duration::from_millis(50)).await;
+                sleep(Duration::from_millis(MEMPOOL_REFRESH_TIMEOUT)).await;
             }
         });
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -11,6 +11,8 @@ pub use {
     trie,
 };
 
+pub const MEMPOOL_REFRESH_TIMEOUT: u64 = 50;
+
 #[derive(Copy, Clone, Debug)]
 pub enum ProtocolErrorKind {
     // traits


### PR DESCRIPTION
## What this PR does / why we need it?

This PR resolves #1523 partially.

This PR requires #1530.

_p.s. I say "partially" because no tests are updated or added._

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
