### PR TITLE
refactor: enhance readability of output logs and errors

### DIFF
--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -426,7 +426,7 @@ where
         // Todo: refactor after the first hard fork occurs.
         if previous_block.header.version != proposal.version {
             log::error!(
-                "[consensus] verify_version, block.header.version: {:?}, correct version {:?}",
+                "[consensus] verify_version, block.header.version: {}, correct version {}",
                 proposal.version,
                 BlockVersion::V0
             );
@@ -437,7 +437,7 @@ where
 
         if previous_block_hash != proposal.prev_hash {
             log::error!(
-                "[consensus] verify_block_header, previous_block_hash: {:?}, block.header.prev_hash: {:?}",
+                "[consensus] verify_block_header, previous_block_hash: {:#x}, block.header.prev_hash: {:#x}",
                 previous_block_hash,
                 proposal.prev_hash
             );
@@ -481,7 +481,7 @@ where
 
         if proposal_hash != proof.block_hash {
             log::error!(
-                "[consensus] verify_proof, block hash: {:?}, proof.block_hash: {:?}",
+                "[consensus] verify_proof, block hash: {:#x}, proof.block_hash: {:#x}",
                 proposal_hash,
                 proof.block_hash
             );
@@ -557,7 +557,7 @@ where
             proof.signature.clone(),
             hex_pubkeys,
         ).await.map_err(|e| {
-            log::error!("[consensus] verify_proof_signature error, number {}, vote: {:?}, vote_hash:{:?}, sig:{:?}, signed_voter:{:?}",
+            log::error!("[consensus] verify_proof_signature error, number {}, vote: {}, vote_hash: {:#x}, sig: 0x{:x}, signed_voter: {:?}",
             block.header.number,
             vote,
             vote_hash,
@@ -610,7 +610,7 @@ where
                     .ok_or(ConsensusError::VerifyProof(block_number, WeightNotFound))
                     .map_err(|e| {
                         log::error!(
-                            "[consensus] verify_proof_weight,signed_voter_address: {:?}",
+                            "[consensus] verify_proof_weight,signed_voter_address: {:#x}",
                             signed_voter_address
                         );
                         e
@@ -618,7 +618,7 @@ where
                 accumulator += u64::from(*(weight));
             } else {
                 log::error!(
-                    "[consensus] verify_proof_weight, weight not found, signed_voter_address: {:?}",
+                    "[consensus] verify_proof_weight, weight not found, signed_voter_address: {:#x}",
                     signed_voter_address
                 );
                 return Err(

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -20,7 +20,8 @@ use core_executor::MetadataHandle;
 use protocol::traits::{ConsensusAdapter, Context, MessageTarget, NodeInfo};
 use protocol::types::{
     Block, BlockVersion, Bytes, ExecResp, ExtraData, Hash, Hex, Metadata, Proof, Proposal,
-    SignedTransaction, ValidatorExtend, BASE_FEE_PER_GAS, MAX_BLOCK_GAS_LIMIT, RLP_NULL,
+    SignedTransaction, ValidatorExtend, VecDisplayHelper, BASE_FEE_PER_GAS, MAX_BLOCK_GAS_LIMIT,
+    RLP_NULL,
 };
 use protocol::{
     async_trait, codec::ProtocolCodec, tokio::sync::Mutex as AsyncMutex, types::HardforkInfoInner,
@@ -229,7 +230,7 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<Proposal> for ConsensusEngine<A
             .write_wal_cost
             .observe(common_apm::metrics::duration_to_sec(time.elapsed()));
         info!(
-            "[consensus-engine]: write wal cost {:?} tx_hashes_len {:?}",
+            "[consensus-engine]: write wal cost {:?} tx_hashes_len {}",
             time.elapsed(),
             tx_hashes_len
         );
@@ -316,9 +317,9 @@ impl<Adapter: ConsensusAdapter + 'static> Engine<Proposal> for ConsensusEngine<A
             .await?;
 
         info!(
-            "[consensus]: validator of number {} is {:?}",
+            "[consensus]: validator of number {} is {}",
             current_number + 1,
-            metadata.verifier_list
+            VecDisplayHelper(&metadata.verifier_list[..])
         );
 
         self.update_status(ctx.clone(), resp, proposal.clone(), proof, signed_txs)
@@ -535,7 +536,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
             .await
             .map_err(|e| {
                 error!(
-                    "[consensus] check_block, verify_block_header error, proposal: {:?}",
+                    "[consensus] check_block, verify_block_header error, proposal: {}",
                     proposal
                 );
                 e
@@ -567,7 +568,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
             .await
             .map_err(|e| {
                 error!(
-                    "[consensus] check_block, verify_proof error, previous block header: {:?}, proof: {:?}",
+                    "[consensus] check_block, verify_proof error, previous block header: {}, proof: {}",
                     previous_block.header,
                     proposal.proof
                 );
@@ -732,7 +733,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
         );
 
         if block.header.number != proof.number {
-            log::error!("[consensus] update_status for handle_commit error, before update, block number {}, proof number {}, proof {:?}",
+            log::error!("[consensus] update_status for handle_commit error, before update, block number {}, proof number {}, proof {}",
                 block_number,
                 proof.number,
                 proof
@@ -755,7 +756,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
             .await
             .is_err()
         {
-            log::error!("Missing next {:?} metadata!", next_epoch);
+            log::error!("Missing next {} metadata!", next_epoch);
         }
     }
 
@@ -805,7 +806,7 @@ fn validate_timestamp(
 ) -> bool {
     if proposal_timestamp < previous_timestamp {
         log::error!(
-            "[consensus] invalid timestamp previous {:?}, proposal {:?}",
+            "[consensus] invalid timestamp previous {}, proposal {}",
             previous_timestamp,
             proposal_timestamp
         );
@@ -814,7 +815,7 @@ fn validate_timestamp(
 
     if proposal_timestamp > current_timestamp {
         log::error!(
-            "[consensus] invalid timestamp proposal {:?}, current {:?}",
+            "[consensus] invalid timestamp proposal {}, current {}",
             proposal_timestamp,
             current_timestamp
         );

--- a/core/consensus/src/lib.rs
+++ b/core/consensus/src/lib.rs
@@ -56,23 +56,35 @@ pub enum ConsensusType {
 #[derive(Debug, Display)]
 pub enum ConsensusError {
     /// Check block error.
-    #[display(fmt = "Check invalid prev_hash, expect {:?} get {:?}", expect, actual)]
+    #[display(
+        fmt = "Check invalid prev_hash, expect {:#x} get {:#x}",
+        expect,
+        actual
+    )]
     InvalidPrevhash { expect: Hash, actual: Hash },
 
-    #[display(fmt = "Check invalid order root, expect {:?} get {:?}", expect, actual)]
+    #[display(
+        fmt = "Check invalid order root, expect {:#x} get {:#x}",
+        expect,
+        actual
+    )]
     InvalidOrderRoot {
         expect: MerkleRoot,
         actual: MerkleRoot,
     },
 
-    #[display(fmt = "Check invalid state root, expect {:?} get {:?}", expect, actual)]
+    #[display(
+        fmt = "Check invalid state root, expect {:#x} get {:#x}",
+        expect,
+        actual
+    )]
     InvalidStateRoot {
         expect: MerkleRoot,
         actual: MerkleRoot,
     },
 
     #[display(
-        fmt = "Check invalid receipts root, expect {:?} get {:?}",
+        fmt = "Check invalid receipts root, expect {:#x} get {:#x}",
         expect,
         actual
     )]
@@ -82,7 +94,7 @@ pub enum ConsensusError {
     },
 
     #[display(
-        fmt = "Check invalid order signed transactions hash, expect {:?} get {:?}",
+        fmt = "Check invalid order signed transactions hash, expect {:#x} get {:#x}",
         expect,
         actual
     )]
@@ -112,7 +124,7 @@ pub enum ConsensusError {
     InvalidProof { expect: u64, actual: u64 },
 
     /// Consensus missed the pill.
-    #[display(fmt = "Consensus missed pill cooresponding {:?}", _0)]
+    #[display(fmt = "Consensus missed pill cooresponding {:#x}", _0)]
     MissingPill(Hash),
 
     /// Invalid timestamp

--- a/core/consensus/src/synchronization.rs
+++ b/core/consensus/src/synchronization.rs
@@ -55,7 +55,7 @@ impl<Adapter: SynchronizationAdapter> Synchronization for OverlordSynchronizatio
         }
 
         log::info!(
-            "[synchronization]: sync start, remote block number {:?} current block number {:?}",
+            "[synchronization]: sync start, remote block number {} current block number {}",
             remote_number,
             current_number,
         );
@@ -73,7 +73,7 @@ impl<Adapter: SynchronizationAdapter> Synchronization for OverlordSynchronizatio
 
         if let Err(e) = sync_resp {
             log::error!(
-                "[synchronization]: err, current_number {:?} err_msg: {:?}",
+                "[synchronization]: err, current_number {} err_msg: {:?}",
                 sync_status.last_number,
                 e
             );
@@ -85,7 +85,7 @@ impl<Adapter: SynchronizationAdapter> Synchronization for OverlordSynchronizatio
         }
 
         log::info!(
-            "[synchronization]: sync end, remote block number {:?} current block number {:?}",
+            "[synchronization]: sync end, remote block number {} current block number {}",
             remote_number,
             sync_status.last_number,
         );
@@ -168,7 +168,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
                 .await
                 .map_err(|e| {
                     log::error!(
-                        "[synchronization]: get_rich_block_from_remote error, number: {:?}",
+                        "[synchronization]: get_rich_block_from_remote error, number: {}",
                         consenting_number
                     );
                     e
@@ -238,7 +238,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
             .await
             .map_err(|e| {
                 log::error!(
-                    "[synchronization]: verify_proof error, syncing block header: {:?}, proof: {:?}",
+                    "[synchronization]: verify_proof error, syncing block header: {}, proof: {}",
                     consenting_rich_block.block.header,
                     consenting_proof,
                 );
@@ -250,7 +250,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
             .await
             .map_err(|e| {
                 log::error!(
-                    "[synchronization]: verify_block_header error, block header: {:?}",
+                    "[synchronization]: verify_block_header error, block header: {}",
                     consenting_rich_block.block.header
                 );
                 e
@@ -277,7 +277,7 @@ impl<Adapter: SynchronizationAdapter> OverlordSynchronization<Adapter> {
             .await
             .map_err(|e| {
                 log::error!(
-                    "[synchronization]: verify_proof error, previous block header: {:?}, proof: {:?}",
+                    "[synchronization]: verify_proof error, previous block header: {}, proof: {}",
                     previous_block.header,
                     consenting_rich_block.block.header.proof
                 );

--- a/core/executor/src/system_contract/mod.rs
+++ b/core/executor/src/system_contract/mod.rs
@@ -206,7 +206,7 @@ pub fn system_contract_dispatch<Adapter: ExecutorAdapter + ApplyBackend>(
     tx: &SignedTransaction,
 ) -> Option<TxResp> {
     if let Some(addr) = tx.get_to() {
-        log::debug!("execute addr {:}", addr);
+        log::debug!("execute addr {:#x}", addr);
 
         if addr == NATIVE_TOKEN_CONTRACT_ADDRESS {
             return Some(NativeTokenContract::default().exec_(adapter, tx));

--- a/core/interoperation/src/lib.rs
+++ b/core/interoperation/src/lib.rs
@@ -114,7 +114,7 @@ pub enum InteroperationError {
     #[display(fmt = "Transaction missing signature")]
     MissingSignature,
 
-    #[display(fmt = "Cannot get program of out point {:?}", _0)]
+    #[display(fmt = "Cannot get program of out point {}", _0)]
     GetProgram(OutPoint),
 
     #[display(fmt = "CKB VM verify script failed {:?}", _0)]
@@ -123,10 +123,10 @@ pub enum InteroperationError {
     #[display(fmt = "CKB VM call failed {:?}", _0)]
     CkbVM(VMError),
 
-    #[display(fmt = "Unsupported blockchain id {:?}", _0)]
+    #[display(fmt = "Unsupported blockchain id {}", _0)]
     GetBlockchainCodeHash(u8),
 
-    #[display(fmt = "Get unknown cell by out point {:?}", _0)]
+    #[display(fmt = "Get unknown cell by out point {}", _0)]
     GetUnknownCell(OutPoint),
 
     #[display(fmt = "Invalid dep group {:?}", _0)]

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -205,7 +205,7 @@ where
                 self.network.report(
                     ctx,
                     TrustFeedback::Worse(format!(
-                        "Mempool wrong chain of tx {:?}",
+                        "Mempool wrong chain of tx {:#x}",
                         stx.transaction.hash
                     )),
                 );
@@ -225,7 +225,7 @@ where
                 self.network.report(
                     ctx,
                     TrustFeedback::Bad(format!(
-                        "Mempool exceed size limit of tx {:?}",
+                        "Mempool exceed size limit of tx {:#x}",
                         stx.transaction.hash
                     )),
                 );
@@ -257,7 +257,7 @@ where
                 self.network.report(
                     ctx,
                     TrustFeedback::Bad(format!(
-                        "Mempool exceed cycle limit of tx {:?}",
+                        "Mempool exceed cycle limit of tx {:#x}",
                         stx.transaction.hash
                     )),
                 );

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -170,7 +170,7 @@ where
             .collect::<Result<Vec<U256>, ProtocolError>>()?;
 
         log::info!(
-            "[mempool] verify txs done, size {:?} cost {:?}",
+            "[mempool] verify txs done, size {} cost {:?}",
             len,
             inst.elapsed()
         );

--- a/core/network/src/error.rs
+++ b/core/network/src/error.rs
@@ -60,7 +60,7 @@ pub enum ErrorKind {
     NoReactor(String),
 
     #[display(
-        fmt = "kind: cannot create chain address from bytes {:?} {}",
+        fmt = "kind: cannot create chain address from bytes {:#x} {}",
         pubkey,
         cause
     )]

--- a/protocol/src/types/block.rs
+++ b/protocol/src/types/block.rs
@@ -1,3 +1,4 @@
+use derive_more::Display;
 use faster_hex::withpfx_lowercase;
 use rlp_derive::{RlpDecodable, RlpEncodable};
 use serde::{Deserialize, Serialize};
@@ -6,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::codec::serialize_uint;
 use crate::types::{
     logs_bloom, Bloom, BloomInput, Bytes, ExecResp, Hash, Hasher, Log, MerkleRoot, Receipt,
-    SignedTransaction, H160, U256,
+    SignedTransaction, VecDisplayHelper, H160, U256,
 };
 use crate::{codec::ProtocolCodec, types::TypesError};
 
@@ -20,7 +21,7 @@ pub const MAX_FEE_HISTORY: u64 = 1024;
 pub const MAX_RPC_GAS_CAP: u64 = 50_000_000;
 pub const BASE_FEE_PER_GAS: u64 = 0x539;
 
-#[derive(Serialize, Deserialize, Default, Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Copy, Clone, Debug, PartialEq, Eq, Display)]
 pub enum BlockVersion {
     #[default]
     V0,
@@ -45,7 +46,30 @@ impl TryFrom<u8> for BlockVersion {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq, Display)]
+#[display(
+    fmt = "Proposal {{ \
+        version: {:?}, prev_hash: {:#x}, proposer: {:#x}, prev_state_root: {:#x}, \
+        transactions_root: {:#x}, signed_txs_hash: {:#x}, timestamp: {}, number: {}, \
+        gas_limit: {}, extra_data: {}, base_fee_per_gas: {}, proof: {}, \
+        call_system_script_count: {}, chain_id: {} tx_hashes: {:?} \
+    }}",
+    version,
+    prev_hash,
+    proposer,
+    prev_state_root,
+    transactions_root,
+    signed_txs_hash,
+    timestamp,
+    number,
+    gas_limit,
+    "VecDisplayHelper(&self.extra_data)",
+    base_fee_per_gas,
+    proof,
+    call_system_script_count,
+    chain_id,
+    tx_hashes
+)]
 pub struct Proposal {
     pub version:                  BlockVersion,
     pub prev_hash:                Hash,
@@ -120,8 +144,18 @@ pub struct PackedTxHashes {
 }
 
 #[derive(
-    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
+    RlpEncodable,
+    RlpDecodable,
+    Serialize,
+    Deserialize,
+    Default,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Display,
 )]
+#[display(fmt = "Block {{ header: {}, tx_hashes: {:?} }}", header, tx_hashes)]
 pub struct Block {
     pub header:    Header,
     pub tx_hashes: Vec<Hash>,
@@ -202,7 +236,42 @@ impl Block {
 }
 
 #[derive(
-    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
+    RlpEncodable,
+    RlpDecodable,
+    Serialize,
+    Deserialize,
+    Default,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Display,
+)]
+#[display(
+    fmt = "Header {{ \
+        version: {:?}, prev_hash: {:#x}, proposer: {:#x}, state_root: {:#x}, \
+        transactions_root: {:#x}, signed_txs_hash: {:#x}, receipts_root: {:#x}, \
+        log_bloom: {:#x}, timestamp: {}, number: {}, gas_used: {}, \
+        gas_limit: {}, extra_data: {}, base_fee_per_gas: {}, proof: {}, \
+        call_system_script_count: {}, chain_id: {} \
+    }}",
+    version,
+    prev_hash,
+    proposer,
+    state_root,
+    transactions_root,
+    signed_txs_hash,
+    receipts_root,
+    log_bloom,
+    timestamp,
+    number,
+    gas_used,
+    gas_limit,
+    "VecDisplayHelper(&self.extra_data)",
+    base_fee_per_gas,
+    proof,
+    call_system_script_count,
+    chain_id
 )]
 pub struct Header {
     pub version:                  BlockVersion,
@@ -242,8 +311,18 @@ impl Header {
 }
 
 #[derive(
-    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
+    RlpEncodable,
+    RlpDecodable,
+    Serialize,
+    Deserialize,
+    Default,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Display,
 )]
+#[display(fmt = "0x{:x}", inner)]
 pub struct ExtraData {
     #[cfg_attr(
         feature = "hex-serialize",
@@ -253,7 +332,27 @@ pub struct ExtraData {
 }
 
 #[derive(
-    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
+    RlpEncodable,
+    RlpDecodable,
+    Serialize,
+    Deserialize,
+    Default,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Display,
+)]
+#[display(
+    fmt = "Proof {{ \
+        number: {}, round: {}, block_hash: {:#x}, \
+        signature: 0x{:x}, bitmap: 0x{:x} \
+    }}",
+    number,
+    round,
+    block_hash,
+    signature,
+    bitmap
 )]
 pub struct Proof {
     #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]

--- a/protocol/src/types/interoperation.rs
+++ b/protocol/src/types/interoperation.rs
@@ -1,4 +1,5 @@
 use ckb_types::{core::cell::CellMeta, packed, prelude::*};
+use derive_more::Display;
 use rlp_derive::{RlpDecodable, RlpEncodable};
 use serde::{Deserialize, Serialize};
 
@@ -247,7 +248,10 @@ pub struct CellDepWithPubKey {
     pub pub_key:  Bytes,
 }
 
-#[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(
+    RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Display,
+)]
+#[display(fmt = "OutPoint {{ tx_hash: {:#x}, index: {} }}", tx_hash, index)]
 pub struct OutPoint {
     pub tx_hash: H256,
     pub index:   u32,

--- a/protocol/src/types/mod.rs
+++ b/protocol/src/types/mod.rs
@@ -33,11 +33,11 @@ use crate::{ProtocolError, ProtocolErrorKind};
 
 #[derive(Debug, Display, From)]
 pub enum TypesError {
-    #[display(fmt = "Expect {:?}, get {:?}.", expect, real)]
+    #[display(fmt = "Expect {}, get {}.", expect, real)]
     LengthMismatch { expect: usize, real: usize },
 
     #[display(
-        fmt = "Eip1559Transaction hash mismatch origin {:?}, computed {:?}",
+        fmt = "Eip1559Transaction hash mismatch origin {:#x}, computed {:#x}",
         origin,
         calc
     )]
@@ -82,7 +82,7 @@ pub enum TypesError {
     #[display(fmt = "Missing interoperation sender")]
     MissingInteroperationSender,
 
-    #[display(fmt = "InvalidBlockVersion {:?}", _0)]
+    #[display(fmt = "InvalidBlockVersion {}", _0)]
     InvalidBlockVersion(u8),
 }
 


### PR DESCRIPTION
## What this PR does / why we need it?

This PR enhances readability of output logs and errors.

Before this PR, there are many formats:
- `ethereum_types::H64`
  - Format with `{}` is `01ff....04ff`.
  - Format with `{:#x}` is `0x01ff02ff03ff04ff`.
- `bytes::Bytes`
  - Format with `{:?}` is `b"\xad@\xe1\xab\xcb\xa9F{6\x01\xa8"`.
  - Format with `{:#x}` is `01ff02ff03ff04ff`.
    Difference with `ethereum_types::Hxxx`, there is no 0x-prefix.
- `Vec<u8>`
  - Format with `{:?}` is `[1, 255, 2, 255, 3, 255, 4, 255]`.

The following changes are applied:
- Format `b"\xad@\xe1\xab\xcb\xa9F{6\x01\xa8"` to `0x01ff02ff03ff04ff`.
- Format `[1, 255, 2, 255, 3, 255, 4, 255]` to `0x01ff02ff03ff04ff`.
- Format `01ff....04ff` to `0x01ff02ff03ff04ff`.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>