### PR TITLE
chore: axon-tools use ckb-blst for riscv64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "blst",
  "bytes",
  "cita_trie 4.1.0",
+ "ckb-blst",
  "derive_more",
  "eth_light_client_in_ckb-prover",
  "ethereum",
@@ -941,6 +942,17 @@ dependencies = [
  "hasher",
  "parking_lot 0.12.1",
  "rlp",
+]
+
+[[package]]
+name = "ckb-blst"
+version = "0.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23956c8f956fabab27aa20632fcefb1ab31f71544dab732c842064605932aea3"
+dependencies = [
+ "cc",
+ "glob",
+ "zeroize",
 ]
 
 [[package]]

--- a/devtools/axon-tools/Cargo.toml
+++ b/devtools/axon-tools/Cargo.toml
@@ -13,6 +13,10 @@ description = """
 Some axon related utilities.
 """
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "doc_cfg"]
+
 [dev-dependencies]
 eth_light_client_in_ckb-prover = { version = "0.3.0-alpha", git = "https://github.com/synapseweb3/eth-light-client-in-ckb" }
 ethereum = "0.14"
@@ -30,18 +34,10 @@ impl-rlp = ["rlp", "rlp-derive", "ethereum-types/rlp"]
 impl-serde = ["serde", "ethereum-types/serialize"]
 std = ["cita_trie", "hex", "log", "derive_more", "serde_json"]
 
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "doc_cfg"]
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies.bit-vec]
 version = "0.6"
 default_features = false
-optional = true
-
-[dependencies.blst]
-version = "0.3"
 optional = true
 
 [dependencies.bytes]
@@ -95,3 +91,9 @@ optional = true
 version = "2.0"
 optional = true
 features = ["keccak"]
+
+[target.'cfg(target_arch = "riscv64")'.dependencies]
+blst = { version = "0.100", package = "ckb-blst", optional = true }
+
+[target.'cfg(not(target_arch = "riscv64"))'.dependencies]
+blst = { version = "0.3", optional = true }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR fixes axon-tools for no_std (esp. ckb contract riscv64 target).

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
