### PR TITLE
refactor!: call reserved system contract address is forbidden

### DIFF
--- a/core/api/src/jsonrpc/error.rs
+++ b/core/api/src/jsonrpc/error.rs
@@ -51,6 +51,8 @@ pub enum RpcError {
     InvalidFromBlockAndToBlockUnion,
     #[display(fmt = "Invalid filter id {}", _0)]
     CannotFindFilterId(u64),
+    #[display(fmt = "Not allow to call system contract address")]
+    CallSystemContract,
 
     #[display(fmt = "EVM error {}", "decode_revert_msg(&_0.ret)")]
     Evm(TxResp),
@@ -88,6 +90,7 @@ impl RpcError {
             RpcError::InvalidRewardPercentiles(_, _) => -40020,
             RpcError::InvalidFromBlockAndToBlockUnion => -40021,
             RpcError::CannotFindFilterId(_) => -40022,
+            RpcError::CallSystemContract => -40023,
 
             RpcError::Evm(_) => -49998,
             RpcError::Internal(_) => -49999,
@@ -129,6 +132,7 @@ impl From<RpcError> for ErrorObjectOwned {
                 ErrorObject::owned(err_code, err, none_data)
             }
             RpcError::CannotFindFilterId(_) => ErrorObject::owned(err_code, err, none_data),
+            RpcError::CallSystemContract => ErrorObject::owned(err_code, err, none_data),
 
             RpcError::Evm(resp) => {
                 ErrorObject::owned(err_code, err.clone(), Some(vm_err(resp.clone())))

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -11,6 +11,7 @@ pub use crate::adapter::{
     AxonExecutorApplyAdapter, AxonExecutorReadOnlyAdapter, MPTTrie, RocksTrieDB,
 };
 pub use crate::system_contract::{
+    is_call_system_script,
     metadata::{MetadataHandle, HARDFORK_INFO},
     DataProvider,
 };
@@ -34,8 +35,8 @@ use protocol::types::{
 use crate::precompiles::build_precompile_set;
 use crate::system_contract::{
     after_block_hook, before_block_hook, system_contract_dispatch,
-    CKB_LIGHT_CLIENT_CONTRACT_ADDRESS, HEADER_CELL_ROOT_KEY, IMAGE_CELL_CONTRACT_ADDRESS,
-    METADATA_CONTRACT_ADDRESS, METADATA_ROOT_KEY, NATIVE_TOKEN_CONTRACT_ADDRESS,
+    CKB_LIGHT_CLIENT_CONTRACT_ADDRESS, HEADER_CELL_ROOT_KEY, METADATA_CONTRACT_ADDRESS,
+    METADATA_ROOT_KEY,
 };
 
 lazy_static::lazy_static! {
@@ -488,20 +489,6 @@ impl AxonExecutor {
             gas_used: gas,
             tx_resp: res,
         }
-    }
-}
-
-pub fn is_call_system_script(action: &TransactionAction) -> bool {
-    let system_contracts = [
-        NATIVE_TOKEN_CONTRACT_ADDRESS,
-        METADATA_CONTRACT_ADDRESS,
-        CKB_LIGHT_CLIENT_CONTRACT_ADDRESS,
-        IMAGE_CELL_CONTRACT_ADDRESS,
-    ];
-
-    match action {
-        TransactionAction::Call(addr) => system_contracts.contains(addr),
-        TransactionAction::Create => false,
     }
 }
 

--- a/core/executor/src/system_contract/error.rs
+++ b/core/executor/src/system_contract/error.rs
@@ -3,7 +3,7 @@ use std::io;
 use ethers::abi::AbiError;
 use thiserror::Error;
 
-use protocol::{ProtocolError, ProtocolErrorKind};
+use protocol::{types::H160, ProtocolError, ProtocolErrorKind};
 
 #[derive(Error, Debug)]
 pub enum SystemScriptError {
@@ -84,6 +84,9 @@ pub enum SystemScriptError {
 
     #[error("Metadata version is discontinuous")]
     MetadataVersionDiscontinuity,
+
+    #[error("Call a reserved system contract address {0}")]
+    ReservedAddress(H160),
 }
 
 impl From<SystemScriptError> for ProtocolError {

--- a/core/executor/src/system_contract/mod.rs
+++ b/core/executor/src/system_contract/mod.rs
@@ -9,6 +9,7 @@ pub mod metadata;
 pub use crate::system_contract::ckb_light_client::{
     CkbLightClientContract, CKB_LIGHT_CLIENT_CONTRACT_ADDRESS,
 };
+use crate::system_contract::error::SystemScriptError;
 pub use crate::system_contract::image_cell::{ImageCellContract, IMAGE_CELL_CONTRACT_ADDRESS};
 pub use crate::system_contract::metadata::{
     check_ckb_related_info_exist, MetadataContract, METADATA_CONTRACT_ADDRESS,
@@ -29,7 +30,8 @@ use rocksdb::DB;
 
 use protocol::traits::{CkbDataProvider, ExecutorAdapter};
 use protocol::types::{
-    Bytes, HardforkInfoInner, Hasher, Metadata, SignedTransaction, TxResp, H160, H256,
+    Bytes, HardforkInfoInner, Hasher, Metadata, SignedTransaction, TransactionAction, TxResp, H160,
+    H256,
 };
 use protocol::{ckb_blake2b_256, ProtocolResult};
 
@@ -45,6 +47,12 @@ pub const fn system_contract_address(addr: u8) -> H160 {
         0xff, 0xff, 0xff, 0xff, addr,
     ])
 }
+const SYSTEM_CONTRACT_ADDRESSES_SET: [H160; 4] = [
+    NATIVE_TOKEN_CONTRACT_ADDRESS,
+    METADATA_CONTRACT_ADDRESS,
+    CKB_LIGHT_CLIENT_CONTRACT_ADDRESS,
+    IMAGE_CELL_CONTRACT_ADDRESS,
+];
 const HEADER_CELL_DB_CACHE_SIZE: usize = 200;
 const METADATA_DB_CACHE_SIZE: usize = 10;
 
@@ -302,5 +310,61 @@ impl CkbDataProvider for DataProvider {}
 impl DataProvider {
     pub fn new(root: H256) -> Self {
         DataProvider { root }
+    }
+}
+
+pub fn is_call_system_script(action: &TransactionAction) -> ProtocolResult<bool> {
+    let call_addr = match action {
+        TransactionAction::Call(addr) => addr,
+        TransactionAction::Create => return Ok(false),
+    };
+
+    // The first 19 bytes of the address are 0xff, which means that the address
+    // follows system contract address format.
+    if call_addr.0.iter().take(19).all(|i| i == &0xff) {
+        if SYSTEM_CONTRACT_ADDRESSES_SET.contains(call_addr) {
+            return Ok(true);
+        }
+
+        // Call a reserved system contract address returns error.
+        return Err(SystemScriptError::ReservedAddress(*call_addr).into());
+    }
+
+    // The address is not a system contract address.
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_call_system_contract() {
+        let action = TransactionAction::Create;
+        assert!(!is_call_system_script(&action).unwrap());
+
+        let addr = H160::from_low_u64_be(0x1);
+        let action = TransactionAction::Call(addr);
+        assert!(!is_call_system_script(&action).unwrap());
+
+        let addr = NATIVE_TOKEN_CONTRACT_ADDRESS;
+        let action = TransactionAction::Call(addr);
+        assert!(is_call_system_script(&action).unwrap());
+
+        let addr = METADATA_CONTRACT_ADDRESS;
+        let action = TransactionAction::Call(addr);
+        assert!(is_call_system_script(&action).unwrap());
+
+        let addr = CKB_LIGHT_CLIENT_CONTRACT_ADDRESS;
+        let action = TransactionAction::Call(addr);
+        assert!(is_call_system_script(&action).unwrap());
+
+        let addr = IMAGE_CELL_CONTRACT_ADDRESS;
+        let action = TransactionAction::Call(addr);
+        assert!(is_call_system_script(&action).unwrap());
+
+        let addr = system_contract_address(0x4);
+        let action = TransactionAction::Call(addr);
+        assert!(is_call_system_script(&action).is_err());
     }
 }

--- a/core/mempool/src/adapter/mod.rs
+++ b/core/mempool/src/adapter/mod.rs
@@ -372,7 +372,7 @@ where
         ctx: Context,
         tx: &SignedTransaction,
     ) -> ProtocolResult<U256> {
-        if is_call_system_script(tx.transaction.unsigned.action()) {
+        if is_call_system_script(tx.transaction.unsigned.action())? {
             return self.check_system_script_tx_authorization(ctx, tx).await;
         }
 

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -183,7 +183,7 @@ where
     Adapter: MemPoolAdapter + 'static,
 {
     async fn insert(&self, ctx: Context, tx: SignedTransaction) -> ProtocolResult<()> {
-        let is_call_system_script = is_call_system_script(tx.transaction.unsigned.action());
+        let is_call_system_script = is_call_system_script(tx.transaction.unsigned.action())?;
 
         log::debug!(
             "[mempool]: is call system script {:?}",
@@ -306,7 +306,7 @@ where
 
             for (signed_tx, check_nonce) in txs.into_iter().zip(check_nonces.into_iter()) {
                 let is_call_system_script =
-                    is_call_system_script(signed_tx.transaction.unsigned.action());
+                    is_call_system_script(signed_tx.transaction.unsigned.action())?;
                 if is_call_system_script {
                     self.pool.insert_system_script_tx(signed_tx)?;
                 } else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR change the call system contract address process. Call a reserved system contract address is forbidden during calling `eth_call`, `eth_estimateGas` and insert into mempool.

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
