### PR TITLE
feat(axon-tools): add precompile payload codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "eth_light_client_in_ckb-prover",
  "ethereum",
  "ethereum-types 0.14.1",
+ "ethers-contract",
  "ethers-core",
  "faster-hex 0.8.1",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "bytes",
  "cita_trie 4.1.0",
  "ckb-blst",
+ "ckb-types",
  "derive_more",
  "eth_light_client_in_ckb-prover",
  "ethereum",

--- a/devtools/axon-tools/Cargo.toml
+++ b/devtools/axon-tools/Cargo.toml
@@ -50,6 +50,10 @@ features = ["serde"]
 version = "4.0"
 optional = true
 
+[dependencies.ckb-types]
+version = "0.111"
+optional = true
+
 [dependencies.derive_more]
 version = "0.99"
 optional = true

--- a/devtools/axon-tools/Cargo.toml
+++ b/devtools/axon-tools/Cargo.toml
@@ -59,11 +59,11 @@ version = "0.14"
 default-features = false
 features = ["serialize"]
 
-[dependencies.ethers-core]
+[dependencies.ethers-contract]
 version = "2.0"
 optional = true
 
-[dependencies.ethers-contract]
+[dependencies.ethers-core]
 version = "2.0"
 optional = true
 

--- a/devtools/axon-tools/Cargo.toml
+++ b/devtools/axon-tools/Cargo.toml
@@ -32,6 +32,7 @@ hash = ["tiny-keccak"]
 hex = ["faster-hex"]
 impl-rlp = ["rlp", "rlp-derive", "ethereum-types/rlp"]
 impl-serde = ["serde", "ethereum-types/serialize"]
+precompile = ["ethers-contract", "ethers-core"]
 std = ["cita_trie", "hex", "log", "derive_more", "serde_json"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -57,6 +58,14 @@ optional = true
 version = "0.14"
 default-features = false
 features = ["serialize"]
+
+[dependencies.ethers-core]
+version = "2.0"
+optional = true
+
+[dependencies.ethers-contract]
+version = "2.0"
+optional = true
 
 [dependencies.faster-hex]
 version = "0.8"

--- a/devtools/axon-tools/src/lib.rs
+++ b/devtools/axon-tools/src/lib.rs
@@ -10,6 +10,8 @@ pub mod hash;
 #[cfg(feature = "hex")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "hex")))]
 pub mod hex;
+#[cfg(feature = "precompile")]
+pub mod precompile;
 #[cfg(feature = "proof")]
 mod proof;
 mod rlp_codec;

--- a/devtools/axon-tools/src/precompile.rs
+++ b/devtools/axon-tools/src/precompile.rs
@@ -1,3 +1,5 @@
+use ckb_types::utilities::{merkle_root, MerkleProof};
+use ckb_types::{packed, prelude::*};
 use ethers_contract::{EthAbiCodec, EthAbiType};
 
 #[derive(EthAbiCodec, EthAbiType, Clone, Debug, PartialEq, Eq)]
@@ -16,4 +18,45 @@ pub struct Proof {
     pub indices: Vec<u32>,
     pub lemmas:  Vec<[u8; 32]>,
     pub leaves:  Vec<[u8; 32]>,
+}
+
+/// A standalone function to verify the ckb-merkle-binary-tree proof.
+pub fn verify_proof(payload: VerifyProofPayload) -> Result<(), String> {
+    // Firstly, verify the transactions_root is consist of the raw_transactions_root
+    // and witnesses_root
+    let transactions_root: packed::Byte32 = payload.transactions_root.pack();
+    let raw_transactions_root: packed::Byte32 = payload.raw_transactions_root.pack();
+    let witnesses_root: packed::Byte32 = payload.witnesses_root.pack();
+
+    if merkle_root(&[raw_transactions_root.clone(), witnesses_root.clone()]) != transactions_root {
+        return Err(String::from("verify transactions_root fail"));
+    }
+
+    // Then, verify the given indices and lemmas can prove the leaves contains in
+    // the raw_transactions_root or the witnesses_root.
+    // If the verify_type is 0, the leaves should be in the raw_transactions_root,
+    // otherwise in the witnesses_root.
+    let lemmas = payload
+        .proof
+        .lemmas
+        .iter()
+        .map(|l| l.pack())
+        .collect::<Vec<_>>();
+    let leaves = payload
+        .proof
+        .leaves
+        .iter()
+        .map(|l| l.pack())
+        .collect::<Vec<_>>();
+    let verifying_root = if payload.verify_type == 0 {
+        raw_transactions_root
+    } else {
+        witnesses_root
+    };
+
+    if MerkleProof::new(payload.proof.indices, lemmas).verify(&verifying_root, &leaves) {
+        return Ok(());
+    }
+
+    Err(String::from("verify raw transactions root failed"))
 }

--- a/devtools/axon-tools/src/precompile.rs
+++ b/devtools/axon-tools/src/precompile.rs
@@ -1,0 +1,19 @@
+use ethers_contract::{EthAbiCodec, EthAbiType};
+
+#[derive(EthAbiCodec, EthAbiType, Clone, Debug, PartialEq, Eq)]
+pub struct VerifyProofPayload {
+    /// If the verify_type is 0, the leaves should be in the
+    /// raw_transactions_root, otherwise in the witnesses_root.
+    pub verify_type:           u8,
+    pub transactions_root:     [u8; 32],
+    pub witnesses_root:        [u8; 32],
+    pub raw_transactions_root: [u8; 32],
+    pub proof:                 Proof,
+}
+
+#[derive(EthAbiCodec, EthAbiType, Clone, Debug, PartialEq, Eq)]
+pub struct Proof {
+    pub indices: Vec<u32>,
+    pub lemmas:  Vec<[u8; 32]>,
+    pub leaves:  Vec<[u8; 32]>,
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR add `verify_cmbt_proof` precompile payload struct to axon-tools.

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #1578

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OCT 1-5 And 12-15
- [ ] OCT 6-10
- [ ] OCT 11
- [ ] OCT 16-19
- [ ] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

<!--
#### Deprecated CIs
- [ ] Chaos CI
| *Chaos CI*                                | Test the liveness and robustness of Axon under terrible network condition |
- [ ] Coverage Test
| *Coverage Test*                           | Get the unit test coverage report                                         |
-->
</details>
