### PR TITLE
refactor!:  increase max gas limitation

### DIFF
--- a/protocol/src/constants/configs.rs
+++ b/protocol/src/constants/configs.rs
@@ -2,15 +2,15 @@ use crate::types::U64;
 
 /// There is not a standard for the maximum gas limit, as long as the account
 /// balance can pay the `gas_limit * gas_price`. For reduce some useless
-/// calculation, `30_000_000` is large enough to cover the transaction usage.
-pub const MAX_GAS_LIMIT: u64 = 30_000_000;
+/// calculation, `50_000_000` is large enough to cover the transaction usage.
+pub const MAX_GAS_LIMIT: u64 = 50_000_000;
 /// According to [go-ethereum](https://github.com/ethereum/go-ethereum/blob/be65b47/eth/gasprice/gasprice.go#L38),
 /// the maximum gas price is 500 Gwei.
 pub const MAX_GAS_PRICE: U64 = U64([500 * GWEI]);
 pub const MIN_TRANSACTION_GAS_LIMIT: u64 = 21_000;
 /// The mempool refresh timeout is 50 milliseconds.
 pub const MEMPOOL_REFRESH_TIMEOUT: u64 = 50;
-pub const MAX_BLOCK_GAS_LIMIT: u64 = 30_000_000;
+pub const MAX_BLOCK_GAS_LIMIT: u64 = 50_000_000;
 // MAX_FEE_HISTORY is the maximum number of blocks that can be retrieved for a
 // fee history request. Between 1 and 1024 blocks can be requested in a single
 // query. reference: https://docs.infura.io/infura/networks/ethereum/json-rpc-methods/eth_feehistory/


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR increase max gas limitation to 50 million.

### What is the impact of this PR?


**PR relation**:
- Ref https://github.com/godwokenrises/godwoken-tests/pull/319

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OpenZeppelin tests
- [ ] v3 Core Tests

### **CI Description**

| CI Name                | Description                                                                                             |
| ---------------------- | ------------------------------------------------------------------------------------------------------- |
| *Web3 Compatible Test* | Test the Web3 compatibility of Axon                                                                     |
| *v3 Core Test*         | Run the compatibility tests provided by Uniswap V3                                                      |
| *OpenZeppelin tests*   | Run the compatibility tests provided by OpenZeppelin, including OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19 |
</details>
