### PR TITLE
feat: add no-std version of axon-tools

### DIFF
--- a/devtools/axon-tools/Cargo.toml
+++ b/devtools/axon-tools/Cargo.toml
@@ -75,12 +75,13 @@ optional = true
 features = ["keccak"]
 
 [features]
-default = ["impl-serde", "proof"]
-proof = ["blst", "bit-vec", "cita_trie", "hash", "impl-rlp"]
+default = []
+proof = ["blst", "bit-vec", "hash", "impl-rlp"]
 hash = ["tiny-keccak"]
 hex = ["faster-hex"]
 impl-rlp = ["rlp", "rlp-derive", "ethereum-types/rlp"]
-impl-serde = ["serde", "ethereum-types/serialize", "hex"]
+impl-serde = ["serde", "ethereum-types/serialize"]
+std = ["cita_trie", "hex"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/devtools/axon-tools/Cargo.toml
+++ b/devtools/axon-tools/Cargo.toml
@@ -18,13 +18,21 @@ eth_light_client_in_ckb-prover = { version = "0.3.0-alpha", git = "https://githu
 ethereum = "0.14"
 ethers-core = "2.0.10"
 hex = "0.4"
+overlord = "0.4"
 rand = "0.8"
 
-[dependencies]
-derive_more = "0.99"
-log = "0.4.19"
-overlord = "0.4"
-serde_json = "1.0"
+[features]
+default = []
+proof = ["blst", "bit-vec", "hash", "impl-rlp"]
+hash = ["tiny-keccak"]
+hex = ["faster-hex"]
+impl-rlp = ["rlp", "rlp-derive", "ethereum-types/rlp"]
+impl-serde = ["serde", "ethereum-types/serialize"]
+std = ["cita_trie", "hex", "log", "derive_more", "serde_json"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "doc_cfg"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies.bit-vec]
@@ -45,6 +53,10 @@ features = ["serde"]
 version = "4.0"
 optional = true
 
+[dependencies.derive_more]
+version = "0.99"
+optional = true
+
 [dependencies.ethereum-types]
 version = "0.14"
 default-features = false
@@ -52,6 +64,11 @@ features = ["serialize"]
 
 [dependencies.faster-hex]
 version = "0.8"
+optional = true
+
+[dependencies.log]
+version = "0.4.19"
+default_features = false
 optional = true
 
 [dependencies.rlp]
@@ -69,20 +86,12 @@ default_features = false
 optional = true
 features = ["derive"]
 
+[dependencies.serde_json]
+version = "1.0"
+default_features = false
+optional = true
+
 [dependencies.tiny-keccak]
 version = "2.0"
 optional = true
 features = ["keccak"]
-
-[features]
-default = []
-proof = ["blst", "bit-vec", "hash", "impl-rlp"]
-hash = ["tiny-keccak"]
-hex = ["faster-hex"]
-impl-rlp = ["rlp", "rlp-derive", "ethereum-types/rlp"]
-impl-serde = ["serde", "ethereum-types/serialize"]
-std = ["cita_trie", "hex"]
-
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "doc_cfg"]

--- a/devtools/axon-tools/src/error.rs
+++ b/devtools/axon-tools/src/error.rs
@@ -77,6 +77,7 @@ pub enum TypesError {
     TxHashMismatch { origin: H256, calc: H256 },
 
     #[display(fmt = "{:?}", _0)]
+    #[cfg(feature = "hex")]
     FromHex(faster_hex::Error),
 
     #[display(fmt = "{:?} is an invalid address", _0)]

--- a/devtools/axon-tools/src/error.rs
+++ b/devtools/axon-tools/src/error.rs
@@ -1,5 +1,4 @@
-use derive_more::{Display, From};
-use ethereum_types::H256;
+#[cfg(feature = "std")]
 use std::fmt::{self, Display};
 
 #[allow(dead_code)]
@@ -18,7 +17,7 @@ pub enum Error {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "proof")))]
     Bls(blst::BLST_ERROR),
 
-    #[cfg(feature = "proof")]
+    #[cfg(all(feature = "proof", feature = "std"))]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "proof")))]
     Trie(cita_trie::TrieError),
 }
