### PR TITLE
fix: rpc method `eth_call` shouldn't set `estimate = true`

### DIFF
--- a/core/api/src/adapter.rs
+++ b/core/api/src/adapter.rs
@@ -197,6 +197,7 @@ where
         gas_limit: Option<U256>,
         value: U256,
         data: Vec<u8>,
+        estimate: bool,
         state_root: Hash,
         mock_header: Proposal,
     ) -> ProtocolResult<TxResp> {
@@ -214,7 +215,7 @@ where
             .map(|gas| gas.as_u64())
             .unwrap_or(MAX_BLOCK_GAS_LIMIT);
 
-        Ok(AxonExecutor.call(&backend, gas_limit, from, to, value, data))
+        Ok(AxonExecutor.call(&backend, gas_limit, from, to, value, data, estimate))
     }
 
     async fn get_code_by_hash(&self, ctx: Context, hash: &Hash) -> ProtocolResult<Option<Bytes>> {

--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -59,6 +59,7 @@ impl<Adapter: APIAdapter> Web3RpcImpl<Adapter> {
         req: Web3CallRequest,
         data: Bytes,
         number: Option<u64>,
+        estimate: bool,
     ) -> ProtocolResult<TxResp> {
         if req.from.is_none() && req.to.is_none() {
             return Err(APIError::RequestPayload("from and to are both None".to_string()).into());
@@ -81,6 +82,7 @@ impl<Adapter: APIAdapter> Web3RpcImpl<Adapter> {
                 req.gas,
                 req.value.unwrap_or_default(),
                 data.to_vec(),
+                estimate,
                 mock_header.state_root,
                 Proposal::new_without_state_root(&mock_header),
             )
@@ -434,7 +436,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
             .map(|hex| hex.as_bytes())
             .unwrap_or_default();
         let resp = self
-            .call_evm(req, data_bytes, number)
+            .call_evm(req, data_bytes, number, false)
             .await
             .map_err(|e| RpcError::Internal(e.to_string()))?;
 
@@ -476,7 +478,7 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
             .map(|hex| hex.as_bytes())
             .unwrap_or_default();
         let resp = self
-            .call_evm(req, data_bytes, num)
+            .call_evm(req, data_bytes, num, true)
             .await
             .map_err(|e| RpcError::Internal(e.to_string()))?;
 

--- a/core/executor/src/debugger/mod.rs
+++ b/core/executor/src/debugger/mod.rs
@@ -7,12 +7,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use evm::tracing::{Event, EventListener};
 
 use protocol::codec::ProtocolCodec;
-use protocol::traits::{Backend, Executor};
+use protocol::traits::Backend;
 use protocol::trie::Trie as _;
 use protocol::types::{
     Account, Eip1559Transaction, ExecResp, ExecutorContext, Hash, Hasher, SignedTransaction,
-    TxResp, UnsignedTransaction, UnverifiedTransaction, H160, H256, MAX_BLOCK_GAS_LIMIT, NIL_DATA,
-    RLP_NULL, U256,
+    UnsignedTransaction, UnverifiedTransaction, H160, H256, NIL_DATA, RLP_NULL, U256,
 };
 
 use core_db::RocksAdapter;
@@ -69,19 +68,6 @@ impl EvmDebugger {
         let res = AxonExecutor.test_exec(&mut backend, &txs, &[]);
         self.state_root = res.state_root;
         res
-    }
-
-    #[allow(dead_code)]
-    pub fn call(
-        &self,
-        number: u64,
-        from: Option<H160>,
-        to: Option<H160>,
-        value: U256,
-        data: Vec<u8>,
-    ) -> TxResp {
-        let backend = self.backend(number);
-        AxonExecutor.call(&backend, MAX_BLOCK_GAS_LIMIT, from, to, value, data)
     }
 
     fn backend(

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -71,12 +71,13 @@ impl Executor for AxonExecutor {
         to: Option<H160>,
         value: U256,
         data: Vec<u8>,
+        estimate: bool,
     ) -> TxResp {
         self.init_local_system_contract_roots(backend);
         let config = {
             let mut config = self.config();
-            // run the gasometer in estimate mode
-            config.estimate = true;
+            // whether run the gasometer in estimate mode or not
+            config.estimate = estimate;
             config
         };
         let metadata = StackSubstateMetadata::new(gas_limit, &config);

--- a/core/executor/src/tests/mod.rs
+++ b/core/executor/src/tests/mod.rs
@@ -192,6 +192,7 @@ async fn test_simplestorage() {
         Some(H160::from_str("0xc15d2ba57d126e6603240e89437efd419ce329d2").unwrap()),
         U256::default(),
         hex_decode("6d4ce63c").unwrap(),
+        false,
     );
     assert_eq!(r.exit_reason, ExitReason::Succeed(ExitSucceed::Stopped));
 }

--- a/protocol/src/traits/api.rs
+++ b/protocol/src/traits/api.rs
@@ -83,6 +83,7 @@ pub trait APIAdapter: Send + Sync {
         gas_limit: Option<U256>,
         value: U256,
         data: Vec<u8>,
+        estimate: bool,
         state_root: Hash,
         proposal: Proposal,
     ) -> ProtocolResult<TxResp>;

--- a/protocol/src/traits/executor.rs
+++ b/protocol/src/traits/executor.rs
@@ -34,6 +34,7 @@ pub trait Executor: Send + Sync {
         to: Option<H160>,
         value: U256,
         data: Vec<u8>,
+        estimate: bool,
     ) -> TxResp;
 
     fn exec<Adapter: ExecutorAdapter + ApplyBackend>(


### PR DESCRIPTION
## What this PR does / why we need it?

This PR resolves a bug introduced since #1603: `AxonExcutor::call(..)` is not only used in `eth_estimateGas`, but also in `eth_call`.

### What is the impact of this PR?

No Breaking Change

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OCT 1-5 And 12-15
- [x] OCT 6-10
- [x] OCT 11
- [x] OCT 16-19
- [x] v3 Core Tests

### **CI Description**

| CI Name                                   | Description                                                               |
| ----------------------------------------- | ------------------------------------------------------------------------- |
| *Web3 Compatible Test*                    | Test the Web3 compatibility of Axon                                       |
| *v3 Core Test*                            | Run the compatibility tests provided by Uniswap V3                        |
| *OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19* | Run the compatibility tests provided by OpenZeppelin                      |

</details>
