### PR TITLE
refactor: change estimate gas calculation

### DIFF
--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -71,15 +71,10 @@ impl Executor for AxonExecutor {
         to: Option<H160>,
         value: U256,
         data: Vec<u8>,
-        estimate: bool,
+        is_estimate: bool,
     ) -> TxResp {
         self.init_local_system_contract_roots(backend);
-        let config = {
-            let mut config = self.config();
-            // whether run the gasometer in estimate mode or not
-            config.estimate = estimate;
-            config
-        };
+        let config = self.config();
         let metadata = StackSubstateMetadata::new(gas_limit, &config);
         let state = MemoryStackState::new(metadata, backend);
         let precompiles = build_precompile_set();
@@ -99,6 +94,11 @@ impl Executor for AxonExecutor {
         };
 
         let used_gas = executor.used_gas();
+        let used_gas =if is_estimate {
+            (used_gas / 4) + used_gas
+        } else {
+            used_gas
+        };
 
         TxResp {
             exit_reason:  exit,

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -94,7 +94,7 @@ impl Executor for AxonExecutor {
         };
 
         let used_gas = executor.used_gas();
-        let used_gas =if is_estimate {
+        let used_gas = if is_estimate {
             // The estimate gas coef is 1.25
             (used_gas / 4) + used_gas
         } else {

--- a/core/executor/src/lib.rs
+++ b/core/executor/src/lib.rs
@@ -95,6 +95,7 @@ impl Executor for AxonExecutor {
 
         let used_gas = executor.used_gas();
         let used_gas =if is_estimate {
+            // The estimate gas coef is 1.25
             (used_gas / 4) + used_gas
         } else {
             used_gas


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR disable the `estimate` flag of EVM config when estimate gas. The estimate gas returns `1.25 * gas_used` as result. 

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #1286

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OpenZeppelin tests
- [x] v3 Core Tests

### **CI Description**

| CI Name                | Description                                                                                             |
| ---------------------- | ------------------------------------------------------------------------------------------------------- |
| *Web3 Compatible Test* | Test the Web3 compatibility of Axon                                                                     |
| *v3 Core Test*         | Run the compatibility tests provided by Uniswap V3                                                      |
| *OpenZeppelin tests*   | Run the compatibility tests provided by OpenZeppelin, including OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19 |
</details>
