### PR TITLE
chore: change default cache size config

### DIFF
--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -36,7 +36,7 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-triedb_cache_size = 500
+triedb_cache_size = 200
 
 [logger]
 filter = "info"
@@ -44,14 +44,14 @@ log_to_console = true
 console_show_file_and_line = false
 log_path = "logs/"
 log_to_file = true
-file_size_limit = 1073741824 # 1 GiB
+file_size_limit = 1073741824       # 1 GiB
 metrics = true
 # you can specify log level for modules with config below
 # modules_level = { "overlord::state::process" = "debug", core_consensus = "error" }
 
 [rocksdb]
 max_open_files = 64
-cache_size = 200
+cache_size = 100
 # Provide an options file to tune RocksDB for your workload and your system configuration.
 # More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
 options_file = "default.db-options"

--- a/devtools/chain/k8s/node_1.toml
+++ b/devtools/chain/k8s/node_1.toml
@@ -42,7 +42,7 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-triedb_cache_size = 500
+triedb_cache_size = 200
 
 [logger]
 filter = "info"
@@ -50,14 +50,14 @@ log_to_console = true
 console_show_file_and_line = false
 log_path = "logs/"
 log_to_file = true
-file_size_limit = 1073741824 # 1 GiB
+file_size_limit = 1073741824       # 1 GiB
 metrics = true
 # you can specify log level for modules with config below
 # modules_level = { "overlord::state::process" = "debug" }
 
 [rocksdb]
 max_open_files = 64
-cache_size = 200
+cache_size = 100
 # Provide an options file to tune RocksDB for your workload and your system configuration.
 # More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
 options_file = "default.db-options"

--- a/devtools/chain/k8s/node_2.toml
+++ b/devtools/chain/k8s/node_2.toml
@@ -42,7 +42,7 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-triedb_cache_size = 500
+triedb_cache_size = 200
 
 [logger]
 filter = "info"
@@ -50,14 +50,14 @@ log_to_console = true
 console_show_file_and_line = false
 log_path = "logs/"
 log_to_file = true
-file_size_limit = 1073741824 # 1 GiB
+file_size_limit = 1073741824       # 1 GiB
 metrics = true
 # you can specify log level for modules with config below
 # modules_level = { "overlord::state::process" = "debug" }
 
 [rocksdb]
 max_open_files = 64
-cache_size = 200
+cache_size = 100
 # Provide an options file to tune RocksDB for your workload and your system configuration.
 # More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
 options_file = "default.db-options"

--- a/devtools/chain/k8s/node_3.toml
+++ b/devtools/chain/k8s/node_3.toml
@@ -42,7 +42,7 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-triedb_cache_size = 500
+triedb_cache_size = 200
 
 [logger]
 filter = "info"
@@ -50,14 +50,14 @@ log_to_console = true
 console_show_file_and_line = false
 log_path = "logs/"
 log_to_file = true
-file_size_limit = 1073741824 # 1 GiB
+file_size_limit = 1073741824       # 1 GiB
 metrics = true
 # you can specify log level for modules with config below
 # modules_level = { "overlord::state::process" = "debug" }
 
 [rocksdb]
 max_open_files = 64
-cache_size = 200
+cache_size = 100
 # Provide an options file to tune RocksDB for your workload and your system configuration.
 # More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
 options_file = "default.db-options"

--- a/devtools/chain/k8s/node_4.toml
+++ b/devtools/chain/k8s/node_4.toml
@@ -42,7 +42,7 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-triedb_cache_size = 500
+triedb_cache_size = 200
 
 [logger]
 filter = "info"
@@ -50,14 +50,14 @@ log_to_console = true
 console_show_file_and_line = false
 log_path = "logs/"
 log_to_file = true
-file_size_limit = 1073741824 # 1 GiB
+file_size_limit = 1073741824       # 1 GiB
 metrics = true
 # you can specify log level for modules with config below
 # modules_level = { "overlord::state::process" = "debug" }
 
 [rocksdb]
 max_open_files = 64
-cache_size = 200
+cache_size = 100
 # Provide an options file to tune RocksDB for your workload and your system configuration.
 # More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
 options_file = "default.db-options"

