### PR TITLE
fix: enable estimation mode for query apis

### DIFF
--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -75,6 +75,7 @@ impl Executor for AxonExecutor {
         self.init_local_system_contract_roots(backend);
         let config = {
             let mut config = self.config();
+            // run the gasometer in estimate mode
             config.estimate = true;
             config
         };

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -73,7 +73,11 @@ impl Executor for AxonExecutor {
         data: Vec<u8>,
     ) -> TxResp {
         self.init_local_system_contract_roots(backend);
-        let config = self.config();
+        let config = {
+            let mut config = self.config();
+            config.estimate = true;
+            config
+        };
         let metadata = StackSubstateMetadata::new(gas_limit, &config);
         let state = MemoryStackState::new(metadata, backend);
         let precompiles = build_precompile_set();


### PR DESCRIPTION
## What this PR does / why we need it?

This PR may resolves #1286.

Ref:
- [EIP-150: Gas cost changes for IO-heavy operations](https://eips.ethereum.org/EIPS/eip-150) (see "all but one 64th" part).
- [EIP-2929: Gas cost increases for state access opcodes](https://eips.ethereum.org/EIPS/eip-2929)

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

</details>

_p.s. This PR is created via [GitHub CLI](https://cli.github.com/ "Try it!")._
