### PR TITLE
chore(CI): add missing `build axon` step in e2e-test

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -39,6 +39,12 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
 
+      - name: Build Axon in the development profile
+        run: |
+          # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
+          lscpu
+          cargo build
+
       - name: Start a single Axon node
         env:
           LOG_FILE: ${{ runner.temp }}/${{ matrix.os }}-single-axon-node.log


### PR DESCRIPTION


This PR fixed the error `target/debug/axon: No such file or directory` in the e2e-test.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
