### PR TITLE
feat: add `ckb_blake2b` precompile contract

### DIFF
--- a/core/executor/src/precompiles/ckb_blake2b.rs
+++ b/core/executor/src/precompiles/ckb_blake2b.rs
@@ -35,6 +35,8 @@ impl PrecompileContract for CkbBlake2b {
         ))
     }
 
+    /// Estimate the gas cost = MIN_GAS + dynamic_gas
+    ///                       = MIN_GAS + 12 * data_word_size
     fn gas_cost(input: &[u8]) -> u64 {
         let data_word_size = (input.len() + 31) / 32;
         (data_word_size * 12) as u64 + Self::MIN_GAS

--- a/core/executor/src/precompiles/ckb_blake2b.rs
+++ b/core/executor/src/precompiles/ckb_blake2b.rs
@@ -1,0 +1,42 @@
+use evm::executor::stack::{PrecompileFailure, PrecompileOutput};
+use evm::{Context, ExitError, ExitSucceed};
+
+use protocol::{ckb_blake2b_256, types::H160};
+
+use crate::err;
+use crate::precompiles::{axon_precompile_address, PrecompileContract};
+
+#[derive(Default, Clone)]
+pub struct CkbBlake2b;
+
+impl PrecompileContract for CkbBlake2b {
+    const ADDRESS: H160 = axon_precompile_address(0x06);
+    const MIN_GAS: u64 = 60;
+
+    fn exec_fn(
+        input: &[u8],
+        gas_limit: Option<u64>,
+        _context: &Context,
+        _is_static: bool,
+    ) -> Result<(PrecompileOutput, u64), PrecompileFailure> {
+        let gas = Self::gas_cost(input);
+        if let Some(limit) = gas_limit {
+            if gas > limit {
+                return err!();
+            }
+        }
+
+        Ok((
+            PrecompileOutput {
+                exit_status: ExitSucceed::Returned,
+                output:      ckb_blake2b_256(input).to_vec(),
+            },
+            gas,
+        ))
+    }
+
+    fn gas_cost(input: &[u8]) -> u64 {
+        let data_word_size = (input.len() + 31) / 32;
+        (data_word_size * 12) as u64 + Self::MIN_GAS
+    }
+}

--- a/core/executor/src/precompiles/mod.rs
+++ b/core/executor/src/precompiles/mod.rs
@@ -1,5 +1,6 @@
 mod blake2_f;
 mod call_ckb_vm;
+mod ckb_blake2b;
 mod ec_add;
 mod ec_mul;
 mod ec_pairing;
@@ -26,8 +27,9 @@ use evm::{Context, ExitError};
 use protocol::types::H160;
 
 use crate::precompiles::{
-    blake2_f::Blake2F, call_ckb_vm::CallCkbVM, ec_add::EcAdd, ec_mul::EcMul, ec_pairing::EcPairing,
-    ecrecover::EcRecover, identity::Identity, modexp::ModExp, ripemd160::Ripemd160, sha256::Sha256,
+    blake2_f::Blake2F, call_ckb_vm::CallCkbVM, ckb_blake2b::CkbBlake2b, ec_add::EcAdd,
+    ec_mul::EcMul, ec_pairing::EcPairing, ecrecover::EcRecover, identity::Identity, modexp::ModExp,
+    ripemd160::Ripemd160, sha256::Sha256,
 };
 
 #[macro_export]
@@ -93,7 +95,8 @@ const fn axon_precompile_address(addr: u8) -> H160 {
 
 pub fn build_precompile_set() -> BTreeMap<H160, PrecompileFn> {
     precompiles!(
-        EcRecover, Sha256, Ripemd160, Identity, ModExp, EcAdd, EcMul, EcPairing, Blake2F, CallCkbVM
+        EcRecover, Sha256, Ripemd160, Identity, ModExp, EcAdd, EcMul, EcPairing, Blake2F,
+        CallCkbVM, CkbBlake2b
     )
 }
 

--- a/core/executor/src/precompiles/tests.rs
+++ b/core/executor/src/precompiles/tests.rs
@@ -1,11 +1,11 @@
 use evm::Context;
 use sha2::Digest;
 
-use protocol::{codec::hex_decode, rand::random, types::U256};
+use protocol::{ckb_blake2b_256, codec::hex_decode, rand::random, types::U256};
 
 use crate::precompiles::{
-    Blake2F, EcAdd, EcMul, EcPairing, EcRecover, Identity, ModExp, PrecompileContract, Ripemd160,
-    Sha256,
+    Blake2F, CkbBlake2b, EcAdd, EcMul, EcPairing, EcRecover, Identity, ModExp, PrecompileContract,
+    Ripemd160, Sha256,
 };
 
 macro_rules! test_precompile {
@@ -47,6 +47,14 @@ fn test_sha256() {
     let output = hasher.finalize().to_vec();
 
     test_precompile!(Sha256, &input, output, 108);
+}
+
+#[test]
+fn test_ckb_blake2b() {
+    let input = rand_bytes(100);
+    let output = ckb_blake2b_256(&input);
+
+    test_precompile!(CkbBlake2b, &input, output, 108);
 }
 
 #[test]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR add [ckb_blake2b](https://docs.rs/ckb-hash/0.112.0/ckb_hash/fn.blake2b_256.html) hash precompile contract.
The gas calculation is same as [sha2-256](https://www.evm.codes/precompiled#0x02?fork=shanghai).

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
