### PR TITLE
chore(CI): add axon sync workflow

### DIFF
--- a/.github/workflows/axon-sync-test.yml
+++ b/.github/workflows/axon-sync-test.yml
@@ -45,11 +45,10 @@ jobs:
            target/debug/axon 
            devtools/chain/default.db-options
            devtools/chain/config.toml 
-           devtools/chain/net.key
            devtools/chain/specs/alphanet_nodes/chain-spec.toml
            devtools/ci/scripts/helper.js
            
-        retention-days: 7
+        retention-days: 3
 
         
   Download_and_Start_Axon_Sync:

--- a/.github/workflows/axon-sync-test.yml
+++ b/.github/workflows/axon-sync-test.yml
@@ -1,0 +1,163 @@
+name: Axon sync test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  Build_and_Archive_Axon:
+    strategy:
+      matrix:
+        # Supported GitHub-hosted runners and hardware resources
+        # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        os: [ubuntu-22.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Cache of Cargo
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ matrix.os }}-${{ runner.os }}-${{ runner.arch }}-cargo-build
+
+    - name: Build Axon 
+      run: |
+        # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
+        # related issue: https://github.com/axonweb3/axon/issues/1387
+        lscpu
+        # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
+        PORTABLE=1 USE_SSE=1 cargo build
+    - name: Generate Key
+      run: |
+        openssl rand -hex 32 |xxd -p -r >  devtools/chain/net.key    
+
+    - name: Archive Axon Artifacts  
+      uses: actions/upload-artifact@v3
+      with:
+        name: axon-dir
+        path: |
+           target/debug/axon 
+           devtools/chain/default.db-options
+           devtools/chain/config.toml 
+           devtools/chain/net.key
+           devtools/chain/specs/alphanet_nodes/chain-spec.toml
+           devtools/ci/scripts/helper.js
+           
+        retention-days: 7
+
+        
+  Download_and_Start_Axon_Sync:
+    name: Download_and_Start_Axon_Sync
+    needs:  Build_and_Archive_Axon       
+    runs-on: simon-runner
+    timeout-minutes: 1800
+
+    steps:
+    - name: Download Axon Binary for Build_and_Archive_Axon  
+      uses: actions/download-artifact@v3
+      with: 
+        name: axon-dir   
+    - name: Replacement configuration
+      run: |
+        sed -i 's@multi_address = "/ip4/127.0.0.1/tcp/8001/p2p/QmNk6bBwkLPuqnsrtxpp819XLZY3ymgjs3p1nKtxBVgqxj"@multi_address = "/dns4/axon1/tcp/8001/p2p/QmcgR2Jj6XJ4B9VDp3UaG3dcwFaeqwXikHco9nLq9Eand6"@' devtools/chain/config.toml   
+        sed -i 's@bls_privkey_file = "bls.key"@bls_privkey_file = "bls_0.key"@' devtools/chain/config.toml
+
+    - name: Start Axon Node
+      env:
+        LOG_FILE: ${{ runner.temp }}/layer2-runner-axon-node.log
+      run: |
+         chmod +x target/debug/axon
+         target/debug/axon generate-keypair -n 1 -p devtools/chain/ 
+         target/debug/axon --version
+         target/debug/axon init \
+          --config     devtools/chain/config.toml  \
+          --chain-spec devtools/chain/specs/alphanet_nodes/chain-spec.toml
+
+         nohup target/debug/axon run \
+          --config     devtools/chain/config.toml  &
+
+    - name: Wati for App to Start
+      run: sleep 15
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3  
+      with:
+        node-version: '20'
+    
+    - name:  Compare Block Heights  
+      run: |
+        npx zx <<'EOF'
+        #!/usr/bin/env zx
+        import { getLatestBlockNum } from './devtools/ci/scripts/helper.js';
+
+        async function main() {
+          let previousLocalHeight = null;
+
+          while (true) {
+            const localHeight = await getLatestBlockNum('http://127.0.0.1:8000');
+            const remoteHeight = await getLatestBlockNum('http://axon1:8000');
+        
+            console.log(`localBlockNumber: ${localHeight}, remoteBlockNumber: ${remoteHeight}`);
+        
+            if (localHeight >= remoteHeight - 10 && localHeight <= remoteHeight) {
+              console.log(`localBlockNumber: ${localHeight}, remoteBlockNumber: ${remoteHeight}, localnode sync succeeded`);
+              return process.exit(0);
+            }
+        
+            if (localHeight === previousLocalHeight) {
+              console.error(`synchronization exception localBlockNumber: ${localHeight}`);
+              return process.exit(1);
+            }
+        
+            previousLocalHeight = localHeight;
+            await new Promise(resolve => setTimeout(resolve, 600000));
+          }
+        }
+        
+        main();
+        EOF
+      timeout-minutes: 1800 
+
+
+
+  notice:
+    runs-on: ubuntu-latest
+    needs: Download_and_Start_Axon_Sync 
+    if: success() || failure()
+    steps:
+      - name: send Axon-sync-test status 
+        run: |
+          curl -H "Content-Type: application/json" \
+          -X POST https://discord.com/api/webhooks/${{secrets.DISCORD_CHANNEL_ID}}/${{secrets.DISCORD_CHANNEL_TOKEN}} \
+          --data '
+             { 
+                "content": "Axon-sync-test", 
+                "embeds": [ 
+                    {
+                    "title":"Axon Sync test Status", 
+                     "color": 5814789,
+                     "fields": [
+                         {
+                             "name": "Job name",
+                             "value": "axon-sync-test\n"
+                         },   
+                         {    "name":  "Job statues",
+                              "value": "${{needs.Download_and_Start_Axon_Sync.result}}\n"
+                         },
+                         {    
+                             "name": "URL",
+                             "value": "[Click and jump to Github workflow](https://github.com/Simon-Tl/axon/actions/workflows/axon-sync-test.yml)\n"
+                         }
+                         
+                     ]
+                } 
+                ]
+            }'            