@@ -39,7 +38,7 @@ impl From<blst::BLST_ERROR> for Error {
     }
 }
 
-#[cfg(feature = "proof")]
+#[cfg(all(feature = "proof", feature = "std"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "proof")))]
 impl From<cita_trie::TrieError> for Error {
     fn from(e: cita_trie::TrieError) -> Self {
@@ -47,6 +46,7 @@ impl From<cita_trie::TrieError> for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -64,59 +64,7 @@ impl Display for Error {
     }
 }
 
-#[derive(Debug, Display, From)]
+#[derive(Debug)]
 pub enum TypesError {
-    #[display(fmt = "Expect {:?}, get {:?}.", expect, real)]
-    LengthMismatch { expect: usize, real: usize },
-
-    #[display(
-        fmt = "Eip1559Transaction hash mismatch origin {:?}, computed {:?}",
-        origin,
-        calc
-    )]
-    TxHashMismatch { origin: H256, calc: H256 },
-
-    #[display(fmt = "{:?}", _0)]
-    #[cfg(feature = "hex")]
-    FromHex(faster_hex::Error),
-
-    #[display(fmt = "{:?} is an invalid address", _0)]
-    InvalidAddress(String),
-
-    #[display(fmt = "Hex should start with 0x")]
-    HexPrefix,
-
-    #[display(fmt = "Invalid public key")]
-    InvalidPublicKey,
-
-    #[display(fmt = "Invalid check sum")]
-    InvalidCheckSum,
-
-    #[display(fmt = "Unsigned")]
-    Unsigned,
-
-    // #[display(fmt = "Crypto error {:?}", _0)]
-    // Crypto(CryptoError),
-    #[display(fmt = "Missing signature")]
-    MissingSignature,
-
-    #[display(fmt = "Invalid crosschain direction")]
-    InvalidDirection,
-
-    #[display(fmt = "Signature R is empty")]
-    SignatureRIsEmpty,
-
-    #[display(fmt = "Invalid signature R type")]
-    InvalidSignatureRType,
-
-    #[display(fmt = "Invalid address source type")]
-    InvalidAddressSourceType,
-
-    #[display(fmt = "Missing interoperation sender")]
-    MissingInteroperationSender,
-
-    #[display(fmt = "InvalidBlockVersion {:?}", _0)]
     InvalidBlockVersion(u8),
 }
-
-impl std::error::Error for TypesError {}

