### PR TITLE
refactor: change some types from `U256` to `U64`

### DIFF
--- a/core/api/src/adapter.rs
+++ b/core/api/src/adapter.rs
@@ -207,7 +207,7 @@ where
             exec_ctx,
         )?;
         let gas_limit = gas_limit
-            .map(|gas| gas.as_u64())
+            .map(|gas| gas.low_u64())
             .unwrap_or(MAX_BLOCK_GAS_LIMIT);
 
         Ok(AxonExecutor.call(&backend, gas_limit, from, to, value, data))

--- a/core/api/src/jsonrpc/error.rs
+++ b/core/api/src/jsonrpc/error.rs
@@ -1,6 +1,6 @@
 use jsonrpsee::types::{error::ErrorObject, ErrorObjectOwned};
 
-use protocol::types::{ExitReason, TxResp};
+use protocol::types::{ExitReason, TxResp, U256};
 use protocol::{codec::hex_encode, Display};
 
 use core_executor::decode_revert_msg;
@@ -42,7 +42,7 @@ pub enum RpcError {
     #[display(fmt = "Invalid newest block {:?}", _0)]
     InvalidNewestBlock(BlockId),
     #[display(fmt = "Invalid position {}", _0)]
-    InvalidPosition(u64),
+    InvalidPosition(U256),
     #[display(fmt = "Cannot find the block")]
     CannotFindBlock,
     #[display(fmt = "Invalid reward percentiles {} {}", _0, _1)]
@@ -51,6 +51,8 @@ pub enum RpcError {
     InvalidFromBlockAndToBlockUnion,
     #[display(fmt = "Invalid filter id {}", _0)]
     CannotFindFilterId(u64),
+    #[display(fmt = "Invalid request params {}", _0)]
+    InvalidRequestParams(U256),
 
     #[display(fmt = "EVM error {}", "decode_revert_msg(&_0.ret)")]
     Evm(TxResp),
@@ -88,6 +90,7 @@ impl RpcError {
             RpcError::InvalidRewardPercentiles(_, _) => -40020,
             RpcError::InvalidFromBlockAndToBlockUnion => -40021,
             RpcError::CannotFindFilterId(_) => -40022,
+            RpcError::InvalidRequestParams(_) => -40023,
 
             RpcError::Evm(_) => -49998,
             RpcError::Internal(_) => -49999,
@@ -129,6 +132,7 @@ impl From<RpcError> for ErrorObjectOwned {
                 ErrorObject::owned(err_code, err, none_data)
             }
             RpcError::CannotFindFilterId(_) => ErrorObject::owned(err_code, err, none_data),
+            RpcError::InvalidRequestParams(_) => ErrorObject::owned(err_code, err, none_data),
 
             RpcError::Evm(resp) => {
                 ErrorObject::owned(err_code, err.clone(), Some(vm_err(resp.clone())))

--- a/core/api/src/jsonrpc/error.rs
+++ b/core/api/src/jsonrpc/error.rs
@@ -51,8 +51,6 @@ pub enum RpcError {
     InvalidFromBlockAndToBlockUnion,
     #[display(fmt = "Invalid filter id {}", _0)]
     CannotFindFilterId(u64),
-    #[display(fmt = "Invalid request params {}", _0)]
-    InvalidRequestParams(U256),
 
     #[display(fmt = "EVM error {}", "decode_revert_msg(&_0.ret)")]
     Evm(TxResp),
@@ -90,7 +88,6 @@ impl RpcError {
             RpcError::InvalidRewardPercentiles(_, _) => -40020,
             RpcError::InvalidFromBlockAndToBlockUnion => -40021,
             RpcError::CannotFindFilterId(_) => -40022,
-            RpcError::InvalidRequestParams(_) => -40023,
 
             RpcError::Evm(_) => -49998,
             RpcError::Internal(_) => -49999,
@@ -132,7 +129,6 @@ impl From<RpcError> for ErrorObjectOwned {
                 ErrorObject::owned(err_code, err, none_data)
             }
             RpcError::CannotFindFilterId(_) => ErrorObject::owned(err_code, err, none_data),
-            RpcError::InvalidRequestParams(_) => ErrorObject::owned(err_code, err, none_data),
 
             RpcError::Evm(resp) => {
                 ErrorObject::owned(err_code, err.clone(), Some(vm_err(resp.clone())))

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -65,7 +65,7 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
         Ok(ret)
     }
 
-    async fn get_proposal_by_number(&self, block_number: U256) -> RpcResult<Proposal> {
+    async fn get_proposal_by_number(&self, block_number: U64) -> RpcResult<Proposal> {
         let block_number = block_number.low_u64();
 
         let prev_state_root = if block_number == 0 {

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -35,7 +35,11 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
                     .get_block_by_number(Context::new(), Some(num.as_u64()))
                     .await
             }
-            BlockId::Earliest => self.adapter.get_block_by_number(Context::new(), Some(0)).await,
+            BlockId::Earliest => {
+                self.adapter
+                    .get_block_by_number(Context::new(), Some(0))
+                    .await
+            }
             BlockId::Latest => self.adapter.get_block_by_number(Context::new(), None).await,
             _ => return Err(ErrorCode::InvalidRequest.into()),
         }

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -32,7 +32,7 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
             // The block number is checked when deserialize
             BlockId::Num(num) => {
                 self.adapter
-                    .get_block_by_number(Context::new(), Some(num.as_u64()))
+                    .get_block_by_number(Context::new(), Some(num.low_u64()))
                     .await
             }
             BlockId::Earliest => {

--- a/core/api/src/jsonrpc/impl/axon.rs
+++ b/core/api/src/jsonrpc/impl/axon.rs
@@ -7,10 +7,9 @@ use common_config_parser::types::spec::HardforkName;
 use protocol::async_trait;
 use protocol::traits::{APIAdapter, Context};
 use protocol::types::{
-    Block, CkbRelatedInfo, HardforkInfoInner, Metadata, Proof, Proposal, H256, U256,
+    Block, CkbRelatedInfo, HardforkInfoInner, Metadata, Proof, Proposal, H256, U64,
 };
 
-use crate::jsonrpc::r#impl::u256_cast_u64;
 use crate::jsonrpc::web3_types::{BlockId, HardforkStatus};
 use crate::jsonrpc::{error::RpcError, AxonRpcServer};
 
@@ -56,11 +55,10 @@ impl<Adapter: APIAdapter + 'static> AxonRpcServer for AxonRpcImpl<Adapter> {
         Ok(ret)
     }
 
-    async fn get_metadata_by_number(&self, block_number: U256) -> RpcResult<Metadata> {
-        let block_number = u256_cast_u64(block_number)?;
+    async fn get_metadata_by_number(&self, block_number: U64) -> RpcResult<Metadata> {
         let ret = self
             .adapter
-            .get_metadata_by_number(Context::new(), Some(block_number))
+            .get_metadata_by_number(Context::new(), Some(block_number.low_u64()))
             .await
             .map_err(|e| RpcError::Internal(e.to_string()))?;
 

--- a/core/api/src/jsonrpc/impl/filter.rs
+++ b/core/api/src/jsonrpc/impl/filter.rs
@@ -204,7 +204,7 @@ where
 
                 match from {
                     BlockId::Num(n) => {
-                        if n.as_u64() < header.number {
+                        if n.low_u64() < header.number {
                             filter.from_block = Some(BlockId::Num(U64::from(header.number + 1)));
                         }
                     }
@@ -302,7 +302,7 @@ where
         let (start, end) = {
             let convert = |id: &BlockId| -> BlockNumber {
                 match id {
-                    BlockId::Num(n) => n.as_u64(),
+                    BlockId::Num(n) => n.low_u64(),
                     BlockId::Earliest => 0,
                     _ => latest_number,
                 }

--- a/core/api/src/jsonrpc/impl/mod.rs
+++ b/core/api/src/jsonrpc/impl/mod.rs
@@ -4,35 +4,8 @@ mod filter;
 mod node;
 mod web3;
 
-use protocol::types::U256;
-
-use crate::jsonrpc::error::RpcError;
-
 pub use axon::AxonRpcImpl;
 pub use ckb_light_client::CkbLightClientRpcImpl;
 pub use filter::filter_module;
 pub use node::NodeRpcImpl;
 pub use web3::{from_receipt_to_web3_log, Web3RpcImpl};
-
-const MAX_U64: U256 = U256([u64::MAX, 0, 0, 0]);
-
-#[allow(clippy::result_large_err)]
-pub(crate) fn u256_cast_u64(value: U256) -> Result<u64, RpcError> {
-    if value > MAX_U64 {
-        Err(RpcError::InvalidRequestParams(value))
-    } else {
-        Ok(value.low_u64())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_u256_cast_u64() {
-        assert_eq!(u256_cast_u64(U256::zero()).ok(), Some(0u64));
-        assert_eq!(u256_cast_u64(MAX_U64).ok(), Some(u64::MAX));
-        assert!(u256_cast_u64(u128::MAX.into()).is_err());
-    }
-}

--- a/core/api/src/jsonrpc/impl/mod.rs
+++ b/core/api/src/jsonrpc/impl/mod.rs
@@ -14,11 +14,25 @@ pub use filter::filter_module;
 pub use node::NodeRpcImpl;
 pub use web3::{from_receipt_to_web3_log, Web3RpcImpl};
 
+const MAX_U64: U256 = U256([u64::MAX, 0, 0, 0]);
+
 #[allow(clippy::result_large_err)]
 pub(crate) fn u256_cast_u64(value: U256) -> Result<u64, RpcError> {
-    if value > u64::max_value().into() {
+    if value > MAX_U64 {
         Err(RpcError::InvalidRequestParams(value))
     } else {
-        Ok(value.as_u64())
+        Ok(value.low_u64())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_u256_cast_u64() {
+        assert_eq!(u256_cast_u64(U256::zero()).ok(), Some(0u64));
+        assert_eq!(u256_cast_u64(MAX_U64).ok(), Some(u64::MAX));
+        assert!(u256_cast_u64(u128::MAX.into()).is_err());
     }
 }

--- a/core/api/src/jsonrpc/impl/mod.rs
+++ b/core/api/src/jsonrpc/impl/mod.rs
@@ -4,8 +4,21 @@ mod filter;
 mod node;
 mod web3;
 
+use protocol::types::U256;
+
+use crate::jsonrpc::error::RpcError;
+
 pub use axon::AxonRpcImpl;
 pub use ckb_light_client::CkbLightClientRpcImpl;
 pub use filter::filter_module;
 pub use node::NodeRpcImpl;
 pub use web3::{from_receipt_to_web3_log, Web3RpcImpl};
+
+#[allow(clippy::result_large_err)]
+pub(crate) fn u256_cast_u64(value: U256) -> Result<u64, RpcError> {
+    if value > u64::max_value().into() {
+        Err(RpcError::InvalidRequestParams(value))
+    } else {
+        Ok(value.as_u64())
+    }
+}

--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -133,6 +133,7 @@ impl<Adapter: APIAdapter> Web3RpcImpl<Adapter> {
         block_count: U256,
         reward_percentiles: &Option<Vec<f64>>,
     ) -> Result<(u64, Vec<U256>, Vec<f64>, Vec<Vec<U256>>), RpcError> {
+        let block_count = u256_cast_u64(block_count)?;
         let latest_block = self
             .adapter
             .get_block_by_number(Context::new(), height)
@@ -142,7 +143,7 @@ impl<Adapter: APIAdapter> Web3RpcImpl<Adapter> {
 
         let latest_block_number = latest_block.header.number;
         let oldest_block_number = latest_block_number
-            .saturating_sub(block_count.as_u64())
+            .saturating_sub(block_count)
             .saturating_add(1);
 
         let mut bash_fee_per_gases: Vec<U256> = Vec::new();
@@ -891,7 +892,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
         position: U256,
     ) -> RpcResult<Option<Web3Transaction>> {
         if position > U256::from(usize::MAX) {
-            return Err(RpcError::InvalidPosition(position.as_u64()).into());
+            return Err(RpcError::InvalidPosition(position).into());
         }
 
         let mut raw = [0u8; 32];
@@ -922,7 +923,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
         position: U256,
     ) -> RpcResult<Option<Web3Transaction>> {
         if position > U256::from(usize::MAX) {
-            return Err(RpcError::InvalidPosition(position.as_u64()).into());
+            return Err(RpcError::InvalidPosition(position).into());
         }
 
         let mut raw = [0u8; 32];

--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -455,7 +455,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
         }
 
         let num = match number {
-            Some(BlockId::Num(n)) => Some(n.as_u64()),
+            Some(BlockId::Num(n)) => Some(n.low_u64()),
             _ => None,
         };
         let data_bytes = req
@@ -674,7 +674,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
                 let (start, end) = {
                     let convert = |id: BlockId| -> BlockNumber {
                         match id {
-                            BlockId::Num(n) => n.as_u64(),
+                            BlockId::Num(n) => n.low_u64(),
                             BlockId::Earliest => 0,
                             _ => latest_number,
                         }
@@ -766,7 +766,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
         match newest_block {
             BlockId::Num(number) => {
                 let (oldest_block_number, bash_fee_per_gases, gas_used_ratios, reward) = self
-                    .inner_fee_history(number.as_u64().into(), blocks_count, &reward_percentiles)
+                    .inner_fee_history(number.low_u64().into(), blocks_count, &reward_percentiles)
                     .await?;
 
                 match reward_percentiles {
@@ -1048,7 +1048,8 @@ fn check_reward_percentiles(reward_percentiles: &Option<Vec<f64>>) -> RpcResult<
 fn calculate_gas_used_ratio(block: &Block) -> f64 {
     (block.header.gas_limit != U256::zero())
         .then(|| {
-            block.header.gas_used.as_u64() as f64 / block.header.gas_limit.as_u64() as f64 * 100f64
+            block.header.gas_used.low_u64() as f64 / block.header.gas_limit.low_u64() as f64
+                * 100f64
         })
         .unwrap_or(0f64)
 }

--- a/core/api/src/jsonrpc/mod.rs
+++ b/core/api/src/jsonrpc/mod.rs
@@ -15,13 +15,13 @@ use common_config_parser::types::{spec::HardforkName, Config};
 use protocol::traits::APIAdapter;
 use protocol::types::{
     Block, CkbRelatedInfo, EthAccountProof, Hash, Hex, Metadata, Proof, Proposal, H160, H256, U256,
+    U64,
 };
 use protocol::ProtocolResult;
 
 use crate::jsonrpc::web3_types::{
-    BlockCount, BlockId, FilterChanges, HardforkStatus, RawLoggerFilter, Web3Block,
-    Web3CallRequest, Web3FeeHistory, Web3Filter, Web3Log, Web3Receipt, Web3SyncStatus,
-    Web3Transaction,
+    BlockId, FilterChanges, HardforkStatus, RawLoggerFilter, Web3Block, Web3CallRequest,
+    Web3FeeHistory, Web3Filter, Web3Log, Web3Receipt, Web3SyncStatus, Web3Transaction,
 };
 use crate::jsonrpc::ws_subscription::{ws_subscription_module, HexIdProvider};
 use crate::APIError;
@@ -88,7 +88,7 @@ pub trait Web3Rpc {
     #[method(name = "eth_feeHistory")]
     async fn fee_history(
         &self,
-        block_count: BlockCount,
+        block_count: U64,
         newest_block: BlockId,
         reward_percentiles: Option<Vec<f64>>,
     ) -> RpcResult<Web3FeeHistory>;
@@ -222,10 +222,10 @@ pub trait AxonRpc {
     async fn get_proof_by_id(&self, block_id: BlockId) -> RpcResult<Option<Proof>>;
 
     #[method(name = "axon_getMetadataByNumber")]
-    async fn get_metadata_by_number(&self, block_number: U256) -> RpcResult<Metadata>;
+    async fn get_metadata_by_number(&self, block_number: U64) -> RpcResult<Metadata>;
 
     #[method(name = "axon_getProposalByNumber")]
-    async fn get_proposal_by_number(&self, block_number: U256) -> RpcResult<Proposal>;
+    async fn get_proposal_by_number(&self, block_number: U64) -> RpcResult<Proposal>;
 
     #[method(name = "axon_getCurrentMetadata")]
     async fn get_current_metadata(&self) -> RpcResult<Metadata>;

--- a/core/api/src/jsonrpc/web3_types.rs
+++ b/core/api/src/jsonrpc/web3_types.rs
@@ -334,6 +334,7 @@ pub enum BlockId {
 impl From<BlockId> for Option<u64> {
     fn from(id: BlockId) -> Self {
         match id {
+            // The BlockId deserialize visitor will ensure that the number is in u64 range.
             BlockId::Num(num) => Some(num.as_u64()),
             BlockId::Earliest => Some(0),
             _ => None,

--- a/core/api/src/jsonrpc/web3_types.rs
+++ b/core/api/src/jsonrpc/web3_types.rs
@@ -335,7 +335,7 @@ impl From<BlockId> for Option<u64> {
     fn from(id: BlockId) -> Self {
         match id {
             // The BlockId deserialize visitor will ensure that the number is in u64 range.
-            BlockId::Num(num) => Some(num.as_u64()),
+            BlockId::Num(num) => Some(num.low_u64()),
             BlockId::Earliest => Some(0),
             _ => None,
         }

--- a/core/api/src/jsonrpc/web3_types.rs
+++ b/core/api/src/jsonrpc/web3_types.rs
@@ -691,13 +691,6 @@ pub struct SyncStatus {
     pub pulled_states:  U256,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[serde(deny_unknown_fields, rename_all = "camelCase", untagged)]
-pub enum BlockCount {
-    U64Type(u64),
-    U256Type(U256),
-}
-
 /// Response type for `eth_feeHistory` RPC call.
 /// Three types of response are possible:
 /// 1. With reward, it returned when request parameter REWARDPERCENTILES is not

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -729,7 +729,7 @@ impl<Adapter: ConsensusAdapter + 'static> ConsensusEngine<Adapter> {
             ctx,
             resp.state_root,
             MAX_BLOCK_GAS_LIMIT,
-            last_status.max_tx_size.as_u64(),
+            last_status.max_tx_size.low_u64(),
         );
 
         if block.header.number != proof.number {

--- a/core/executor/benches/revm_adapter.rs
+++ b/core/executor/benches/revm_adapter.rs
@@ -52,7 +52,7 @@ where
         let raw = raw.unwrap();
         Ok(Some(Account::decode(raw).map(|a| AccountInfo {
             balance:   U256(a.balance.0),
-            nonce:     a.nonce.as_u64(),
+            nonce:     a.nonce.low_u64(),
             code_hash: a.code_hash,
             code:      None,
         })?))
@@ -101,11 +101,11 @@ where
 
     fn block_hash(&mut self, number: U256) -> Result<H256, Self::Error> {
         let current_number = self.exec_ctx.block_number;
-        if number.as_u64() > current_number.as_u64() {
+        if number > current_number {
             return Ok(H256::default());
         }
 
-        let number = number.as_u64();
+        let number = number.low_u64();
         let res = blocking_async!(self, storage, get_block, Context::new(), number)
             .map(|b| b.hash())
             .unwrap_or_default();
@@ -299,7 +299,7 @@ where
             .nonce;
         set_revm(
             evm,
-            tx.transaction.unsigned.gas_limit().as_u64(),
+            tx.transaction.unsigned.gas_limit().low_u64(),
             Some(tx.sender),
             tx.transaction.unsigned.to(),
             *tx.transaction.unsigned.value(),
@@ -324,7 +324,7 @@ where
             exit_reason: evm::ExitReason::Succeed(ExitSucceed::Returned),
             ret,
             gas_used: res.gas_used,
-            remain_gas: tx.transaction.unsigned.gas_limit().as_u64() - res.gas_used,
+            remain_gas: tx.transaction.unsigned.gas_limit().low_u64() - res.gas_used,
             fee_cost: res.gas_used.into(),
             // todo
             logs: vec![],

--- a/core/executor/src/adapter/backend/read_only.rs
+++ b/core/executor/src/adapter/backend/read_only.rs
@@ -77,7 +77,7 @@ where
             return H256::default();
         }
 
-        let number = number.as_u64();
+        let number = number.low_u64();
         blocking_async!(self, get_storage, get_block, Context::new(), number)
             .map(|b| b.hash())
             .unwrap_or_default()

--- a/core/executor/src/debugger/create2.rs
+++ b/core/executor/src/debugger/create2.rs
@@ -29,7 +29,7 @@ async fn test_create2_gas() {
     let gas_used = resp.tx_resp[0].gas_used;
     let after_balance = debugger.backend(1).basic(sender).balance;
 
-    assert_eq!(gas_used * 8, (init_balance - after_balance).as_u64());
+    assert_eq!(gas_used * 8, (init_balance - after_balance).low_u64());
 }
 
 fn mock_create2_tx(nonce: U256, sender: H160) -> SignedTransaction {

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -312,7 +312,7 @@ impl AxonExecutor {
         account.balance = account.balance.saturating_sub(prepay_gas);
         adapter.save_account(&sender, &account);
 
-        let metadata = StackSubstateMetadata::new(gas_limit.as_u64(), config);
+        let metadata = StackSubstateMetadata::new(gas_limit.low_u64(), config);
         let mut executor = StackExecutor::new_with_precompiles(
             MemoryStackState::new(metadata, adapter),
             config,
@@ -333,14 +333,14 @@ impl AxonExecutor {
                 *addr,
                 *tx.transaction.unsigned.value(),
                 tx.transaction.unsigned.data().to_vec(),
-                gas_limit.as_u64(),
+                gas_limit.low_u64(),
                 access_list,
             ),
             TransactionAction::Create => executor.transact_create(
                 tx.sender,
                 *tx.transaction.unsigned.value(),
                 tx.transaction.unsigned.data().to_vec(),
-                gas_limit.as_u64(),
+                gas_limit.low_u64(),
                 access_list,
             ),
         };

--- a/core/executor/src/system_contract/metadata/mod.rs
+++ b/core/executor/src/system_contract/metadata/mod.rs
@@ -50,7 +50,7 @@ impl<Adapter: ExecutorAdapter + ApplyBackend> SystemContract<Adapter>
         let tx = &tx.transaction.unsigned;
         let tx_data = tx.data();
         let gas_limit = *tx.gas_limit();
-        let block_number = adapter.block_number().as_u64();
+        let block_number = adapter.block_number().low_u64();
         let root = CURRENT_METADATA_ROOT.with(|r| *r.borrow());
 
         let mut store = exec_try!(
@@ -124,11 +124,11 @@ impl<Adapter: ExecutorAdapter + ApplyBackend> SystemContract<Adapter>
             }
         }
 
-        let hardfork = store.hardfork_info(block_number.as_u64()).unwrap();
+        let hardfork = store.hardfork_info(block_number.low_u64()).unwrap();
 
         HARDFORK_INFO.swap(Arc::new(hardfork));
 
-        if let Err(e) = store.update_propose_count(block_number.as_u64(), &adapter.origin()) {
+        if let Err(e) = store.update_propose_count(block_number.low_u64(), &adapter.origin()) {
             panic!("Update propose count at {:?} failed: {:?}", block_number, e)
         }
 

--- a/core/executor/src/system_contract/utils.rs
+++ b/core/executor/src/system_contract/utils.rs
@@ -14,7 +14,7 @@ pub fn revert_resp(gas_limit: U256) -> TxResp {
     TxResp {
         exit_reason:  ExitReason::Revert(ExitRevert::Reverted),
         ret:          vec![],
-        gas_used:     (gas_limit - 1).as_u64(),
+        gas_used:     (gas_limit - 1).low_u64(),
         remain_gas:   1u64,
         fee_cost:     U256::one(),
         logs:         vec![],
@@ -28,7 +28,7 @@ pub fn succeed_resp(gas_limit: U256) -> TxResp {
         exit_reason:  ExitReason::Succeed(ExitSucceed::Stopped),
         ret:          vec![],
         gas_used:     0u64,
-        remain_gas:   gas_limit.as_u64(),
+        remain_gas:   gas_limit.low_u64(),
         fee_cost:     U256::zero(),
         logs:         vec![],
         code_address: None,

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -262,7 +262,7 @@ where
             }
             return Err(MemPoolError::ExceedGasLimit {
                 tx_hash:          stx.transaction.hash,
-                gas_limit_tx:     gas_limit_tx.as_u64(),
+                gas_limit_tx:     gas_limit_tx.low_u64(),
                 gas_limit_config: self.gas_limit.load(Ordering::Acquire),
             }
             .into());
@@ -378,8 +378,8 @@ where
         if let Some(res) = self.addr_nonce.get(addr) {
             if tx.transaction.unsigned.nonce() < &res.value().0 {
                 return Err(MemPoolError::InvalidNonce {
-                    current:  res.value().0.as_u64(),
-                    tx_nonce: tx.transaction.unsigned.nonce().as_u64(),
+                    current:  res.value().0.low_u64(),
+                    tx_nonce: tx.transaction.unsigned.nonce().low_u64(),
                 }
                 .into());
             } else if res.value().1 < tx.transaction.unsigned.may_cost() {
@@ -401,8 +401,8 @@ where
 
         if &account.nonce > tx.transaction.unsigned.nonce() {
             return Err(MemPoolError::InvalidNonce {
-                current:  account.nonce.as_u64(),
-                tx_nonce: tx.transaction.unsigned.nonce().as_u64(),
+                current:  account.nonce.low_u64(),
+                tx_nonce: tx.transaction.unsigned.nonce().low_u64(),
             }
             .into());
         }

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -325,7 +325,7 @@ where
         Arc::clone(storage),
         Arc::clone(trie_db),
         current_header.chain_id,
-        current_header.gas_limit.as_u64(),
+        current_header.gas_limit.low_u64(),
         config.pool_size as usize,
         config.broadcast_txs_size,
         config.broadcast_txs_interval,

--- a/devtools/axon-tools/src/rlp_codec.rs
+++ b/devtools/axon-tools/src/rlp_codec.rs
@@ -46,7 +46,7 @@ impl Encodable for Proposal {
             .append(&self.signed_txs_hash)
             .append(&self.timestamp)
             .append(&self.number)
-            .append(&self.gas_limit.as_u64())
+            .append(&self.gas_limit.low_u64())
             .append_list(&self.extra_data)
             .append(&self.proof)
             .append(&self.call_system_script_count)

--- a/protocol/src/codec/block.rs
+++ b/protocol/src/codec/block.rs
@@ -32,7 +32,7 @@ impl Encodable for Proposal {
             .append(&self.signed_txs_hash)
             .append(&self.timestamp)
             .append(&self.number)
-            .append(&self.gas_limit.as_u64())
+            .append(&self.gas_limit.low_u64())
             .append_list(&self.extra_data)
             .append(&self.proof)
             .append(&self.call_system_script_count)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR:
1. Change the `block_number` parameter type of `axon_getMetadata` and `axon_getProposal` from `U256` to `U64`. Since then no need to check the u64 overflow.
2. Change some `as_u64` to `low_u64` to improve performance

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
