### PR TITLE
fix: use a same default value for `max_payload_size`

### DIFF
--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -12,7 +12,7 @@ data_path = "./devtools/chain/data"
 http_listening_address = "0.0.0.0:8000"
 ws_listening_address = "0.0.0.0:8010"
 maxconn = 25000
-max_payload_size = 10485760
+max_payload_size = 10_485_760
 client_version = "0.1.0"
 
 [web3]

--- a/devtools/chain/config.toml
+++ b/devtools/chain/config.toml
@@ -13,7 +13,6 @@ http_listening_address = "0.0.0.0:8000"
 ws_listening_address = "0.0.0.0:8010"
 maxconn = 25000
 max_payload_size = 10_485_760
-client_version = "0.1.0"
 
 [web3]
 max_gas_cap = 50_000_000

--- a/devtools/chain/k8s/node_1.toml
+++ b/devtools/chain/k8s/node_1.toml
@@ -10,7 +10,6 @@ http_listening_address = "0.0.0.0:8000"
 ws_listening_address = "0.0.0.0:8010"
 maxconn = 25000
 max_payload_size = 10_485_760
-client_version = "0.1.0"
 
 [web3]
 max_gas_cap = 50_000_000

--- a/devtools/chain/k8s/node_1.toml
+++ b/devtools/chain/k8s/node_1.toml
@@ -9,7 +9,7 @@ data_path = "./devtools/chain/data1"
 http_listening_address = "0.0.0.0:8000"
 ws_listening_address = "0.0.0.0:8010"
 maxconn = 25000
-max_payload_size = 10485760
+max_payload_size = 10_485_760
 client_version = "0.1.0"
 
 [web3]

--- a/devtools/chain/k8s/node_2.toml
+++ b/devtools/chain/k8s/node_2.toml
@@ -10,7 +10,6 @@ http_listening_address = "0.0.0.0:8000"
 ws_listening_address = "0.0.0.0:8010"
 maxconn = 25000
 max_payload_size = 10_485_760
-client_version = "0.1.0"
 
 [web3]
 max_gas_cap = 50_000_000

--- a/devtools/chain/k8s/node_2.toml
+++ b/devtools/chain/k8s/node_2.toml
@@ -9,7 +9,7 @@ data_path = "./devtools/chain/data2"
 http_listening_address = "0.0.0.0:8000"
 ws_listening_address = "0.0.0.0:8010"
 maxconn = 25000
-max_payload_size = 10485760
+max_payload_size = 10_485_760
 client_version = "0.1.0"
 
 [web3]

--- a/devtools/chain/k8s/node_3.toml
+++ b/devtools/chain/k8s/node_3.toml
@@ -9,7 +9,7 @@ data_path = "./devtools/chain/data3"
 http_listening_address = "0.0.0.0:8000"
 ws_listening_address = "0.0.0.0:8010"
 maxconn = 25000
-max_payload_size = 10485760
+max_payload_size = 10_485_760
 client_version = "0.1.0"
 
 [web3]

--- a/devtools/chain/k8s/node_3.toml
+++ b/devtools/chain/k8s/node_3.toml
@@ -10,7 +10,6 @@ http_listening_address = "0.0.0.0:8000"
 ws_listening_address = "0.0.0.0:8010"
 maxconn = 25000
 max_payload_size = 10_485_760
-client_version = "0.1.0"
 
 [web3]
 max_gas_cap = 50_000_000

--- a/devtools/chain/k8s/node_4.toml
+++ b/devtools/chain/k8s/node_4.toml
@@ -10,7 +10,6 @@ http_listening_address = "0.0.0.0:8000"
 ws_listening_address = "0.0.0.0:8010"
 maxconn = 25000
 max_payload_size = 10_485_760
-client_version = "0.1.0"
 
 [web3]
 max_gas_cap = 50_000_000

--- a/devtools/chain/k8s/node_4.toml
+++ b/devtools/chain/k8s/node_4.toml
@@ -9,7 +9,7 @@ data_path = "./devtools/chain/data4"
 http_listening_address = "0.0.0.0:8000"
 ws_listening_address = "0.0.0.0:8010"
 maxconn = 25000
-max_payload_size = 10485760
+max_payload_size = 10_485_760
 client_version = "0.1.0"
 
 [web3]

--- a/devtools/chain/nodes/node_1.toml
+++ b/devtools/chain/nodes/node_1.toml
@@ -9,7 +9,7 @@ data_path = "./devtools/chain/data/node_1"
 http_listening_address = "127.0.0.1:8001"
 ws_listening_address = "127.0.0.1:8011"
 maxconn = 25000
-max_payload_size = 1048576
+max_payload_size = 10_485_760
 
 [web3]
 max_gas_cap = 50_000_000

--- a/devtools/chain/nodes/node_2.toml
+++ b/devtools/chain/nodes/node_2.toml
@@ -9,7 +9,7 @@ data_path = "./devtools/chain/data/node_2"
 http_listening_address = "127.0.0.1:8002"
 ws_listening_address = "127.0.0.1:8012"
 maxconn = 25000
-max_payload_size = 1048576
+max_payload_size = 10_485_760
 
 [web3]
 max_gas_cap = 50_000_000

--- a/devtools/chain/nodes/node_3.toml
+++ b/devtools/chain/nodes/node_3.toml
@@ -9,7 +9,7 @@ data_path = "./devtools/chain/data/node_3"
 http_listening_address = "127.0.0.1:8003"
 ws_listening_address = "127.0.0.1:8013"
 maxconn = 25000
-max_payload_size = 1048576
+max_payload_size = 10_485_760
 
 [web3]
 max_gas_cap = 50_000_000

--- a/devtools/chain/nodes/node_4.toml
+++ b/devtools/chain/nodes/node_4.toml
@@ -9,7 +9,7 @@ data_path = "./devtools/chain/data/node_4"
 http_listening_address = "127.0.0.1:8004"
 ws_listening_address = "127.0.0.1:8014"
 maxconn = 25000
-max_payload_size = 1048576
+max_payload_size = 10_485_760
 
 [web3]
 max_gas_cap = 50_000_000


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR unifies the default value for `max_payload_size`.

https://github.com/axonweb3/axon/blob/9ad502d163517e49516448a7a72577e9db001c01/devtools/chain/k8s/node_1.toml#L12
https://github.com/axonweb3/axon/blob/9ad502d163517e49516448a7a72577e9db001c01/devtools/chain/nodes/node_1.toml#L12

### Questions

- [x] Could I remove the `client_version` field? Some configuration files have this field but some don't have.

  https://github.com/axonweb3/axon/blob/9ad502d163517e49516448a7a72577e9db001c01/devtools/chain/k8s/node_1.toml#L13

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
