### PR TITLE
fix(executor)!: set_ckb_related_info transaction is not committed

### DIFF
--- a/core/executor/src/system_contract/metadata/store.rs
+++ b/core/executor/src/system_contract/metadata/store.rs
@@ -72,12 +72,13 @@ impl MetadataStore {
     }
 
     pub fn set_ckb_related_info(&mut self, info: &CkbRelatedInfo) -> ProtocolResult<()> {
-        self.trie
-            .insert(
-                CKB_RELATED_INFO_KEY.as_bytes().to_vec(),
-                info.encode()?.to_vec(),
-            )
-            .map_err(Into::into)
+        self.trie.insert(
+            CKB_RELATED_INFO_KEY.as_bytes().to_vec(),
+            info.encode()?.to_vec(),
+        )?;
+        let new_root = self.trie.commit()?;
+        CURRENT_METADATA_ROOT.with(|r| *r.borrow_mut() = new_root);
+        Ok(())
     }
 
     pub fn append_metadata(&mut self, metadata: &Metadata) -> ProtocolResult<()> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR will commit if function setCkbRelatedInfo of system contract Metadata is called.

### What is the impact of this PR?

Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
