### PR TITLE
ci: specify commits of tests

### DIFF
--- a/.github/workflows/copy_config_to_devops.yml
+++ b/.github/workflows/copy_config_to_devops.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: axonweb3/axon-devops
+          ref: 32e274a1f14c065fe63d37f006ac1a3c4f70654f
           path: ${{ github.workspace}}/axon-devops
       - name: apply config toml config_toml.patch
         run: |

--- a/.github/workflows/hardfork_test.yml
+++ b/.github/workflows/hardfork_test.yml
@@ -77,7 +77,8 @@ jobs:
     - name: Checkout axonweb3/axon-hardfork-test
       uses: actions/checkout@v4
       with:
-        repository: sunchengzhu/axon-hardfork-test
+        repository: axonweb3/axon-hardfork-test
+        ref: 33eff5b0341097563ad4042dab3c5f72fd0b3abb
         path: axon-hardfork-test
 
     - name: Choose network

--- a/.github/workflows/openzeppelin_test_11.yml
+++ b/.github/workflows/openzeppelin_test_11.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: axonweb3/openzeppelin-contracts
-          ref: compatibillity-axon
+          ref: c2c4b8f591b7bc048dcbcf45dd2a1d2017074107
           path: openzeppelin-contracts
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/openzeppelin_test_16_19.yml
+++ b/.github/workflows/openzeppelin_test_16_19.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: axonweb3/openzeppelin-contracts
-          ref: compatibillity-axon
+          ref: c2c4b8f591b7bc048dcbcf45dd2a1d2017074107
           path: openzeppelin-contracts
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
+++ b/.github/workflows/openzeppelin_test_1_5_and_12_15.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: axonweb3/openzeppelin-contracts
-          ref: compatibillity-axon
+          ref: c2c4b8f591b7bc048dcbcf45dd2a1d2017074107
           path: openzeppelin-contracts
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/openzeppelin_test_6_10.yml
+++ b/.github/workflows/openzeppelin_test_6_10.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: axonweb3/openzeppelin-contracts
-          ref: compatibillity-axon
+          ref: c2c4b8f591b7bc048dcbcf45dd2a1d2017074107
           path: openzeppelin-contracts
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/v3_core_test.yml
+++ b/.github/workflows/v3_core_test.yml
@@ -73,6 +73,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: axonweb3/v3-core
+          ref: d60a654a45874155467b5e40605e5b8e1f5b423e
           path: v3-core
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -105,6 +105,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: axonweb3/axon-test
+          ref: 0e2e379ac17175c301115127ea679f1d0085ddc3
           path: axon-test
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR specifies commits of tests.

So, we could find a corresponding version of tests for every historical commits of Axon.
And, the CI won't be broken when those tests have new commits.

Temporarily fix the CI to allow PRs merged before #1534 fixed.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