--- a/devtools/chain/nodes/node_1.toml
+++ b/devtools/chain/nodes/node_1.toml
@@ -41,7 +41,7 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-triedb_cache_size = 500
+triedb_cache_size = 200
 
 [logger]
 filter = "info"
@@ -49,14 +49,14 @@ log_to_console = true
 console_show_file_and_line = false
 log_path = "logs/node_1/"
 log_to_file = true
-file_size_limit = 1073741824 # 1 GiB
+file_size_limit = 1073741824       # 1 GiB
 metrics = true
 # you can specify log level for modules with config below
 # modules_level = { "overlord::state::process" = "debug", core_consensus = "error" }
 
 [rocksdb]
 max_open_files = 64
-cache_size = 200
+cache_size = 100
 # Provide an options file to tune RocksDB for your workload and your system configuration.
 # More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
 options_file = "default.db-options"

--- a/devtools/chain/nodes/node_2.toml
+++ b/devtools/chain/nodes/node_2.toml
@@ -41,7 +41,7 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-triedb_cache_size = 500
+triedb_cache_size = 200
 
 [logger]
 filter = "info"
@@ -49,14 +49,14 @@ log_to_console = true
 console_show_file_and_line = false
 log_path = "logs/node_2/"
 log_to_file = true
-file_size_limit = 1073741824 # 1 GiB
+file_size_limit = 1073741824       # 1 GiB
 metrics = true
 # you can specify log level for modules with config below
 # modules_level = { "overlord::state::process" = "debug", core_consensus = "error" }
 
 [rocksdb]
 max_open_files = 64
-cache_size = 200
+cache_size = 100
 # Provide an options file to tune RocksDB for your workload and your system configuration.
 # More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
 options_file = "default.db-options"

--- a/devtools/chain/nodes/node_3.toml
+++ b/devtools/chain/nodes/node_3.toml
@@ -41,7 +41,7 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-triedb_cache_size = 500
+triedb_cache_size = 200
 
 [logger]
 filter = "info"
@@ -49,14 +49,14 @@ log_to_console = true
 console_show_file_and_line = false
 log_path = "logs/node_3"
 log_to_file = true
-file_size_limit = 1073741824 # 1 GiB
+file_size_limit = 1073741824       # 1 GiB
 metrics = true
 # you can specify log level for modules with config below
 # modules_level = { "overlord::state::process" = "debug", core_consensus = "error" }
 
 [rocksdb]
 max_open_files = 64
-cache_size = 200
+cache_size = 100
 # Provide an options file to tune RocksDB for your workload and your system configuration.
 # More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
 options_file = "default.db-options"

--- a/devtools/chain/nodes/node_4.toml
+++ b/devtools/chain/nodes/node_4.toml
@@ -41,7 +41,7 @@ broadcast_txs_size = 200
 broadcast_txs_interval = 200
 
 [executor]
-triedb_cache_size = 500
+triedb_cache_size = 200
 
 [logger]
 filter = "info"
@@ -49,14 +49,14 @@ log_to_console = true
 console_show_file_and_line = false
 log_path = "logs/node_4/"
 log_to_file = true
-file_size_limit = 1073741824 # 1 GiB
+file_size_limit = 1073741824       # 1 GiB
 metrics = true
 # you can specify log level for modules with config below
 # modules_level = { "overlord::state::process" = "debug", core_consensus = "error" }
 
 [rocksdb]
 max_open_files = 64
-cache_size = 200
+cache_size = 100
 # Provide an options file to tune RocksDB for your workload and your system configuration.
 # More details can be found in [the official tuning guide](https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide).
 options_file = "default.db-options"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?



rocksdb_cache | trie_cache | Memory Usage | TPS
-- | -- | -- | --
0 | 0 |   |  
10 | 20 | 1.31G | 745
30 | 50 | 1.43G | 747
50 | 100 | 1.37G | 825
100 | 200 | 1.52G | 1000
200 | 500 | 1.54 | 1004




### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Axon configuration docs: https://docs.axonweb3.io/devops/configuration

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