--- a/devtools/axon-tools/src/hash.rs
+++ b/devtools/axon-tools/src/hash.rs
@@ -13,6 +13,7 @@ pub fn keccak_256(data: &[u8]) -> [u8; 32] {
 #[derive(Default)]
 pub(crate) struct InnerKeccak;
 
+#[cfg(all(feature = "proof", feature = "std"))]
 impl cita_trie::Hasher for InnerKeccak {
     const LENGTH: usize = 32;
 

--- a/devtools/axon-tools/src/lib.rs
+++ b/devtools/axon-tools/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+// #![no_std]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 extern crate alloc;
@@ -17,7 +19,10 @@ pub use error::Error;
 
 #[cfg(feature = "proof")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "proof")))]
-pub use proof::{verify_proof, verify_trie_proof};
+pub use proof::verify_proof;
+
+#[cfg(all(feature = "proof", feature = "std"))]
+pub use proof::verify_trie_proof;
 
 #[cfg(feature = "hash")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "hash")))]

--- a/devtools/axon-tools/src/proof.rs
+++ b/devtools/axon-tools/src/proof.rs
@@ -7,11 +7,14 @@ use bytes::Bytes;
 use ethereum_types::H256;
 use rlp::Encodable;
 
+#[cfg(all(feature = "proof", feature = "std"))]
+use crate::hash::InnerKeccak;
 use crate::types::{AxonBlock, Proof, Proposal, ValidatorExtend, Vote};
-use crate::{error::Error, hash::InnerKeccak, keccak_256};
+use crate::{error::Error, keccak_256};
 
 const DST: &str = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RONUL";
 
+#[cfg(all(feature = "proof", feature = "std"))]
 pub fn verify_trie_proof(
     root: H256,
     key: &[u8],
@@ -91,11 +94,6 @@ fn extract_pks(
         count += 1;
     }
 
-    log::debug!(
-        "extract_pks count: {}, validator len: {}",
-        count,
-        validator_list.len()
-    );
     if count * 3 <= validator_list.len() * 2 {
         return Err(Error::NotEnoughSignatures);
     }

--- a/devtools/axon-tools/src/rlp_codec.rs
+++ b/devtools/axon-tools/src/rlp_codec.rs
@@ -1,4 +1,7 @@
-use crate::types::{BlockVersion, Proposal, Vote};
+#[cfg(feature = "impl-rlp")]
+use crate::types::BlockVersion;
+#[cfg(feature = "proof")]
+use crate::types::{Proposal, Vote};
 #[cfg(feature = "impl-rlp")]
 use rlp::{Decodable, DecoderError, Encodable, Rlp, RlpStream};
 

--- a/devtools/axon-tools/src/tests/verify_proof.rs
+++ b/devtools/axon-tools/src/tests/verify_proof.rs
@@ -1,16 +1,24 @@
+#[cfg(feature = "proof")]
 use crate::hash::keccak_256;
+#[cfg(feature = "proof")]
 use crate::types::{AxonBlock, BlockVersion, Metadata, Proof, Proposal, ValidatorExtend};
+#[cfg(feature = "proof")]
 use bytes::Bytes;
+#[cfg(feature = "proof")]
 use ethereum_types::{H160, H256, U256};
+#[cfg(feature = "proof")]
 use rlp::Encodable;
+#[cfg(feature = "proof")]
 use serde::de::DeserializeOwned;
 
+#[cfg(feature = "proof")]
 fn read_json<T: DeserializeOwned>(path: &str) -> T {
     let json = std::fs::read_to_string(path).unwrap();
     serde_json::from_str(&json).unwrap()
 }
 
 #[test]
+#[cfg(feature = "proof")]
 fn test_proposal() {
     let proposal = Proposal {
         version:                  BlockVersion::V0,
@@ -46,6 +54,7 @@ fn test_proposal() {
 }
 
 #[test]
+#[cfg(feature = "proof")]
 fn test_verify_proof() {
     let block: AxonBlock = read_json("src/tests/block.json");
     let proof: Proof = read_json("src/tests/proof.json");

--- a/devtools/axon-tools/src/tests/verify_trie_proof.rs
+++ b/devtools/axon-tools/src/tests/verify_trie_proof.rs
@@ -1,15 +1,19 @@
 #[cfg(feature = "proof")]
 use crate::verify_trie_proof;
-use eth_light_client_in_ckb_prover::{encode_receipt, Receipts};
-use ethereum_types::{Bloom, H256, U256};
 #[cfg(feature = "proof")]
-use ethers_core::utils::rlp;
+use eth_light_client_in_ckb_prover::{encode_receipt, Receipts};
+#[cfg(feature = "proof")]
+use ethereum_types::U256;
+use ethereum_types::{Bloom, H256};
+use ethers_core::{types::Log, utils::keccak256};
+#[cfg(feature = "proof")]
 use ethers_core::{
-    types::{Log, TransactionReceipt, U64},
-    utils::keccak256,
+    types::{TransactionReceipt, U64},
+    utils::rlp,
 };
 
 #[test]
+#[cfg(feature = "std")]
 fn test_receipt() {
     let mut tx_receipts = Vec::<TransactionReceipt>::new();
 

--- a/devtools/axon-tools/src/tests/verify_trie_proof.rs
+++ b/devtools/axon-tools/src/tests/verify_trie_proof.rs
@@ -1,9 +1,12 @@
+#[cfg(feature = "proof")]
 use crate::verify_trie_proof;
 use eth_light_client_in_ckb_prover::{encode_receipt, Receipts};
 use ethereum_types::{Bloom, H256, U256};
+#[cfg(feature = "proof")]
+use ethers_core::utils::rlp;
 use ethers_core::{
     types::{Log, TransactionReceipt, U64},
-    utils::{keccak256, rlp},
+    utils::keccak256,
 };
 
 #[test]
@@ -52,6 +55,7 @@ fn test_receipt() {
 }
 
 #[test]
+#[cfg(all(feature = "proof", feature = "std"))]
 fn test_verify_trie_proof() {
     let mut tx_receipts = Vec::<TransactionReceipt>::new();
 

--- a/devtools/axon-tools/src/types.rs
+++ b/devtools/axon-tools/src/types.rs
@@ -1,4 +1,5 @@
 use crate::error::TypesError;
+use alloc::vec;
 use alloc::vec::Vec;
 use bytes::{Bytes, BytesMut};
 use core::cmp::Ordering;
@@ -19,6 +20,7 @@ use core::str::FromStr;
 #[cfg(feature = "hex")]
 use faster_hex::withpfx_lowercase;
 
+#[cfg(feature = "std")]
 const HEX_PREFIX: &str = "0x";
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -56,6 +58,7 @@ impl Hex {
         self.0.clone()
     }
 
+    #[cfg(feature = "hex")]
     fn is_prefixed(s: &str) -> bool {
         s.starts_with(HEX_PREFIX)
     }
@@ -70,6 +73,13 @@ impl Default for Hex {
 impl AsRef<[u8]> for Hex {
     fn as_ref(&self) -> &[u8] {
         &self.0
+    }
+}
+
+impl From<Vec<u8>> for Hex {
+    fn from(bytes: Vec<u8>) -> Self {
+        let bytes = Bytes::from(bytes);
+        Hex(bytes)
     }
 }
 
@@ -92,7 +102,7 @@ impl From<Hex> for Bytes {
     }
 }
 
-#[cfg(feature = "impl-serde")]
+#[cfg(all(feature = "impl-serde", feature = "std"))]
 impl Serialize for Hex {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -102,7 +112,7 @@ impl Serialize for Hex {
     }
 }
 
-#[cfg(feature = "impl-serde")]
+#[cfg(all(feature = "impl-serde", feature = "std"))]
 impl<'de> Deserialize<'de> for Hex {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -128,6 +138,7 @@ impl From<BlockVersion> for u8 {
     }
 }
 
+// #[cfg(feature = "std")]
 impl TryFrom<u8> for BlockVersion {
     type Error = TypesError;
 
@@ -151,7 +162,7 @@ pub type BlockNumber = u64;
 #[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtraData {
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(
             serialize_with = "withpfx_lowercase::serialize",
             deserialize_with = "withpfx_lowercase::deserialize"
@@ -176,7 +187,7 @@ pub struct AxonHeader {
     pub receipts_root:            MerkleRoot,
     pub log_bloom:                Bloom,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(
             serialize_with = "encode::serialize_uint",
             deserialize_with = "decode::deserialize_hex_u64"
@@ -184,7 +195,7 @@ pub struct AxonHeader {
     )]
     pub timestamp:                u64,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(
             serialize_with = "encode::serialize_uint",
             deserialize_with = "decode::deserialize_hex_u64"
@@ -200,7 +211,7 @@ pub struct AxonHeader {
     pub base_fee_per_gas:         U256,
     pub proof:                    Proof,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(
             serialize_with = "encode::serialize_uint",
             deserialize_with = "decode::deserialize_hex_u32"
@@ -208,7 +219,7 @@ pub struct AxonHeader {
     )]
     pub call_system_script_count: u32,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(
             serialize_with = "encode::serialize_uint",
             deserialize_with = "decode::deserialize_hex_u64"
@@ -240,12 +251,12 @@ pub struct Proposal {
     pub transactions_root:        MerkleRoot,
     pub signed_txs_hash:          Hash,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub timestamp:                u64,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub number:                   BlockNumber,
@@ -254,12 +265,12 @@ pub struct Proposal {
     pub base_fee_per_gas:         U256,
     pub proof:                    Proof,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub chain_id:                 u64,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u32")
     )]
     pub call_system_script_count: u32,
@@ -274,7 +285,7 @@ pub struct Proposal {
 #[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Proof {
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(
             serialize_with = "encode::serialize_uint",
             deserialize_with = "decode::deserialize_hex_u64"
@@ -282,7 +293,7 @@ pub struct Proof {
     )]
     pub number:     u64,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(
             serialize_with = "encode::serialize_uint",
             deserialize_with = "decode::deserialize_hex_u64"
@@ -291,7 +302,7 @@ pub struct Proof {
     pub round:      u64,
     pub block_hash: Hash,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(
             serialize_with = "withpfx_lowercase::serialize",
             deserialize_with = "withpfx_lowercase::deserialize"
@@ -299,7 +310,7 @@ pub struct Proof {
     )]
     pub signature:  Bytes,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(
             serialize_with = "withpfx_lowercase::serialize",
             deserialize_with = "withpfx_lowercase::deserialize"
@@ -366,12 +377,12 @@ impl Vote {
 #[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MetadataVersion {
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub start: BlockNumber,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub end:   BlockNumber,
@@ -392,17 +403,23 @@ impl MetadataVersion {
     feature = "impl-rlp",
     derive(rlp_derive::RlpEncodable, rlp_derive::RlpDecodable)
 )]
-#[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    all(feature = "impl-serde", feature = "std"),
+    derive(serde::Serialize, serde::Deserialize)
+)]
 #[cfg_attr(feature = "hex", derive(Debug))]
 pub struct Metadata {
     pub version:          MetadataVersion,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub epoch:            u64,
     pub verifier_list:    Vec<ValidatorExtend>,
-    #[cfg_attr(feature = "impl-serde", serde(skip_deserializing))]
+    #[cfg_attr(
+        all(feature = "impl-serde", feature = "std"),
+        serde(skip_deserializing)
+    )]
     pub propose_counter:  Vec<ProposeCount>,
     pub consensus_config: ConsensusConfig,
 }
@@ -415,42 +432,42 @@ pub struct Metadata {
 #[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConsensusConfig {
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub gas_limit:       u64,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub interval:        u64,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub propose_ratio:   u64,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub prevote_ratio:   u64,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub precommit_ratio: u64,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub brake_ratio:     u64,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub tx_num_limit:    u64,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub max_tx_size:     u64,
@@ -462,7 +479,7 @@ pub struct ConsensusConfig {
 pub struct ProposeCount {
     pub address: H160,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u64")
     )]
     pub count:   u64,
@@ -473,18 +490,21 @@ pub struct ProposeCount {
     feature = "impl-rlp",
     derive(rlp_derive::RlpEncodable, rlp_derive::RlpDecodable)
 )]
-#[cfg_attr(feature = "impl-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    all(feature = "impl-serde", feature = "std"),
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct ValidatorExtend {
     pub bls_pub_key:    Hex,
     pub pub_key:        Hex,
     pub address:        H160,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u32")
     )]
     pub propose_weight: u32,
     #[cfg_attr(
-        feature = "impl-serde",
+        all(feature = "impl-serde", feature = "std"),
         serde(deserialize_with = "decode::deserialize_hex_u32")
     )]
     pub vote_weight:    u32,
@@ -501,16 +521,6 @@ impl Ord for ValidatorExtend {
         self.pub_key.as_bytes().cmp(&other.pub_key.as_bytes())
     }
 }
-
-// impl From<ValidatorExtend> for Validator {
-//     fn from(ve: ValidatorExtend) -> Self {
-//         Validator {
-//             pub_key:        ve.pub_key.as_bytes(),
-//             propose_weight: ve.propose_weight,
-//             vote_weight:    ve.vote_weight,
-//         }
-//     }
-// }
 
 #[cfg(feature = "hex")]
 impl std::fmt::Debug for ValidatorExtend {
@@ -548,7 +558,7 @@ pub struct CkbRelatedInfo {
     pub reward_smt_type_id:   H256,
 }
 
-#[cfg(feature = "impl-serde")]
+#[cfg(all(feature = "impl-serde", feature = "std"))]
 mod encode {
     use ethereum_types::U256;
     use serde::ser::Serializer;
@@ -599,7 +609,7 @@ mod encode {
     }
 }
 
-#[cfg(feature = "impl-serde")]
+#[cfg(all(feature = "impl-serde", feature = "std"))]
 mod decode {
     use ethereum_types::U256;
     use serde::de::{Deserialize, Deserializer};


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR add no-std version of axon-tools to support forcerelay related contracts.

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
