### PR TITLE
fix: get pending tx count by number

### DIFF
--- a/core/api/src/adapter.rs
+++ b/core/api/src/adapter.rs
@@ -177,11 +177,15 @@ where
         }
     }
 
-    async fn get_pending_tx_count(&self, ctx: Context, address: H160) -> ProtocolResult<U256> {
+    async fn get_pending_tx_count(
+        &self,
+        ctx: Context,
+        address: H160,
+    ) -> ProtocolResult<(U256, Option<BlockNumber>)> {
         self.mempool
             .get_tx_count_by_address(ctx, address)
             .await
-            .map(U256::from)
+            .map(|(n, b)| (U256::from(n), b))
     }
 
     async fn evm_call(

--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -354,14 +354,14 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
     ) -> RpcResult<U256> {
         match block_id.unwrap_or_default() {
             BlockId::Pending => {
-                let pending_tx_count = self
+                let (pending_tx_count, block_number) = self
                     .adapter
                     .get_pending_tx_count(Context::new(), address)
                     .await
                     .map_err(|e| RpcError::Internal(e.to_string()))?;
                 Ok(self
                     .adapter
-                    .get_account(Context::new(), address, BlockId::Pending.into())
+                    .get_account(Context::new(), address, block_number)
                     .await
                     .map(|account| account.nonce + pending_tx_count)
                     .unwrap_or_default())

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -320,7 +320,11 @@ where
         Ok(())
     }
 
-    async fn get_tx_count_by_address(&self, _ctx: Context, address: H160) -> ProtocolResult<usize> {
+    async fn get_tx_count_by_address(
+        &self,
+        _ctx: Context,
+        address: H160,
+    ) -> ProtocolResult<(usize, Option<BlockNumber>)> {
         Ok(self.pool.get_tx_count_by_address(address))
     }
 

--- a/protocol/src/traits/api.rs
+++ b/protocol/src/traits/api.rs
@@ -68,7 +68,11 @@ pub trait APIAdapter: Send + Sync {
         number: Option<BlockNumber>,
     ) -> ProtocolResult<Account>;
 
-    async fn get_pending_tx_count(&self, ctx: Context, address: H160) -> ProtocolResult<U256>;
+    async fn get_pending_tx_count(
+        &self,
+        ctx: Context,
+        address: H160,
+    ) -> ProtocolResult<(U256, Option<BlockNumber>)>;
 
     async fn evm_call(
         &self,

--- a/protocol/src/traits/mempool.rs
+++ b/protocol/src/traits/mempool.rs
@@ -35,7 +35,11 @@ pub trait MemPool: Send + Sync {
         order_tx_hashes: &[Hash],
     ) -> ProtocolResult<()>;
 
-    async fn get_tx_count_by_address(&self, ctx: Context, address: H160) -> ProtocolResult<usize>;
+    async fn get_tx_count_by_address(
+        &self,
+        ctx: Context,
+        address: H160,
+    ) -> ProtocolResult<(usize, Option<BlockNumber>)>;
 
     fn get_tx_from_mem(&self, ctx: Context, tx_hash: &Hash) -> Option<SignedTransaction>;
     fn set_args(&self, context: Context, state_root: MerkleRoot, gas_limit: u64, max_tx_size: u64);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR will get pending tx count by number

### What is the impact of this PR?

No Breaking Change

**PR relation**:
fix #1604 

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
