### PR TITLE
ci: run unit tests in separate processes

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -37,14 +37,17 @@ jobs:
           target/
         key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
 
+    - uses: taiki-e/install-action@nextest
     - name: Run Rust unit-test
       run: |
-        make test
+        make test-in-separate-processes
         du -hd1 target/debug/
         echo "reduce the cargo cache size"
         rm -rf target/debug/examples
         rm -rf target/debug/incremental
         du -hd1 target/debug/
+        ls -l ~/.cargo/bin/
+        rm -f ~/.cargo/bin/cargo-nextest
 
   other-unit-test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ CARGO := cargo
 test:
 	${CARGO} test ${VERBOSE} --all -- --nocapture
 
+# Since Axon uses global variables, run all tests in one process may cause unexpected errors.
+test-in-separate-processes:
+	cargo nextest run --workspace --no-fail-fast --hide-progress-bar --failure-output final
+
 doc:
 	cargo doc --all --no-deps
 


### PR DESCRIPTION
## What this PR does / why we need it?

Since Axon uses global variables, run all tests in one process may cause unexpected errors.

With this PR, unit tests will run in separate processes, instead of in threads.

False errors in the unit tests decrease developers' expectation threshold, make developers feel that failed CI checks are reasonable.
Like the story of the boy who cried wolf, it's dangerous.

I have to check CI every time when I see a red cross mark :x:, false errors also increase my mental load.

Let false errors f**k off!

## Out of Topic

The `$HOME/.cargo/bin` has more than 250 MiB binaries, which will be restored from cache, and then they will be overwritten by the binaries that download from internet.

Every workflow will put their tools that be downloaded into that directory, but no workflows will clean that directory.

<details><summary>Execute <code>ls -l ~/.cargo/bin/`</code>.</summary><br/>

```
-rwxr-xr-x 1 runner docker 15474520 Oct 26 18:15 bindgen
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 cargo
-rwxr-xr-x 1 runner docker 28399320 Oct 26 18:15 cargo-audit
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 cargo-clippy
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 cargo-fmt
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 cargo-miri
-rwxr-xr-x 1 runner docker 16653376 Oct 26 18:15 cargo-outdated
-rwxr-xr-x 1 runner docker 12171496 Oct 26 18:15 cbindgen
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 clippy-driver
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 rls
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 rust-analyzer
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 rust-gdb
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 rust-gdbgui
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 rust-lldb
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 rustc
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 rustdoc
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 rustfmt
-rwxr-xr-x 1 runner docker 14293176 Oct 26 18:15 rustup
```

</details>

---

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
