### PR TITLE
refactor: remove duplicated code to protect :eye::eye: of developers

### DIFF
--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -332,16 +332,16 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
             .map_err(|e| RpcError::Internal(e.to_string()))?;
 
         if let Some(stx) = res {
+            let mut web3_stx: Web3Transaction = stx.into();
             if let Some(receipt) = self
                 .adapter
                 .get_receipt_by_tx_hash(Context::new(), hash)
                 .await
                 .map_err(|e| RpcError::Internal(e.to_string()))?
             {
-                Ok(Some((stx, receipt).into()))
-            } else {
-                Ok(Some(stx.into()))
+                web3_stx.update_with_receipt(&receipt);
             }
+            Ok(Some(web3_stx))
         } else {
             Ok(None)
         }


### PR DESCRIPTION
## What this PR does / why we need it?

This PR removes duplicated code to protect :eyes: of developers.
It harms :eyes: deeply to find differences between two more-than-50-lines duplicated code blocks. (ref: #1530)

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
