### PR TITLE
feat: enable get header precompile

### DIFF
--- a/core/executor/src/precompiles/mod.rs
+++ b/core/executor/src/precompiles/mod.rs
@@ -28,8 +28,9 @@ use protocol::types::H160;
 
 use crate::precompiles::{
     blake2_f::Blake2F, call_ckb_vm::CallCkbVM, ckb_blake2b::CkbBlake2b, ckb_mbt_verify::CMBTVerify,
-    ec_add::EcAdd, ec_mul::EcMul, ec_pairing::EcPairing, ecrecover::EcRecover, identity::Identity,
-    modexp::ModExp, ripemd160::Ripemd160, sha256::Sha256,
+    ec_add::EcAdd, ec_mul::EcMul, ec_pairing::EcPairing, ecrecover::EcRecover,
+    get_header::GetHeader, identity::Identity, modexp::ModExp, ripemd160::Ripemd160,
+    sha256::Sha256,
 };
 
 #[macro_export]
@@ -96,7 +97,7 @@ const fn axon_precompile_address(addr: u8) -> H160 {
 pub fn build_precompile_set() -> BTreeMap<H160, PrecompileFn> {
     precompiles!(
         EcRecover, Sha256, Ripemd160, Identity, ModExp, EcAdd, EcMul, EcPairing, Blake2F,
-        CallCkbVM, CkbBlake2b, CMBTVerify
+        CallCkbVM, CkbBlake2b, CMBTVerify, GetHeader
     )
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

This PR enables the GetHeader precompile.

### What is the impact of this PR?

No Breaking Change

### **CI Tests**

- [x] sync test
   https://github.com/axonweb3/axon/actions/runs/7284552825/job/19850123063
- [x] Web3 Compatible Tests
- [x] OpenZeppelin tests
- [x] v3 Core Tests


### **CI Description**

| CI Name                | Description                                                                                             |
| ---------------------- | ------------------------------------------------------------------------------------------------------- |
| *Web3 Compatible Test* | Test the Web3 compatibility of Axon                                                                     |
| *v3 Core Test*         | Run the compatibility tests provided by Uniswap V3                                                      |
| *OpenZeppelin tests*   | Run the compatibility tests provided by OpenZeppelin, including OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19 |

