### PR TITLE
fix(ci): Intermittent failures in eth_getCode_9

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -4,6 +4,7 @@ on:
   push:
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 # Ensure that only a single job or workflow using the same concurrency group will run at a time.
 # see https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

--- a/tests/e2e/src/eth_getCode.test.js
+++ b/tests/e2e/src/eth_getCode.test.js
@@ -55,13 +55,13 @@ describe("eth_getCode", () => {
  * param2: real number
  */
   it("eth_getCode_4", async () => {
-      const testType = await page.$(goto.pageIds.testTypeId);
-      const param1 = await page.$(goto.pageIds.param1Id);
-      const param2 = await page.$(goto.pageIds.param2Id);
-      await testType.type("1"); // 0: none params 1: common params to request 2: more params
-      await param1.type(testDataInfo.accountAddress);
-      await param2.type(testDataInfo.hexBlockNumber);
-      await goto.checkAndWait(page, "0x", 20);
+    const testType = await page.$(goto.pageIds.testTypeId);
+    const param1 = await page.$(goto.pageIds.param1Id);
+    const param2 = await page.$(goto.pageIds.param2Id);
+    await testType.type("1"); // 0: none params 1: common params to request 2: more params
+    await param1.type(testDataInfo.accountAddress);
+    await param2.type(testDataInfo.hexBlockNumber);
+    await goto.checkAndWait(page, "0x", 20);
   }, 25000);
 
   /**

--- a/tests/e2e/src/eth_getCode.test.js
+++ b/tests/e2e/src/eth_getCode.test.js
@@ -55,14 +55,14 @@ describe("eth_getCode", () => {
  * param2: real number
  */
   it("eth_getCode_4", async () => {
-    const testType = await page.$(goto.pageIds.testTypeId);
-    const param1 = await page.$(goto.pageIds.param1Id);
-    const param2 = await page.$(goto.pageIds.param2Id);
-    await testType.type("1"); // 0: none params 1: common params to request 2: more params
-    await param1.type(testDataInfo.accountAddress);
-    await param2.type(testDataInfo.hexBlockNumber);
-    await goto.check(page, "0x");
-  });
+      const testType = await page.$(goto.pageIds.testTypeId);
+      const param1 = await page.$(goto.pageIds.param1Id);
+      const param2 = await page.$(goto.pageIds.param2Id);
+      await testType.type("1"); // 0: none params 1: common params to request 2: more params
+      await param1.type(testDataInfo.accountAddress);
+      await param2.type(testDataInfo.hexBlockNumber);
+      await goto.checkAndWait(page, "0x", 20);
+  }, 25000);
 
   /**
   * param1: real account address but not exist

--- a/tests/e2e/src/eth_getCode.test.js
+++ b/tests/e2e/src/eth_getCode.test.js
@@ -61,6 +61,8 @@ describe("eth_getCode", () => {
     await testType.type("1"); // 0: none params 1: common params to request 2: more params
     await param1.type(testDataInfo.accountAddress);
     await param2.type(testDataInfo.hexBlockNumber);
+    // Running eth_getCode_4 and eth_getCode_9 simultaneously causes axonweb3/axon/issues/1579
+    // temporary solution: just wait 20 seconds after executing eth_getCode_4
     await goto.checkAndWait(page, "0x", 20);
   }, 25000);
 

--- a/tests/e2e/src/goto.js
+++ b/tests/e2e/src/goto.js
@@ -20,6 +20,14 @@ const goto = {
     await currentpage.waitForFunction(() => document.getElementById("ret").innerText !== "");
     await expect(currentpage.$eval("#ret", (e) => e.innerText)).resolves.toMatch(expectedValue);
   },
+
+  async checkAndWait(currentpage, expectedValue, second) {
+    await currentpage.click(goto.pageIds.btnId);
+    await currentpage.waitForFunction(() => document.getElementById("ret").innerText !== "");
+    await new Promise((resolve) => { setTimeout(resolve, second * 1000); });
+    await expect(currentpage.$eval("#ret", (e) => e.innerText)).resolves.toMatch(expectedValue);
+  },
+
   // get the  value
   async value(currentpage) {
     await currentpage.click(goto.pageIds.btnId);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR fixes the intermittent failure issue with eth_getCode_9.
### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref https://github.com/axonweb3/axon/issues/1579

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
