### PR TITLE
refactor: omit `address` field in chain spec parsing

### DIFF
--- a/common/config-parser/src/types/spec.rs
+++ b/common/config-parser/src/types/spec.rs
@@ -12,7 +12,7 @@ use common_crypto::Secp256k1RecoverablePrivateKey;
 use protocol::{
     codec::{decode_256bits_key, deserialize_address},
     types::{
-        HardforkInfoInner, Header, Key256Bits, Metadata, H160, H256, RLP_EMPTY_LIST, RLP_NULL,
+        HardforkInfoInner, Header, Key256Bits, SpecMetadata, H160, H256, RLP_EMPTY_LIST, RLP_NULL,
         U256, U64,
     },
 };
@@ -30,7 +30,7 @@ pub struct ChainSpec {
     ///
     /// All parameters are not allowed to be modified after the chain
     /// initialized.
-    pub params:   Metadata,
+    pub params:   SpecMetadata,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/core/consensus/src/adapter.rs
+++ b/core/consensus/src/adapter.rs
@@ -18,8 +18,8 @@ use protocol::traits::{
     Network, PeerTrust, Priority, Rpc, Storage, SynchronizationAdapter,
 };
 use protocol::types::{
-    BatchSignedTxs, Block, BlockNumber, BlockVersion, Bytes, ExecResp, Hash, Header, Hex,
-    MerkleRoot, Metadata, PackedTxHashes, Proof, Proposal, Receipt, SignedTransaction, Validator,
+    BatchSignedTxs, Block, BlockNumber, BlockVersion, Bytes, ConsensusValidator, ExecResp, Hash,
+    Header, Hex, MerkleRoot, Metadata, PackedTxHashes, Proof, Proposal, Receipt, SignedTransaction,
     U256,
 };
 use protocol::{async_trait, tokio::task, trie, ProtocolResult};
@@ -140,7 +140,7 @@ where
         prevote_ratio: u64,
         precommit_ratio: u64,
         brake_ratio: u64,
-        validators: Vec<Validator>,
+        validators: Vec<ConsensusValidator>,
     ) -> ProtocolResult<()> {
         self.overlord_handler
             .read()

--- a/core/consensus/src/consensus.rs
+++ b/core/consensus/src/consensus.rs
@@ -6,7 +6,7 @@ use overlord::types::{
 use overlord::{DurationConfig, Overlord, OverlordHandler};
 
 use protocol::traits::{Consensus, ConsensusAdapter, Context, NodeInfo};
-use protocol::types::{Proposal, Validator};
+use protocol::types::{ConsensusValidator, Proposal};
 use protocol::{
     async_trait, codec::ProtocolCodec, tokio::sync::Mutex as AsyncMutex, ProtocolResult,
 };
@@ -167,7 +167,7 @@ impl<Adapter: ConsensusAdapter + 'static> OverlordConsensus<Adapter> {
         &self,
         init_height: u64,
         interval: u64,
-        validators: Vec<Validator>,
+        validators: Vec<ConsensusValidator>,
         timer_config: Option<DurationConfig>,
     ) -> ProtocolResult<()> {
         // The address field of Node struct should use the node's secp256k1 public key
@@ -196,7 +196,7 @@ pub fn gen_overlord_status(
     prevote_ratio: u64,
     precommit_ratio: u64,
     brake_ratio: u64,
-    validators: Vec<Validator>,
+    validators: Vec<ConsensusValidator>,
 ) -> Status {
     // The address field of Node struct should use the node's secp256k1 public key
     let mut authority_list = validators

--- a/core/consensus/src/tests/mod.rs
+++ b/core/consensus/src/tests/mod.rs
@@ -11,10 +11,10 @@ use protocol::{
     codec::hex_decode,
     traits::{CommonConsensusAdapter, Context, SynchronizationAdapter},
     types::{
-        Address, Block, BlockNumber, Bytes, Eip1559Transaction, ExecResp, Hash, Hasher, Header,
-        Hex, MerkleRoot, Metadata, Proof, Proposal, Public, Receipt, SignatureComponents,
-        SignedTransaction, TransactionAction, UnsignedTransaction, UnverifiedTransaction,
-        Validator, H160, H256, U256, U64,
+        Address, Block, BlockNumber, Bytes, ConsensusValidator, Eip1559Transaction, ExecResp, Hash,
+        Hasher, Header, Hex, MerkleRoot, Metadata, Proof, Proposal, Public, Receipt,
+        SignatureComponents, SignedTransaction, TransactionAction, UnsignedTransaction,
+        UnverifiedTransaction, H160, H256, U256, U64,
     },
     ProtocolResult,
 };
@@ -93,12 +93,12 @@ fn _mock_pub_key() -> Hex {
     Hex::from_str("0x026c184a9016f6f71a234c86b141621f38b68c78602ab06768db4d83682c616004").unwrap()
 }
 
-fn _mock_validators(len: usize) -> Vec<Validator> {
+fn _mock_validators(len: usize) -> Vec<ConsensusValidator> {
     (0..len).map(|_| _mock_validator()).collect::<Vec<_>>()
 }
 
-fn _mock_validator() -> Validator {
-    Validator {
+fn _mock_validator() -> ConsensusValidator {
+    ConsensusValidator {
         pub_key:        _mock_pub_key().as_bytes(),
         propose_weight: random::<u32>(),
         vote_weight:    random::<u32>(),
@@ -145,7 +145,7 @@ impl SynchronizationAdapter for MockSyncAdapter {
         prevote_ratio: u64,
         precommit_ratio: u64,
         brake_ratio: u64,
-        validators: Vec<Validator>,
+        validators: Vec<ConsensusValidator>,
     ) -> ProtocolResult<()> {
         Ok(())
     }

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -14,8 +14,8 @@ use protocol::traits::{
     Context, Executor, Gossip, MemPool, Network, NodeInfo, PeerTrust, ReadOnlyStorage, Rpc, Storage,
 };
 use protocol::types::{
-    Block, Bloom, BloomInput, ExecResp, HardforkInfoInner, Header, Metadata, Proposal, RichBlock,
-    SignedTransaction, Validator, ValidatorExtend, H256,
+    Block, Bloom, BloomInput, ConsensusValidator, ExecResp, HardforkInfoInner, Header, Metadata,
+    Proposal, RichBlock, SignedTransaction, ValidatorExtend, H256,
 };
 use protocol::{lazy::CHAIN_ID, trie::DB as TrieDB, ProtocolResult};
 
@@ -213,7 +213,8 @@ async fn start<K: KeyProvider>(
     metadata_handle.init_hardfork(current_block.header.number)?;
 
     let metadata = metadata_handle.get_metadata_by_block_number(current_block.header.number)?;
-    let validators: Vec<Validator> = metadata.verifier_list.iter().map(Into::into).collect();
+    let validators: Vec<ConsensusValidator> =
+        metadata.verifier_list.iter().map(Into::into).collect();
 
     // Set args in mempool
     mempool.set_args(
@@ -416,7 +417,7 @@ async fn get_status_agent(
 
 fn run_overlord_consensus<M, N, S, DB>(
     metadata: Metadata,
-    validators: Vec<Validator>,
+    validators: Vec<ConsensusValidator>,
     current_block: Block,
     overlord_consensus: Arc<OverlordConsensus<OverlordConsensusAdapter<M, N, S, DB>>>,
 ) where

--- a/core/run/src/lib.rs
+++ b/core/run/src/lib.rs
@@ -466,7 +466,7 @@ async fn execute_genesis(
         &partial_genesis,
         db_group,
         &spec.accounts,
-        &[metadata_0, metadata_1],
+        &[metadata_0.into(), metadata_1.into()],
         spec.genesis.generate_hardfork_info(),
     )?;
 

--- a/core/run/src/tests.rs
+++ b/core/run/src/tests.rs
@@ -193,8 +193,8 @@ fn check_state(spec: &ChainSpec, genesis_header: &Header, db_group: &DatabaseGro
     )
     .unwrap();
 
-    let metadata_0 = spec.params.clone();
-    let metadata_1 = {
+    let metadata_0: Metadata = spec.params.clone().into();
+    let metadata_1: Metadata = {
         let mut tmp = metadata_0.clone();
         tmp.epoch = metadata_0.epoch + 1;
         tmp.version.start = metadata_0.version.end + 1;

--- a/devtools/chain/specs/multi_nodes/chain-spec.toml
+++ b/devtools/chain/specs/multi_nodes/chain-spec.toml
@@ -79,27 +79,23 @@ interval = 3000
 [[params.verifier_list]]
 bls_pub_key = "0xa26e3fe1cf51bd4822072c61bdc315ac32e3d3c2e2484bb92942666399e863b4bf56cf2926383cc706ffc15dfebc85c6"
 pub_key = "0x031ddc35212b7fc7ff6685b17d91f77c972535aee5c7ae5684d3e72b986f08834b"
-address = "0x8ab0cf264df99d83525e9e11c7e4db01558ae1b1"
 propose_weight = 1
 vote_weight = 1
 
 [[params.verifier_list]]
 bls_pub_key = "0x80310fa9df724b5603d283b472ed3bf85254a8a4ceda8a274b421f6cf2be1d9184267cdfe9a199d36ff14e57668a55d0"
 pub_key = "0x02b77c74eb68af3d4d6cc7884ed6709f1a2a1af0f713382a4438ec2ea3a70d4d7f"
-address = "0xf386573563c3a75dbbd269fce9782620826ddac2"
 propose_weight = 1
 vote_weight = 1
 
 [[params.verifier_list]]
 bls_pub_key = "0x897721e9016864141a8b982a48217f66ef318ce598aa31842cddaaebe3cd7feab17050022afa6c2123aba39938fe4142"
 pub_key = "0x027ffd6a6a231561f2afe5878b1c743323b34263d16787130b1815fe35649b0bf5"
-address = "0x8af204ac5d7cb8815a6c53a50b72d01e729d3b22"
 propose_weight = 1
 vote_weight = 1
 
 [[params.verifier_list]]
 bls_pub_key = "0x98eef09a3927acb225191101a1d9aa85775fdcdc87b9ba36898f6c132b485d66aef91c0f51cda331be4f985c3be6761c"
 pub_key = "0x0232c489c23b1207107e9a24648c1e4754a8c1c0b38db96df57a526201035058cb"
-address = "0xf4cc1652dcec2e5de9ce6fb1b6f9fa9456e957f1"
 propose_weight = 1
 vote_weight = 1

--- a/devtools/chain/specs/multi_nodes_short_epoch_len/chain-spec.toml
+++ b/devtools/chain/specs/multi_nodes_short_epoch_len/chain-spec.toml
@@ -79,27 +79,23 @@ interval = 3000
 [[params.verifier_list]]
 bls_pub_key = "0xa26e3fe1cf51bd4822072c61bdc315ac32e3d3c2e2484bb92942666399e863b4bf56cf2926383cc706ffc15dfebc85c6"
 pub_key = "0x031ddc35212b7fc7ff6685b17d91f77c972535aee5c7ae5684d3e72b986f08834b"
-address = "0x8ab0cf264df99d83525e9e11c7e4db01558ae1b1"
 propose_weight = 1
 vote_weight = 1
 
 [[params.verifier_list]]
 bls_pub_key = "0x80310fa9df724b5603d283b472ed3bf85254a8a4ceda8a274b421f6cf2be1d9184267cdfe9a199d36ff14e57668a55d0"
 pub_key = "0x02b77c74eb68af3d4d6cc7884ed6709f1a2a1af0f713382a4438ec2ea3a70d4d7f"
-address = "0xf386573563c3a75dbbd269fce9782620826ddac2"
 propose_weight = 1
 vote_weight = 1
 
 [[params.verifier_list]]
 bls_pub_key = "0x897721e9016864141a8b982a48217f66ef318ce598aa31842cddaaebe3cd7feab17050022afa6c2123aba39938fe4142"
 pub_key = "0x027ffd6a6a231561f2afe5878b1c743323b34263d16787130b1815fe35649b0bf5"
-address = "0x8af204ac5d7cb8815a6c53a50b72d01e729d3b22"
 propose_weight = 1
 vote_weight = 1
 
 [[params.verifier_list]]
 bls_pub_key = "0x98eef09a3927acb225191101a1d9aa85775fdcdc87b9ba36898f6c132b485d66aef91c0f51cda331be4f985c3be6761c"
 pub_key = "0x0232c489c23b1207107e9a24648c1e4754a8c1c0b38db96df57a526201035058cb"
-address = "0xf4cc1652dcec2e5de9ce6fb1b6f9fa9456e957f1"
 propose_weight = 1
 vote_weight = 1

--- a/devtools/chain/specs/single_node/chain-spec.toml
+++ b/devtools/chain/specs/single_node/chain-spec.toml
@@ -79,6 +79,5 @@ interval = 3000
 [[params.verifier_list]]
 bls_pub_key = "0xa26e3fe1cf51bd4822072c61bdc315ac32e3d3c2e2484bb92942666399e863b4bf56cf2926383cc706ffc15dfebc85c6"
 pub_key = "0x031ddc35212b7fc7ff6685b17d91f77c972535aee5c7ae5684d3e72b986f08834b"
-address = "0x8ab0cf264df99d83525e9e11c7e4db01558ae1b1"
 propose_weight = 1
 vote_weight = 1

--- a/protocol/src/traits/consensus.rs
+++ b/protocol/src/traits/consensus.rs
@@ -6,8 +6,9 @@ use std::{
 use common_crypto::Secp256k1PublicKey;
 
 use crate::types::{
-    Address, Block, BlockNumber, Bytes, ExecResp, HardforkInfoInner, Hash, Header, Hex, MerkleRoot,
-    Metadata, PackedTxHashes, Proof, Proposal, Receipt, SignedTransaction, Validator, U256,
+    Address, Block, BlockNumber, Bytes, ConsensusValidator, ExecResp, HardforkInfoInner, Hash,
+    Header, Hex, MerkleRoot, Metadata, PackedTxHashes, Proof, Proposal, Receipt, SignedTransaction,
+    U256,
 };
 use crate::{async_trait, traits::Context, ProtocolResult};
 
@@ -72,7 +73,7 @@ pub trait SynchronizationAdapter: CommonConsensusAdapter + Send + Sync {
         prevote_ratio: u64,
         precommit_ratio: u64,
         brake_ratio: u64,
-        validators: Vec<Validator>,
+        validators: Vec<ConsensusValidator>,
     ) -> ProtocolResult<()>;
 
     /// Pull some blocks from other nodes from `begin` to `end`.

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -468,7 +468,7 @@ impl From<(H160, u64)> for ProposeCount {
 }
 
 #[derive(RlpEncodable, RlpDecodable, Clone, Debug, PartialEq, Eq)]
-pub struct Validator {
+pub struct ConsensusValidator {
     pub pub_key:        Bytes,
     pub propose_weight: u32,
     pub vote_weight:    u32,
@@ -507,9 +507,9 @@ impl Ord for ValidatorExtend {
     }
 }
 
-impl From<&ValidatorExtend> for Validator {
+impl From<&ValidatorExtend> for ConsensusValidator {
     fn from(ve: &ValidatorExtend) -> Self {
-        Validator {
+        ConsensusValidator {
             pub_key:        ve.pub_key.as_bytes(),
             propose_weight: ve.propose_weight,
             vote_weight:    ve.vote_weight,

--- a/protocol/src/types/primitive.rs
+++ b/protocol/src/types/primitive.rs
@@ -311,6 +311,19 @@ impl MetadataVersion {
 #[derive(
     RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
 )]
+pub struct SpecMetadata {
+    pub version:          MetadataVersion,
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    pub epoch:            u64,
+    pub verifier_list:    Vec<Validator>,
+    #[serde(skip_deserializing)]
+    pub propose_counter:  Vec<ProposeCount>,
+    pub consensus_config: ConsensusConfig,
+}
+
+#[derive(
+    RlpEncodable, RlpDecodable, Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq,
+)]
 pub struct Metadata {
     pub version:          MetadataVersion,
     #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
@@ -319,6 +332,18 @@ pub struct Metadata {
     #[serde(skip_deserializing)]
     pub propose_counter:  Vec<ProposeCount>,
     pub consensus_config: ConsensusConfig,
+}
+
+impl From<SpecMetadata> for Metadata {
+    fn from(value: SpecMetadata) -> Self {
+        Metadata {
+            version:          value.version,
+            epoch:            value.epoch,
+            verifier_list:    value.verifier_list.into_iter().map(Into::into).collect(),
+            propose_counter:  value.propose_counter,
+            consensus_config: value.consensus_config,
+        }
+    }
 }
 
 impl Metadata {
@@ -474,6 +499,27 @@ pub struct ConsensusValidator {
     pub vote_weight:    u32,
 }
 
+#[derive(
+    RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Display,
+)]
+#[display(
+    fmt = "Validator {{ \
+        bls_pub_key: {}, pub_key: {}, propose_weight: {}, vote_weight: {} \
+    }}",
+    bls_pub_key,
+    pub_key,
+    propose_weight,
+    vote_weight
+)]
+pub struct Validator {
+    pub bls_pub_key:    Hex,
+    pub pub_key:        Hex,
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    pub propose_weight: u32,
+    #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
+    pub vote_weight:    u32,
+}
+
 #[derive(RlpEncodable, RlpDecodable, Serialize, Deserialize, Clone, PartialEq, Eq, Display)]
 #[display(
     fmt = "ValidatorExtend {{ \
@@ -493,6 +539,20 @@ pub struct ValidatorExtend {
     pub propose_weight: u32,
     #[cfg_attr(feature = "hex-serialize", serde(serialize_with = "serialize_uint"))]
     pub vote_weight:    u32,
+}
+
+impl From<Validator> for ValidatorExtend {
+    fn from(value: Validator) -> Self {
+        let address =
+            Address::from_pubkey_bytes(value.pub_key.as_ref()).expect("invalid public key");
+        ValidatorExtend {
+            bls_pub_key:    value.bls_pub_key,
+            address:        address.0,
+            pub_key:        value.pub_key,
+            propose_weight: value.propose_weight,
+            vote_weight:    value.vote_weight,
+        }
+    }
 }
 
 impl PartialOrd for ValidatorExtend {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR:
1. Rename `Validator` as `ConsensusValidator`
2. Omit `address` field in chain spec and it will calculate before executing genesis.

### What is the impact of this PR?

No Breaking Change

**PR relation**:
- Fix #1511
<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OpenZeppelin tests
- [ ] v3 Core Tests

### **CI Description**

| CI Name                | Description                                                                                             |
| ---------------------- | ------------------------------------------------------------------------------------------------------- |
| *Web3 Compatible Test* | Test the Web3 compatibility of Axon                                                                     |
| *v3 Core Test*         | Run the compatibility tests provided by Uniswap V3                                                      |
| *OpenZeppelin tests*   | Run the compatibility tests provided by OpenZeppelin, including OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19 |
</details>
