### PR TITLE
chore: bump Axon version to 0.3.0-beta

### DIFF
--- a/.github/workflows/build_image_ghcr.yml
+++ b/.github/workflows/build_image_ghcr.yml
@@ -2,7 +2,7 @@ name: Build ghcr.io image
 
 on:
   push:
-    branches: [ 'main', '*docker*', '*dev*' ]
+    branches: [ 'main', '*dev*', '*alpha*', '*beta*', '*rc*' ]
     tags:
   workflow_dispatch:
     inputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * fix!: fix the implementation of Axon Tries ([\#1580](https://github.com/axonweb3/axon/pull/1580))
 * refactor!: call reserved system contract address is forbidden ([\#1597](https://github.com/axonweb3/axon/pull/1597))
 * refactor!: change many U256 type to U64 ([\#1591](https://github.com/axonweb3/axon/pull/1591))
+* fix(mempool)!: check gas limit range ([\#1634](https://github.com/axonweb3/axon/pull/1634))
 
 ### FEATURES
 
@@ -17,7 +18,6 @@
 * feat: add `ckb_blake2b` precompile contract ([\#1555](https://github.com/axonweb3/axon/pull/1555))
 * feat: add ckb mbt proof verify precompile contract ([\#1578](https://github.com/axonweb3/axon/pull/1578))
 * feat: support stop at specific height ([\#1581](https://github.com/axonweb3/axon/pull/1581))
-
 
 ### BUG FIXES
 
@@ -45,6 +45,7 @@
 * refactor: rename Proof.block_hash serde to proposal_hash ([\#1618](https://github.com/axonweb3/axon/pull/1618))
 * refactor: forbid call eth_getStorageAt to system contract accounts ([\#1619](https://github.com/axonweb3/axon/pull/1619))
 * refactor: change estimate gas calculation logic ([\#1603](https://github.com/axonweb3/axon/pull/1603), [\#1626](https://github.com/axonweb3/axon/pull/1626))
+* refactor(cli): update keypair generate command ([\#1621](https://github.com/axonweb3/axon/pull/1621))
 
 ### CHORE
 * ci: adjust CI after migrating the test projects ([\#1513](https://github.com/axonweb3/axon/pull/1513))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased (v0.3.0-dev)
+## v0.3.0-beta
 
 ### BREAKING CHANGES
 * refactor!: remove the limitation of set ckb related info ([\#1517](https://github.com/axonweb3/axon/pull/1517))
@@ -11,10 +11,8 @@
 
 ### FEATURES
 
-- Migrate axon-tools to axon repo in
-  ([\#1519](https://github.com/axonweb3/axon/pull/1519)) and ([\#1545](https://github.com/axonweb3/axon/pull/1545))
-- Add no-std feature of axon-tools, using use ckb-blst for riscv64
-  ([\#1532](https://github.com/axonweb3/axon/pull/1532)) and ([\#1563](https://github.com/axonweb3/axon/pull/1563))
+* Migrate axon-tools to axon repo ([\#1519](https://github.com/axonweb3/axon/pull/1519), [\#1545](https://github.com/axonweb3/axon/pull/1545))
+* Add no-std feature of axon-tools, using use ckb-blst for riscv64 (([\#1532](https://github.com/axonweb3/axon/pull/1532)), [\#1563](https://github.com/axonweb3/axon/pull/1563))
 * feat: add `eth_getProof` JSON RPC API ([\#1540](https://github.com/axonweb3/axon/pull/1540), [\#1549](https://github.com/axonweb3/axon/pull/1549), [\#1564](https://github.com/axonweb3/axon/pull/1564), [\#1571](https://github.com/axonweb3/axon/pull/1571))
 * feat: add `ckb_blake2b` precompile contract ([\#1555](https://github.com/axonweb3/axon/pull/1555))
 * feat: add ckb mbt proof verify precompile contract ([\#1578](https://github.com/axonweb3/axon/pull/1578))
@@ -23,39 +21,36 @@
 
 ### BUG FIXES
 
-- Fix value of gas in JSON RPC Transaction should be gas limit
-  ([\#1530](https://github.com/axonweb3/axon/pull/1530))
+* Fix value of gas in JSON RPC Transaction should be gas limit ([\#1530](https://github.com/axonweb3/axon/pull/1530))
 * fix: check mempool when call `eth_getTransactionByHash` ([\#1526](https://github.com/axonweb3/axon/pull/1526))
 * fix: use a same default value for `max_payload_size` ([\#1548](https://github.com/axonweb3/axon/pull/1548))
 * fix: rlp decode of `SignedTransction` with interoperation signature ([\#1533](https://github.com/axonweb3/axon/pull/1533))
 * fix: get genesis block proposal may panic ([\#1554](https://github.com/axonweb3/axon/pull/1554))
 * fix: field `chainId` should be acceptable for `eth_estimateGas` ([\#1601](https://github.com/axonweb3/axon/pull/1601))
-* fix: enable estimation mode for query apis ([\#1603](https://github.com/axonweb3/axon/pull/1603))
 * fix: get pending tx count by number ([\#1605](https://github.com/axonweb3/axon/pull/1605))
 * fix: duplicated calculation in `eth_estimateGas` ([\#1599](https://github.com/axonweb3/axon/pull/1599), [\#1609](https://github.com/axonweb3/axon/pull/1609))
-
+* fix: gas limit too low error ([\#1625](https://github.com/axonweb3/axon/pull/1625))
 
 ### CODE REFACTORS
 
-- Add more details for JSON RPC errors ([\#1495](https://github.com/axonweb3/axon/pull/1495))
-- Remove the limitation of set CKB related info in system contract ([\#1517](https://github.com/axonweb3/axon/pull/1517))
+* Add more details for JSON RPC errors ([\#1495](https://github.com/axonweb3/axon/pull/1495))
+* Remove the limitation of set CKB related info in system contract ([\#1517](https://github.com/axonweb3/axon/pull/1517))
 * Remove empty crates ([\#1521](https://github.com/axonweb3/axon/pull/1521))
-- Enhance readability of output logs and errors ([\#1528](https://github.com/axonweb3/axon/pull/1528))
-- Change default db cache size ([\#1531](https://github.com/axonweb3/axon/pull/1531))
+* Enhance readability of output logs and errors ([\#1528](https://github.com/axonweb3/axon/pull/1528))
+* Change default db cache size ([\#1531](https://github.com/axonweb3/axon/pull/1531))
 * config(blockscan): update the env variables of Axon's explorer ([\#1550](https://github.com/axonweb3/axon/pull/1550))
 * Refactor fn is_hardfork_enabled ([\#1538](https://github.com/axonweb3/axon/pull/1538))
 * Remove duplicated code to protect ([\#1556](https://github.com/axonweb3/axon/pull/1556))
 * Update CkbType.sol and ImageCell.sol for consistent ABI output with json file in ([\#1558](https://github.com/axonweb3/axon/pull/1558), [\#1567](https://github.com/axonweb3/axon/pull/1567))
-* ci: refactor OpenZeppelin tests and entry_workflow.yml ([\#1610](https://github.com/axonweb3/axon/pull/1610))
-
+* refactor: rename Proof.block_hash serde to proposal_hash ([\#1618](https://github.com/axonweb3/axon/pull/1618))
+* refactor: forbid call eth_getStorageAt to system contract accounts ([\#1619](https://github.com/axonweb3/axon/pull/1619))
+* refactor: change estimate gas calculation logic ([\#1603](https://github.com/axonweb3/axon/pull/1603), [\#1626](https://github.com/axonweb3/axon/pull/1626))
 
 ### CHORE
 * ci: adjust CI after migrating the test projects ([\#1513](https://github.com/axonweb3/axon/pull/1513))
 * chore: make blst portable ([\#1520](https://github.com/axonweb3/axon/pull/1520))
 * ci: run unit tests in separate processes ([\#1559](https://github.com/axonweb3/axon/pull/1559))
-
-
-**Full Changelog**: https://github.com/axonweb3/axon/compare/v0.2.0-beta.2...v0.3.0-dev
+* ci: refactor OpenZeppelin tests and entry_workflow.yml ([\#1610](https://github.com/axonweb3/axon/pull/1610))
 
 ## v0.2.0-beta.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axon"
-version = "0.3.0-alpha"
+version = "0.3.0-beta"
 dependencies = [
  "axon-protocol",
  "clap 4.4.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axon"
-version = "0.3.0-alpha"
+version = "0.3.0-beta"
 authors = ["Nervos Dev <dev@nervos.org>"]
 edition = "2021"
 repository = "https://github.com/axonweb3/axon"


### PR DESCRIPTION
## Changes
- update CHANGELOG.md
- [chore(docker): build ghcr image for alpha branch](https://github.com/axonweb3/axon/pull/1627/commits/dd35f500fce0ec3adf28b59fea8c431a4a4087c8) -> https://github.com/axonweb3/axon/actions/runs/7124929839

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OpenZeppelin tests
- [x] v3 Core Tests

### **CI Description**

| CI Name                | Description                                                                                             |
| ---------------------- | ------------------------------------------------------------------------------------------------------- |
| *Web3 Compatible Test* | Test the Web3 compatibility of Axon                                                                     |
| *v3 Core Test*         | Run the compatibility tests provided by Uniswap V3                                                      |
| *OpenZeppelin tests*   | Run the compatibility tests provided by OpenZeppelin, including OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19 |

