### PR TITLE
fix: value of gas in JSON RPC Transaction should be gas limit

### DIFF
--- a/core/api/src/jsonrpc/web3_types.rs
+++ b/core/api/src/jsonrpc/web3_types.rs
@@ -164,7 +164,7 @@ impl From<(SignedTransaction, Receipt)> for Web3Transaction {
             block_hash:               Some(receipt.block_hash),
             raw:                      Hex::encode(stx.transaction.encode().unwrap()),
             public_key:               stx.public,
-            gas:                      receipt.used_gas,
+            gas:                      *stx.transaction.unsigned.gas_limit(),
             gas_price:                stx.transaction.unsigned.gas_price(),
             max_fee_per_gas:          if is_eip1559 {
                 Some(U256::from(MAX_PRIORITY_FEE_PER_GAS))


### PR DESCRIPTION
## What this PR does / why we need it?

This PR resolves #1529 partially.

This PR blocks #1526.

_p.s. "Partially" because no tests are updated or added in this PR._

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
