### PR TITLE
chore(CI): add a retry mechanism for Axon node's health_check

### DIFF
--- a/.github/workflows/axon-start-test.yml
+++ b/.github/workflows/axon-start-test.yml
@@ -56,7 +56,7 @@ jobs:
 
         npx zx <<'EOF'
         import { waitXBlocksPassed } from './devtools/ci/scripts/helper.js'
-        await waitXBlocksPassed('http://127.0.0.1:8000', 2);
+        await retry(3, '6s', () => waitXBlocksPassed('http://127.0.0.1:8000', 2))
         EOF
       timeout-minutes: 1
 
@@ -122,12 +122,12 @@ jobs:
 
         npx zx <<'EOF'
         import { waitXBlocksPassed } from './devtools/ci/scripts/helper.js'
-        await Promise.all([
+        await retry(3, '6s', () => Promise.all([
           waitXBlocksPassed('http://127.0.0.1:8001', 4),
           waitXBlocksPassed('http://127.0.0.1:8002', 4),
           waitXBlocksPassed('http://127.0.0.1:8003', 4),
           waitXBlocksPassed('http://127.0.0.1:8004', 4),
-        ])
+        ]))
         EOF
       timeout-minutes: 1
 

--- a/.github/workflows/build_image_ghcr.yml
+++ b/.github/workflows/build_image_ghcr.yml
@@ -122,6 +122,6 @@ jobs:
 
         npx zx <<'EOF'
         import { waitXBlocksPassed } from '../ci/scripts/helper.js'
-        await waitXBlocksPassed('http://127.0.0.1:8000', 2);
+        await retry(3, '6s', () => waitXBlocksPassed('http://127.0.0.1:8000', 2))
         EOF
       timeout-minutes: 2

--- a/.github/workflows/hardfork_test.yml
+++ b/.github/workflows/hardfork_test.yml
@@ -65,12 +65,12 @@ jobs:
 
         npx zx <<'EOF'
         import { waitXBlocksPassed } from './devtools/ci/scripts/helper.js'
-        await Promise.all([
+        await retry(3, '6s', () => Promise.all([
           waitXBlocksPassed('http://127.0.0.1:8001', 4),
           waitXBlocksPassed('http://127.0.0.1:8002', 4),
           waitXBlocksPassed('http://127.0.0.1:8003', 4),
           waitXBlocksPassed('http://127.0.0.1:8004', 4),
-        ])
+        ]))
         EOF
       timeout-minutes: 1
 

--- a/.github/workflows/web3_compatible.yml
+++ b/.github/workflows/web3_compatible.yml
@@ -140,8 +140,9 @@ jobs:
         run: |
           npx zx <<'EOF'
           import { waitXBlocksPassed } from './devtools/ci/scripts/helper.js'
-          await waitXBlocksPassed('http://127.0.0.1:8000', 2);
+          await retry(3, '6s', () => waitXBlocksPassed('http://127.0.0.1:8000', 2))
           EOF
+
       - name: Publish reports
         if: success() || failure()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR resolves #1465.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
