### PR TITLE
chore: make some structs to be public

### DIFF
--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -10,6 +10,9 @@ use common_apm_derive::trace_span;
 use core_executor::system_contract::metadata::MetadataHandle;
 use core_executor::{AxonExecutor, AxonExecutorApplyAdapter, AxonExecutorReadOnlyAdapter};
 use core_network::{PeerId, PeerIdExt};
+use protocol::constants::endpoints::{
+    BROADCAST_HEIGHT, RPC_SYNC_PULL_BLOCK, RPC_SYNC_PULL_PROOF, RPC_SYNC_PULL_TXS,
+};
 use protocol::traits::{
     CommonConsensusAdapter, ConsensusAdapter, Context, Executor, Gossip, MemPool, MessageTarget,
     Network, PeerTrust, Priority, Rpc, Storage, SynchronizationAdapter,
@@ -22,9 +25,6 @@ use protocol::types::{
 use protocol::{async_trait, tokio::task, trie, ProtocolResult};
 
 use crate::consensus::gen_overlord_status;
-use crate::message::{
-    BROADCAST_HEIGHT, RPC_SYNC_PULL_BLOCK, RPC_SYNC_PULL_PROOF, RPC_SYNC_PULL_TXS,
-};
 use crate::util::{convert_hex_to_bls_pubkeys, OverlordCrypto};
 use crate::BlockHeaderField::{PreviousBlockHash, Version};
 use crate::BlockProofField::{BitMap, HashMismatch, HeightMismatch, Signature, WeightNotFound};

--- a/core/consensus/src/engine.rs
+++ b/core/consensus/src/engine.rs
@@ -17,6 +17,10 @@ use common_crypto::BlsPublicKey;
 use common_logger::{json, log};
 use common_merkle::TrieMerkle;
 use core_executor::MetadataHandle;
+use protocol::constants::endpoints::{
+    END_GOSSIP_AGGREGATED_VOTE, END_GOSSIP_SIGNED_CHOKE, END_GOSSIP_SIGNED_PROPOSAL,
+    END_GOSSIP_SIGNED_VOTE,
+};
 use protocol::traits::{ConsensusAdapter, Context, MessageTarget, NodeInfo};
 use protocol::types::{
     Block, BlockVersion, Bytes, ExecResp, ExtraData, Hash, Hex, Metadata, Proof, Proposal,
@@ -28,10 +32,6 @@ use protocol::{
     ProtocolError, ProtocolResult,
 };
 
-use crate::message::{
-    END_GOSSIP_AGGREGATED_VOTE, END_GOSSIP_SIGNED_CHOKE, END_GOSSIP_SIGNED_PROPOSAL,
-    END_GOSSIP_SIGNED_VOTE,
-};
 use crate::status::{CurrentStatus, StatusAgent};
 use crate::stop_signal::StopSignal;
 use crate::util::{digest_signed_transactions, time_now, OverlordCrypto};

--- a/core/consensus/src/message.rs
+++ b/core/consensus/src/message.rs
@@ -7,6 +7,9 @@ use overlord::Codec;
 use rlp::Encodable;
 
 use common_apm_derive::trace_span;
+use protocol::constants::endpoints::{
+    RPC_RESP_SYNC_PULL_BLOCK, RPC_RESP_SYNC_PULL_PROOF, RPC_RESP_SYNC_PULL_TXS,
+};
 use protocol::traits::{
     Consensus, Context, MessageHandler, Priority, Rpc, Storage, Synchronization, TrustFeedback,
 };
@@ -16,18 +19,6 @@ use protocol::{async_trait, types::BlockNumber, ProtocolError};
 use core_storage::StorageError;
 
 pub use crate::types::PullTxsRequest;
-
-pub const END_GOSSIP_SIGNED_PROPOSAL: &str = "/gossip/consensus/signed_proposal";
-pub const END_GOSSIP_SIGNED_VOTE: &str = "/gossip/consensus/signed_vote";
-pub const END_GOSSIP_AGGREGATED_VOTE: &str = "/gossip/consensus/qc";
-pub const END_GOSSIP_SIGNED_CHOKE: &str = "/gossip/consensus/signed_choke";
-pub const RPC_SYNC_PULL_BLOCK: &str = "/rpc_call/consensus/sync_pull_block";
-pub const RPC_RESP_SYNC_PULL_BLOCK: &str = "/rpc_resp/consensus/sync_pull_block";
-pub const RPC_SYNC_PULL_TXS: &str = "/rpc_call/consensus/sync_pull_txs";
-pub const RPC_RESP_SYNC_PULL_TXS: &str = "/rpc_resp/consensus/sync_pull_txs";
-pub const BROADCAST_HEIGHT: &str = "/gossip/consensus/broadcast_height";
-pub const RPC_SYNC_PULL_PROOF: &str = "/rpc_call/consensus/sync_pull_proof";
-pub const RPC_RESP_SYNC_PULL_PROOF: &str = "/rpc_resp/consensus/sync_pull_proof";
 
 macro_rules! overlord_message {
     ($msg_name: ident, $overlord_type_name: ident) => {

--- a/core/mempool/src/adapter/message.rs
+++ b/core/mempool/src/adapter/message.rs
@@ -5,17 +5,14 @@ use rlp_derive::{RlpDecodable, RlpEncodable};
 
 use common_apm::Instant;
 use protocol::{
-    async_trait, tokio,
+    async_trait,
+    constants::endpoints::RPC_RESP_PULL_TXS,
+    tokio,
     traits::{Context, MemPool, MessageHandler, Priority, Rpc, TrustFeedback},
     types::{BatchSignedTxs, Hash, SignedTransaction},
 };
 
 use crate::context::TxContext;
-
-pub const END_GOSSIP_NEW_TXS: &str = "/gossip/mempool/new_txs";
-pub const RPC_PULL_TXS: &str = "/rpc_call/mempool/pull_txs";
-pub const RPC_RESP_PULL_TXS: &str = "/rpc_resp/mempool/pull_txs";
-pub const RPC_RESP_PULL_TXS_SYNC: &str = "/rpc_resp/mempool/pull_txs_sync";
 
 pub struct NewTxsHandler<M> {
     mem_pool: Arc<M>,

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -20,8 +20,10 @@ use protocol::types::{
     SignedTransaction, H160, U256,
 };
 use protocol::{
-    async_trait, codec::ProtocolCodec, tokio, trie, Display, ProtocolError, ProtocolErrorKind,
-    ProtocolResult,
+    async_trait,
+    codec::ProtocolCodec,
+    constants::endpoints::{END_GOSSIP_NEW_TXS, RPC_PULL_TXS},
+    tokio, trie, Display, ProtocolError, ProtocolErrorKind, ProtocolResult,
 };
 
 use common_apm_derive::trace_span;
@@ -31,7 +33,7 @@ use core_executor::{
 };
 use core_interoperation::InteroperationImpl;
 
-use crate::adapter::message::{MsgPullTxs, END_GOSSIP_NEW_TXS, RPC_PULL_TXS};
+use crate::adapter::message::MsgPullTxs;
 use crate::context::TxContext;
 use crate::MemPoolError;
 

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -5,10 +5,7 @@ mod pool;
 mod tests;
 mod tx_wrapper;
 
-pub use adapter::message::{
-    MsgPullTxs, NewTxsHandler, PullTxsHandler, END_GOSSIP_NEW_TXS, RPC_PULL_TXS, RPC_RESP_PULL_TXS,
-    RPC_RESP_PULL_TXS_SYNC,
-};
+pub use adapter::message::{MsgPullTxs, NewTxsHandler, PullTxsHandler};
 pub use adapter::{AdapterError, DefaultMemPoolAdapter};
 
 use std::collections::HashSet;

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -3,19 +3,21 @@
 mod common;
 mod compress;
 mod config;
-mod endpoint;
+pub mod endpoint;
 mod error;
 mod message;
 mod outbound;
-mod peer_manager;
-mod protocols;
-mod reactor;
+pub mod peer_manager;
+pub mod protocols;
+pub mod reactor;
 mod rpc;
 mod service;
 mod traits;
 
 pub use self::config::NetworkConfig;
-pub use self::service::{NetworkService, NetworkServiceHandle};
+pub use self::outbound::{NetworkGossip, NetworkRpc};
+pub use self::peer_manager::PeerManager;
+pub use self::service::{NetworkService, NetworkServiceHandle, ServiceHandler};
 pub use self::traits::NetworkContext;
 pub use tentacle::{
     multiaddr,

--- a/core/network/src/reactor/mod.rs
+++ b/core/network/src/reactor/mod.rs
@@ -13,7 +13,7 @@ use crate::message::NetworkMessage;
 use crate::rpc::RpcResponse;
 use crate::traits::NetworkContext;
 
-pub(crate) use router::{MessageRouter, RemotePeer, RouterContext};
+pub use router::{MessageRouter, RemotePeer, RouterContext};
 
 #[async_trait]
 pub trait Reactor: Send + Sync {
@@ -130,6 +130,15 @@ where
 {
     pub fn new() -> Self {
         NoopHandler { pin_m: PhantomData }
+    }
+}
+
+impl<M> Default for NoopHandler<M>
+where
+    M: MessageCodec,
+{
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/core/network/src/reactor/router.rs
+++ b/core/network/src/reactor/router.rs
@@ -69,6 +69,12 @@ pub struct MessageRouter {
     pub(crate) rpc_map: Arc<RpcMap>,
 }
 
+impl Default for MessageRouter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MessageRouter {
     pub fn new() -> Self {
         MessageRouter {

--- a/core/network/src/service.rs
+++ b/core/network/src/service.rs
@@ -542,9 +542,9 @@ where
     }
 }
 
-struct ServiceHandler {
-    peer_store: Arc<PeerManager>,
-    config:     Arc<NetworkConfig>,
+pub struct ServiceHandler {
+    pub peer_store: Arc<PeerManager>,
+    pub config:     Arc<NetworkConfig>,
 }
 
 #[async_trait]

--- a/core/run/src/components/network.rs
+++ b/core/run/src/components/network.rs
@@ -5,20 +5,19 @@ use std::sync::Arc;
 use core_consensus::message::{
     ChokeMessageHandler, ProposalMessageHandler, PullBlockRpcHandler, PullProofRpcHandler,
     PullTxsRpcHandler, QCMessageHandler, RemoteHeightMessageHandler, VoteMessageHandler,
-    BROADCAST_HEIGHT, END_GOSSIP_AGGREGATED_VOTE, END_GOSSIP_SIGNED_CHOKE,
-    END_GOSSIP_SIGNED_PROPOSAL, END_GOSSIP_SIGNED_VOTE, RPC_RESP_SYNC_PULL_BLOCK,
-    RPC_RESP_SYNC_PULL_PROOF, RPC_RESP_SYNC_PULL_TXS, RPC_SYNC_PULL_BLOCK, RPC_SYNC_PULL_PROOF,
-    RPC_SYNC_PULL_TXS,
 };
 use core_consensus::OverlordSynchronization;
 use core_db::RocksAdapter;
-use core_mempool::{
-    NewTxsHandler, PullTxsHandler, END_GOSSIP_NEW_TXS, RPC_PULL_TXS, RPC_RESP_PULL_TXS,
-    RPC_RESP_PULL_TXS_SYNC,
-};
+use core_mempool::{NewTxsHandler, PullTxsHandler};
 use core_network::{KeyProvider, NetworkService, PeerId, PeerIdExt};
 use core_storage::ImplStorage;
 use protocol::{
+    constants::endpoints::{
+        BROADCAST_HEIGHT, END_GOSSIP_AGGREGATED_VOTE, END_GOSSIP_NEW_TXS, END_GOSSIP_SIGNED_CHOKE,
+        END_GOSSIP_SIGNED_PROPOSAL, END_GOSSIP_SIGNED_VOTE, RPC_PULL_TXS, RPC_RESP_PULL_TXS,
+        RPC_RESP_PULL_TXS_SYNC, RPC_RESP_SYNC_PULL_BLOCK, RPC_RESP_SYNC_PULL_PROOF,
+        RPC_RESP_SYNC_PULL_TXS, RPC_SYNC_PULL_BLOCK, RPC_SYNC_PULL_PROOF, RPC_SYNC_PULL_TXS,
+    },
     traits::{Consensus, Context, MemPool, Network, SynchronizationAdapter},
     types::ValidatorExtend,
     ProtocolResult,

--- a/protocol/src/constants/endpoints.rs
+++ b/protocol/src/constants/endpoints.rs
@@ -1,0 +1,16 @@
+pub const END_GOSSIP_NEW_TXS: &str = "/gossip/mempool/new_txs";
+pub const RPC_PULL_TXS: &str = "/rpc_call/mempool/pull_txs";
+pub const RPC_RESP_PULL_TXS: &str = "/rpc_resp/mempool/pull_txs";
+pub const RPC_RESP_PULL_TXS_SYNC: &str = "/rpc_resp/mempool/pull_txs_sync";
+
+pub const END_GOSSIP_SIGNED_PROPOSAL: &str = "/gossip/consensus/signed_proposal";
+pub const END_GOSSIP_SIGNED_VOTE: &str = "/gossip/consensus/signed_vote";
+pub const END_GOSSIP_AGGREGATED_VOTE: &str = "/gossip/consensus/qc";
+pub const END_GOSSIP_SIGNED_CHOKE: &str = "/gossip/consensus/signed_choke";
+pub const RPC_SYNC_PULL_BLOCK: &str = "/rpc_call/consensus/sync_pull_block";
+pub const RPC_RESP_SYNC_PULL_BLOCK: &str = "/rpc_resp/consensus/sync_pull_block";
+pub const RPC_SYNC_PULL_TXS: &str = "/rpc_call/consensus/sync_pull_txs";
+pub const RPC_RESP_SYNC_PULL_TXS: &str = "/rpc_resp/consensus/sync_pull_txs";
+pub const BROADCAST_HEIGHT: &str = "/gossip/consensus/broadcast_height";
+pub const RPC_SYNC_PULL_PROOF: &str = "/rpc_call/consensus/sync_pull_proof";
+pub const RPC_RESP_SYNC_PULL_PROOF: &str = "/rpc_resp/consensus/sync_pull_proof";

--- a/protocol/src/constants/mod.rs
+++ b/protocol/src/constants/mod.rs
@@ -1,0 +1,1 @@
+pub mod endpoints;

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod codec;
+pub mod constants;
 pub mod lazy;
 pub mod traits;
 pub mod types;


### PR DESCRIPTION
## What this PR does / why we need it?

This PR is useful for creating network tools on Axon chain.
For example: count all nodes, p2p protocol fuzz tester.

### Commits

- chore: make some structs to be public
- chore: move constants to a lightweight crate
  To avoid compile RocksDB when users just want to refer the gossip endpoints.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>