--- a/.github/workflows/axon-sync-test.yml
+++ b/.github/workflows/axon-sync-test.yml
@@ -55,7 +55,7 @@ jobs:
   Download_and_Start_Axon_Sync:
     name: Download_and_Start_Axon_Sync
     needs:  Build_and_Archive_Axon       
-    runs-on: simon-runner
+    runs-on: simon-runners
     timeout-minutes: 1800
 
     steps:

--- a/.github/workflows/axon-sync-test.yml
+++ b/.github/workflows/axon-sync-test.yml
@@ -54,7 +54,7 @@ jobs:
   Download_and_Start_Axon_Sync:
     name: Download_and_Start_Axon_Sync
     needs:  Build_and_Archive_Axon       
-    runs-on: simon-runners
+    runs-on: layer2-runners
     timeout-minutes: 1800
 
     steps:
@@ -152,7 +152,7 @@ jobs:
                          },
                          {    
                              "name": "URL",
-                             "value": "[Click and jump to Github workflow](https://github.com/Simon-Tl/axon/actions/workflows/axon-sync-test.yml)\n"
+                             "value": "[Click and jump to Github workflow](https://github.com/axonweb3/axon/actions/workflows/axon-sync-test.yml)\n"
                          }
                          
                      ]

--- a/.github/workflows/axon-sync-test.yml
+++ b/.github/workflows/axon-sync-test.yml
@@ -2,6 +2,8 @@ name: Axon sync test
 
 on:
   workflow_dispatch:
+  # TODO: remove `pull_request` event when this workflow is stable
+  pull_request:
 
 jobs:
   Build_and_Archive_Axon:

--- a/.github/workflows/axon-sync-test.yml
+++ b/.github/workflows/axon-sync-test.yml
@@ -35,9 +35,7 @@ jobs:
         lscpu
         # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
         PORTABLE=1 USE_SSE=1 cargo build
-    - name: Generate Key
-      run: |
-        openssl rand -hex 32 |xxd -p -r >  devtools/chain/net.key    
+ 
 
     - name: Archive Axon Artifacts  
       uses: actions/upload-artifact@v3
@@ -69,6 +67,7 @@ jobs:
       run: |
         sed -i 's@multi_address = "/ip4/127.0.0.1/tcp/8001/p2p/QmNk6bBwkLPuqnsrtxpp819XLZY3ymgjs3p1nKtxBVgqxj"@multi_address = "/dns4/axon1/tcp/8001/p2p/QmcgR2Jj6XJ4B9VDp3UaG3dcwFaeqwXikHco9nLq9Eand6"@' devtools/chain/config.toml   
         sed -i 's@bls_privkey_file = "bls.key"@bls_privkey_file = "bls_0.key"@' devtools/chain/config.toml
+        sed -i 's@net_privkey_file = "net.key"@net_privkey_file = "net_0.key"@' devtools/chain/config.toml
 
     - name: Start Axon Node
       env:

