### PR TITLE
chore: bump Axon version to 0.3.1-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.3.1-beta
+
+### BUG FIXES
+* fix(cli): Fix peer id generation by @samtvlabs in https://github.com/axonweb3/axon/pull/1656
+
+
 ## v0.3.0-beta
 
 ### BREAKING CHANGES

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axon"
-version = "0.3.0-beta"
+version = "0.3.1-beta"
 dependencies = [
  "axon-protocol",
  "clap 4.4.6",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "core-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axon-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axon"
-version = "0.3.0-beta"
+version = "0.3.1-beta"
 authors = ["Nervos Dev <dev@nervos.org>"]
 edition = "2021"
 repository = "https://github.com/axonweb3/axon"

--- a/core/cli/Cargo.toml
+++ b/core/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION

# CHANGELOG (No Breaking Change)

## v0.3.1-beta

### BUG FIXES
* fix(cli): Fix peer id generation by @samtvlabs in https://github.com/axonweb3/axon/pull/1656


<details><summary>CI Settings</summary><br/>

<!--  Have I run `make ci`? -->
### **CI Usage**

**Tip**: Check the CI you want to run below, and then comment `/run-ci`.

**CI Switch**

- [x] Web3 Compatible Tests
- [x] OpenZeppelin tests
- [x] v3 Core Tests

### **CI Description**

| CI Name                | Description                                                                                             |
| ---------------------- | ------------------------------------------------------------------------------------------------------- |
| *Web3 Compatible Test* | Test the Web3 compatibility of Axon                                                                     |
| *v3 Core Test*         | Run the compatibility tests provided by Uniswap V3                                                      |
| *OpenZeppelin tests*   | Run the compatibility tests provided by OpenZeppelin, including OCT 1-5 \| 6-10 \| 11 \| 12-15 \| 16-19 |
</details>
