### PR TITLE
fix: gas limit too low error

### DIFF
--- a/core/api/src/jsonrpc/error.rs
+++ b/core/api/src/jsonrpc/error.rs
@@ -27,8 +27,6 @@ pub enum RpcError {
     GasLimitIsTooLow,
     #[display(fmt = "Gas limit is too large")]
     GasLimitIsTooLarge,
-    #[display(fmt = "Gas limit is zero")]
-    GasLimitIsZero,
     #[display(fmt = "Transaction is not signed")]
     TransactionIsNotSigned,
     #[display(fmt = "Cannot get latest block")]
@@ -78,7 +76,6 @@ impl RpcError {
             RpcError::GasPriceIsTooLarge => -40007,
             RpcError::GasLimitIsTooLow => -40008,
             RpcError::GasLimitIsTooLarge => -40009,
-            RpcError::GasLimitIsZero => -40010,
             RpcError::TransactionIsNotSigned => -40011,
             RpcError::CannotGetLatestBlock => -40013,
             RpcError::InvalidBlockHash => -40014,
@@ -116,7 +113,6 @@ impl From<RpcError> for ErrorObjectOwned {
             RpcError::GasPriceIsTooLarge => ErrorObject::owned(err_code, err, none_data),
             RpcError::GasLimitIsTooLow => ErrorObject::owned(err_code, err, none_data),
             RpcError::GasLimitIsTooLarge => ErrorObject::owned(err_code, err, none_data),
-            RpcError::GasLimitIsZero => ErrorObject::owned(err_code, err, none_data),
             RpcError::TransactionIsNotSigned => ErrorObject::owned(err_code, err, none_data),
             RpcError::CannotGetLatestBlock => ErrorObject::owned(err_code, err, none_data),
             RpcError::InvalidBlockHash => ErrorObject::owned(err_code, err, none_data),

--- a/core/api/src/jsonrpc/impl/web3.rs
+++ b/core/api/src/jsonrpc/impl/web3.rs
@@ -453,8 +453,8 @@ impl<Adapter: APIAdapter + 'static> Web3RpcServer for Web3RpcImpl<Adapter> {
     #[metrics_rpc("eth_estimateGas")]
     async fn estimate_gas(&self, req: Web3CallRequest, number: Option<BlockId>) -> RpcResult<U256> {
         if let Some(gas_limit) = req.gas.as_ref() {
-            if gas_limit == &U64::zero() {
-                return Err(RpcError::GasPriceIsZero.into());
+            if gas_limit < &(MIN_TRANSACTION_GAS_LIMIT.into()) {
+                return Err(RpcError::GasLimitIsTooLow.into());
             }
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR fix gas limit too low error.

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OpenZeppelin tests
- [ ] v3 Core Tests

### **CI Description**

| CI Name                | Description                                                                                             |
| ---------------------- | ------------------------------------------------------------------------------------------------------- |
| *Web3 Compatible Test* | Test the Web3 compatibility of Axon                                                                     |
| *v3 Core Test*         | Run the compatibility tests provided by Uniswap V3                                                      |
| *OpenZeppelin tests*   | Run the compatibility tests provided by OpenZeppelin, including OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19 |
</details>
