### PR TITLE
fix: field `chainId` should be acceptable for `eth_estimateGas`

### DIFF
--- a/core/api/README.md
+++ b/core/api/README.md
@@ -2273,6 +2273,8 @@ The Web3CallRequest objects.
 
 *   `access_list`: `Array<` [`AccessList`](#type-AccessList)`>`  - The accessList specifies a list of addresses and storage keys; these addresses and storage keys are added into the accessed_addresses and accessed_storage_keys global sets.
 
+*   `chain_id`: [`U64`](#type-U64)  - QUANTITY - The id of the chain.
+
 *   `max_priority_fee_per_gas`: [`U256`](#type-U256)  -  QUANTITY - (optional) determined by the user, and is paid directly to miners.
 
 ### Type `AccessList`

--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -7,7 +7,7 @@ use protocol::traits::{APIAdapter, Context};
 use protocol::types::{
     Block, BlockNumber, Bytes, EthAccountProof, Hash, Header, Hex, Proposal, Receipt,
     SignedTransaction, TxResp, UnverifiedTransaction, BASE_FEE_PER_GAS, H160, H256,
-    MAX_FEE_HISTORY, MAX_RPC_GAS_CAP, MIN_TRANSACTION_GAS_LIMIT, U256,
+    MAX_FEE_HISTORY, MAX_RPC_GAS_CAP, MIN_TRANSACTION_GAS_LIMIT, U256, U64,
 };
 use protocol::{
     async_trait, codec::ProtocolCodec, lazy::PROTOCOL_VERSION, tokio::time::sleep, ProtocolResult,
@@ -1093,7 +1093,11 @@ fn mock_header_by_call_req(latest_header: Header, call_req: &Web3CallRequest) ->
         },
         proof:                    latest_header.proof,
         call_system_script_count: 0,
-        chain_id:                 latest_header.chain_id,
+        chain_id:                 call_req
+            .chain_id
+            .as_ref()
+            .map(U64::low_u64)
+            .unwrap_or(latest_header.chain_id),
     }
 }
 

--- a/core/api/src/jsonrpc/web3_types.rs
+++ b/core/api/src/jsonrpc/web3_types.rs
@@ -317,6 +317,7 @@ pub struct Web3CallRequest {
     pub nonce:                    Option<U256>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub access_list:              Option<AccessList>,
+    pub chain_id:                 Option<U64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_priority_fee_per_gas: Option<U256>,
 }


### PR DESCRIPTION
## What this PR does / why we need it?

This PR resolves #1583.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

</details>

_p.s. This PR is created via [GitHub CLI](https://cli.github.com/ "Try it!")._
