### PR TITLE
refactor!: change some precompile input and output to tuple

### DIFF
--- a/core/executor/src/precompiles/call_ckb_vm.rs
+++ b/core/executor/src/precompiles/call_ckb_vm.rs
@@ -55,11 +55,11 @@ impl PrecompileContract for CallCkbVM {
 
 fn parse_input(input: &[u8]) -> Result<(CellDep, Vec<Bytes>), PrecompileFailure> {
     let payload =
-        <CallCkbVmPayload as AbiDecode>::decode(input).map_err(|_| err!(_, "decode input"))?;
+        <(CallCkbVmPayload,) as AbiDecode>::decode(input).map_err(|_| err!(_, "decode input"))?;
 
     Ok((
-        payload.cell,
-        payload.inputs.into_iter().map(|i| i.0).collect(),
+        payload.0.cell,
+        payload.0.inputs.into_iter().map(|i| i.0).collect(),
     ))
 }
 

--- a/core/executor/src/precompiles/ckb_mbt_verify.rs
+++ b/core/executor/src/precompiles/ckb_mbt_verify.rs
@@ -67,7 +67,9 @@ impl PrecompileContract for CMBTVerify {
 }
 
 fn parse_input(input: &[u8]) -> Result<VerifyProofPayload, PrecompileFailure> {
-    <VerifyProofPayload as AbiDecode>::decode(input).map_err(|_| err!(_, "decode input"))
+    <(VerifyProofPayload,) as AbiDecode>::decode(input)
+        .map(|r| r.0)
+        .map_err(|_| err!(_, "decode input"))
 }
 
 fn inner_verify_proof(payload: VerifyProofPayload) -> Result<(), PrecompileFailure> {

--- a/core/executor/src/precompiles/get_cell.rs
+++ b/core/executor/src/precompiles/get_cell.rs
@@ -52,7 +52,7 @@ impl PrecompileContract for GetCell {
         Ok((
             PrecompileOutput {
                 exit_status: ExitSucceed::Returned,
-                output:      cell_opt.unwrap().encode(),
+                output:      AbiEncode::encode((cell_opt.unwrap(),)),
             },
             gas,
         ))

--- a/core/executor/src/precompiles/get_header.rs
+++ b/core/executor/src/precompiles/get_header.rs
@@ -1,10 +1,11 @@
-use ethers::abi::AbiDecode;
+use ethers::abi::{AbiDecode, AbiEncode};
 use evm::executor::stack::{PrecompileFailure, PrecompileOutput};
 use evm::{Context, ExitError, ExitSucceed};
 
 use protocol::types::{H160, H256};
 
 use crate::precompiles::{axon_precompile_address, PrecompileContract};
+use crate::system_contract::ckb_light_client::ckb_light_client_abi;
 use crate::{err, system_contract::ckb_light_client::CkbHeaderReader, CURRENT_HEADER_CELL_ROOT};
 
 #[derive(Default, Clone)]
@@ -39,10 +40,13 @@ impl PrecompileContract for GetHeader {
             return err!("get header return None");
         }
 
+        let header =
+            <ckb_light_client_abi::Header as AbiDecode>::decode(header_opt.unwrap()).unwrap();
+
         Ok((
             PrecompileOutput {
                 exit_status: ExitSucceed::Returned,
-                output:      header_opt.unwrap(),
+                output:      AbiEncode::encode((header,)),
             },
             gas,
         ))

--- a/core/executor/src/precompiles/tests.rs
+++ b/core/executor/src/precompiles/tests.rs
@@ -303,11 +303,11 @@ fn test_verify_cmbt_proof() {
         proof:                 witness_proof,
     };
 
-    let input = AbiEncode::encode(raw_tx_payload);
+    let input = AbiEncode::encode((raw_tx_payload,));
     let output = vec![1u8];
     test_precompile!(CMBTVerify, &input, output, 56000);
 
-    let input = AbiEncode::encode(witness_payload);
+    let input = AbiEncode::encode((witness_payload,));
     let output = vec![1u8];
     test_precompile!(CMBTVerify, &input, output, 56000);
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR change the input type of `ckb_mbt_verify` and the output type of `get_header` and `get_cell` precompile from `T` to `(T, )` which is easy to parse in solidity. 

### What is the impact of this PR?


## References
- https://docs.soliditylang.org/en/develop/abi-spec.html#formal-specification-of-the-encoding

<!--
**Special notes for your reviewer**:
NIL

**Which issue(s) this PR fixes**:
You could link a pull request to an issue by using a supported keyword in the pull request's description or in a commit message.

Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

See also:
* [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

* [Manually linking a pull request to an issue using the pull request sidebar](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar)

-->

<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [ ] Web3 Compatible Tests
- [ ] OpenZeppelin tests
- [ ] v3 Core Tests

### **CI Description**

| CI Name                | Description                                                                                             |
| ---------------------- | ------------------------------------------------------------------------------------------------------- |
| *Web3 Compatible Test* | Test the Web3 compatibility of Axon                                                                     |
| *v3 Core Test*         | Run the compatibility tests provided by Uniswap V3                                                      |
| *OpenZeppelin tests*   | Run the compatibility tests provided by OpenZeppelin, including OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19 |
</details>