--- a/.github/workflows/axon-sync-test.yml
+++ b/.github/workflows/axon-sync-test.yml
@@ -35,8 +35,7 @@ jobs:
         # check for AVX2 support by inspecting `/proc/cpuinfo` or running `lscpu`
         # related issue: https://github.com/axonweb3/axon/issues/1387
         lscpu
-        # PORTABLE=1 USE_SSE=1 tell rocksdb to target AVX2
-        PORTABLE=1 USE_SSE=1 cargo build
+        cargo build
  
 
     - name: Archive Axon Artifacts  

--- a/devtools/chain/specs/alphanet_nodes/chain-spec.toml
+++ b/devtools/chain/specs/alphanet_nodes/chain-spec.toml
@@ -1,0 +1,105 @@
+#
+# Data of the genesis block.
+#
+
+[genesis]
+timestamp = 1680249207
+base_fee_per_gas = "0x539"
+# The default chain id is the hexadecimal of ASCII string "Axon".
+chain_id = 0x41786f6e
+hardforks = ["None"]
+
+#
+# Accounts since the genesis block.
+#
+# WARNING: The following accounts are publicly known, DO NOT USE them in any production environment.
+# Generated with the mnemonic "test test test test test test test test test test test junk".
+
+[[accounts]]
+address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
+balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
+balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc"
+balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0x976EA74026E726554dB657fA54763abd0C3a0aa9"
+balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955"
+balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f"
+balance = "04ee2d6d415b85acef8100000000"
+
+[[accounts]]
+address = "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720"
+balance = "04ee2d6d415b85acef8100000000"
+
+#
+# Parameters which make the chain to be unique.
+#
+
+[params]
+epoch = 0
+
+[params.version]
+start = 1
+end = 100000000
+
+[params.consensus_config]
+propose_ratio = 15
+prevote_ratio = 10
+precommit_ratio = 10
+brake_ratio = 10
+tx_num_limit = 20000
+max_tx_size = 409600000
+gas_limit = 4294967295000
+interval = 3000
+
+[[params.verifier_list]]
+bls_pub_key = "0x95a16ed1f4c43a7470917771bf820741dbd040c51967122de66dc5bc9f6eff5953a36be6c0fdf8c202a26d6f2b0f8885"
+pub_key = "0x035e184329714d7e3f7e39e5d96ac3be4835897adbaab85bae2558473391fa8fcf"
+address = "0x81fb11017e520fda13df35d1fd1a3903e384020f"
+propose_weight = 1
+vote_weight = 1
+
+[[params.verifier_list]]
+bls_pub_key = "0xa8d1c7c4152ce4ad8eff7ee90406b6cdf27eee97f0e520b8098a88ff3873c83aa8b74d9aab3a1c15361b5d3bc9224e9a"
+pub_key = "0x02f0018382fef706e37faf9770c14a58d35a457c7a2fa0ec84240d50b6d74f4adb"
+address = "0x7249d82017b77a5006808fe020e779af0d95e12e"
+propose_weight = 1
+vote_weight = 1
+
+[[params.verifier_list]]
+bls_pub_key = "0x8d999a5c29604f32950bfedf289f6b8e7e2f1a19f86b208d370024e709f77d1208f5e000dc4232a63064530613aa4b26"
+pub_key = "0x03ea501a5600c260b62ff0cdb0c227e9374643395243f026f9c73fe9aa8ebcfebd"
+address = "0x387f3253e85c320b5e881656447eedccf5230f22"
+propose_weight = 1
+vote_weight = 1
+
+[[params.verifier_list]]
+bls_pub_key = "0xafefcad3f6289c0bc0a9fd0015f533dcfcc1d7ba5161ff518702fee7aec33374a08d4fa45baeef85836c1e604e8f221d"
+pub_key = "0x02b2daf6d950f25735f2faa129cfe2a65c70bcbd4a050c9d18a06ed0e63a91f2a9"
+address = "0xc384b679bbc0de6e471fdb7735c0ff2d9508ece0"
+propose_weight = 1
+vote_weight = 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR is add axon sync workflow and add chain-spec.toml to devtools/chain/alphanet-nodes

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Ref #

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OpenZeppelin tests
- [ ] v3 Core Tests

### **CI Description**

| CI Name                | Description                                                                                             |
| ---------------------- | ------------------------------------------------------------------------------------------------------- |
| *Web3 Compatible Test* | Test the Web3 compatibility of Axon                                                                     |
| *v3 Core Test*         | Run the compatibility tests provided by Uniswap V3                                                      |
| *OpenZeppelin tests*   | Run the compatibility tests provided by OpenZeppelin, including OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19 |
</details>
